### PR TITLE
Google Analyticsでトラフィック計測できるようにする

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Alforge Labs — Algorithmic Trading Systems</title>
   <meta name="description" content="AI-driven quantitative trading systems. Backtesting, optimization, and automated execution." />
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-K8LQ5G28RY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-K8LQ5G28RY');
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## 概要
- GA4 Measurement ID `G-K8LQ5G28RY` の gtag.js タグを追加
- 既存の React + Babel CDN 構成は維持

## 確認
- `rg -F "G-K8LQ5G28RY" index.html`
- `rg -F "gtag/js?id=G-K8LQ5G28RY" index.html`
- `rg -F "gtag('config', 'G-K8LQ5G28RY')" index.html`
- `git diff --check HEAD~1..HEAD`
- `uv run python -m http.server 8080 --bind 127.0.0.1` + `curl -I http://127.0.0.1:8080/`

Closes #1