### PR TITLE
feat: インストーラースクリプト（install.sh / install.ps1）を追加

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,78 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    AlphaForge forge の Windows インストーラー
+
+.DESCRIPTION
+    GitHub Releases から最新の forge.exe をダウンロードし、
+    %USERPROFILE%\bin\forge.exe へ配置します。
+    PATH が未設定の場合は追加方法を案内します。
+
+.EXAMPLE
+    irm https://alforge-labs.github.io/install.ps1 | iex
+#>
+
+$ErrorActionPreference = "Stop"
+
+$REPO       = "ysakae/alpha-forge"
+$ARTIFACT   = "forge-windows-x86_64.exe"
+$INSTALL_DIR = Join-Path $env:USERPROFILE "bin"
+$INSTALL_PATH = Join-Path $INSTALL_DIR "forge.exe"
+
+# 最新バージョンを取得
+Write-Host "最新バージョンを確認中..."
+try {
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest" -UseBasicParsing
+    $VERSION = $release.tag_name
+} catch {
+    Write-Error "リリースバージョンの取得に失敗しました: $_"
+    exit 1
+}
+
+if (-not $VERSION) {
+    Write-Error "バージョン情報を取得できませんでした。"
+    exit 1
+}
+
+Write-Host "AlphaForge forge $VERSION をインストールします..."
+
+# インストール先ディレクトリを作成
+if (-not (Test-Path $INSTALL_DIR)) {
+    New-Item -ItemType Directory -Path $INSTALL_DIR | Out-Null
+    Write-Host "$INSTALL_DIR を作成しました。"
+}
+
+# ダウンロード
+$DOWNLOAD_URL = "https://github.com/$REPO/releases/download/$VERSION/$ARTIFACT"
+$TMP_PATH = Join-Path $env:TEMP "forge_tmp.exe"
+
+Write-Host "ダウンロード中: $DOWNLOAD_URL"
+try {
+    Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_PATH -UseBasicParsing
+} catch {
+    Write-Error "ダウンロードに失敗しました: $_"
+    exit 1
+}
+
+# 配置
+Move-Item -Path $TMP_PATH -Destination $INSTALL_PATH -Force
+
+Write-Host ""
+Write-Host "✓ forge を $INSTALL_PATH にインストールしました" -ForegroundColor Green
+Write-Host ""
+
+# PATH の確認と案内
+$currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+if ($currentPath -notlike "*$INSTALL_DIR*") {
+    Write-Host "PATH に $INSTALL_DIR が含まれていません。" -ForegroundColor Yellow
+    Write-Host "以下のコマンドで追加できます（PowerShell を再起動後に有効）:" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `$env:PATH + ';$INSTALL_DIR', 'User')" -ForegroundColor Cyan
+    Write-Host ""
+} else {
+    Write-Host "PATH は設定済みです。"
+}
+
+Write-Host "次のステップ:"
+Write-Host "  forge --version"
+Write-Host "  forge license activate <YOUR_LICENSE_KEY>"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+REPO="ysakae/alpha-forge"
+
+# OS・アーキテクチャ判定
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+case "${OS}-${ARCH}" in
+  Darwin-arm64)  ARTIFACT="forge-macos-arm64" ;;
+  Darwin-x86_64) ARTIFACT="forge-macos-x86_64" ;;
+  Linux-x86_64)  ARTIFACT="forge-linux-x86_64" ;;
+  *) echo "未対応プラットフォーム: ${OS}-${ARCH}"; exit 1 ;;
+esac
+
+# 最新バージョンを取得
+VERSION="$(curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" \
+  | grep '"tag_name"' | cut -d '"' -f 4)"
+
+if [ -z "${VERSION}" ]; then
+  echo "エラー: リリースバージョンの取得に失敗しました。"
+  exit 1
+fi
+
+echo "AlphaForge forge ${VERSION} (${ARTIFACT}) をインストールします..."
+
+# インストール先ディレクトリが存在しない場合は作成を試みる
+if [ ! -d "${INSTALL_DIR}" ]; then
+  echo "${INSTALL_DIR} が存在しないため作成します..."
+  mkdir -p "${INSTALL_DIR}" 2>/dev/null || {
+    echo "権限エラー: sudo で再実行してください。"
+    echo "  sudo INSTALL_DIR=${INSTALL_DIR} bash <(curl -sSL https://alforge-labs.github.io/install.sh)"
+    exit 1
+  }
+fi
+
+# ダウンロード & 配置
+TMP_FILE="$(mktemp)"
+trap 'rm -f "${TMP_FILE}"' EXIT
+
+curl -sSL \
+  "https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT}" \
+  -o "${TMP_FILE}"
+
+# 書き込み権限チェック
+if [ ! -w "${INSTALL_DIR}" ]; then
+  echo "権限エラー: ${INSTALL_DIR} への書き込み権限がありません。sudo で再実行してください。"
+  echo "  sudo INSTALL_DIR=${INSTALL_DIR} bash <(curl -sSL https://alforge-labs.github.io/install.sh)"
+  exit 1
+fi
+
+cp "${TMP_FILE}" "${INSTALL_DIR}/forge"
+chmod +x "${INSTALL_DIR}/forge"
+
+echo ""
+echo "✓ forge を ${INSTALL_DIR}/forge にインストールしました"
+echo ""
+echo "次のステップ:"
+echo "  forge --version"
+echo "  forge license activate <YOUR_LICENSE_KEY>"

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,40 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    AlphaForge forge の Windows アンインストーラー
+
+.DESCRIPTION
+    %USERPROFILE%\bin\forge.exe を削除します。
+    削除前にライセンスの非アクティベートを案内します。
+
+.EXAMPLE
+    irm https://alforge-labs.github.io/uninstall.ps1 | iex
+#>
+
+$ErrorActionPreference = "Stop"
+
+$INSTALL_DIR  = Join-Path $env:USERPROFILE "bin"
+$INSTALL_PATH = Join-Path $INSTALL_DIR "forge.exe"
+
+if (-not (Test-Path $INSTALL_PATH)) {
+    Write-Error "forge が $INSTALL_PATH に見つかりません。"
+    exit 1
+}
+
+Write-Host "アンインストールを開始します。"
+Write-Host ""
+Write-Host "重要: ライセンスシートを解放するために、先にライセンスを非アクティベートしてください:" -ForegroundColor Yellow
+Write-Host "  forge license deactivate" -ForegroundColor Cyan
+Write-Host ""
+$CONFIRMED = Read-Host "非アクティベート済みですか? [y/N]"
+
+if ($CONFIRMED -notmatch "^[yY]") {
+    Write-Host "アンインストールをキャンセルしました。"
+    Write-Host "先に 'forge license deactivate' を実行してください。"
+    exit 0
+}
+
+Remove-Item -Path $INSTALL_PATH -Force
+
+Write-Host ""
+Write-Host "✓ forge を $INSTALL_PATH から削除しました" -ForegroundColor Green

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+FORGE_PATH="${INSTALL_DIR}/forge"
+
+if [ ! -f "${FORGE_PATH}" ]; then
+  echo "forge が ${FORGE_PATH} に見つかりません。インストール先を INSTALL_DIR で指定してください。"
+  exit 1
+fi
+
+# ライセンスを非アクティベートしてからアンインストールするよう案内
+echo "アンインストールを開始します。"
+echo ""
+echo "重要: ライセンスシートを解放するために、先にライセンスを非アクティベートしてください:"
+echo "  forge license deactivate"
+echo ""
+read -r -p "非アクティベート済みですか? [y/N]: " CONFIRMED
+case "${CONFIRMED}" in
+  [yY]|[yY][eE][sS]) ;;
+  *)
+    echo "アンインストールをキャンセルしました。"
+    echo "先に 'forge license deactivate' を実行してください。"
+    exit 0
+    ;;
+esac
+
+# 削除
+if [ ! -w "${INSTALL_DIR}" ]; then
+  echo "権限エラー: ${INSTALL_DIR} への書き込み権限がありません。sudo で再実行してください。"
+  echo "  sudo INSTALL_DIR=${INSTALL_DIR} bash <(curl -sSL https://alforge-labs.github.io/uninstall.sh)"
+  exit 1
+fi
+
+rm -f "${FORGE_PATH}"
+
+echo ""
+echo "✓ forge を ${FORGE_PATH} から削除しました"


### PR DESCRIPTION
## 概要

GitHub Releases から `forge` バイナリをワンライナーでインストールできるスクリプトを配置。

- `install.sh` — macOS arm64 / macOS x86_64 / Linux x86_64 対応
- `install.ps1` — Windows x86_64 対応（`%USERPROFILE%\bin\forge.exe` へ配置）

## 使用方法

**macOS / Linux:**
```bash
curl -sSL https://alforge-labs.github.io/install.sh | bash
```

**Windows (PowerShell):**
```powershell
irm https://alforge-labs.github.io/install.ps1 | iex
```

## テスト計画

- [ ] macOS arm64 で `install.sh` を実行 → `forge --version` が通ること
- [ ] Linux x86_64 で `install.sh` を実行 → `forge --version` が通ること
- [ ] Windows 環境で `install.ps1` を実行 → `forge.exe` が配置されること
- [ ] 権限エラー時に適切なエラーメッセージが表示されること
- [ ] VERSION 取得失敗時にエラー終了すること

## 関連

- alpha-forge Issue: ysakae/alpha-forge#151