### PR TITLE
feat: Pricingセクションを追加（Lifetime $299 / Annual $99）

### DIFF
--- a/homepage-app.jsx
+++ b/homepage-app.jsx
@@ -244,6 +244,7 @@ function App() {
       <Hero t={t} />
       <Products t={t} />
       <PerformanceChart t={t} dark={dark} />
+      <Pricing t={t} />
       <Roadmap t={t} />
       <FAQ t={t} />
       <FollowCTA t={t} />

--- a/homepage-components.jsx
+++ b/homepage-components.jsx
@@ -42,6 +42,7 @@ function NavBar({ dark, setDark, lang, setLang, t }) {
       </a>
       <ul className="nav-center">
         <li><a href="#products">{t.nav.products}</a></li>
+        <li><a href="#pricing">{t.nav.pricing}</a></li>
         <li><a href="#roadmap">{t.nav.roadmap}</a></li>
         <li><a href="#faq">{t.nav.faq}</a></li>
       </ul>
@@ -279,5 +280,51 @@ function PerformanceChart({ t, dark }) {
   );
 }
 
+/* ── PRICING ── */
+function Pricing({ t }) {
+  const c = t.pricing;
+  return (
+    <section className="pricing reveal" id="pricing">
+      <div className="container">
+        <div className="sec-label">{c.label}</div>
+        <h2 className="sec-title" style={{ whiteSpace: 'pre-line' }}>{c.title}</h2>
+        <p style={{ marginTop: '0.6rem', color: 'var(--text2)', fontSize: '0.92rem' }}>{c.subtitle}</p>
+        <div className="pricing-grid" style={{ marginTop: '2.5rem' }}>
+          {c.plans.map((plan, i) => (
+            <div key={i} className={`pricing-card${plan.featured ? ' featured' : ''}`}>
+              <div className="pricing-card-top">
+                <div className="pricing-plan">{plan.name}</div>
+                {plan.badge && <span className="pricing-badge">{plan.badge}</span>}
+              </div>
+              <div className="pricing-price">
+                <span className="price-amount">{plan.price}</span>
+                <span className="price-period">{plan.period}</span>
+              </div>
+              <p className="pricing-desc">{plan.desc}</p>
+              <ul className="pricing-features">
+                {plan.features.map((f, j) => (
+                  <li key={j} className="pricing-feature">
+                    <span className="feature-check">✓</span>
+                    <span>{f}</span>
+                  </li>
+                ))}
+              </ul>
+              <a
+                href={plan.url}
+                target="_blank" rel="noopener"
+                className={plan.featured ? 'btn-primary' : 'btn-secondary'}
+                style={{ justifyContent: 'center', marginTop: 'auto' }}
+              >
+                {c.buyNow}
+              </a>
+            </div>
+          ))}
+        </div>
+        <p className="pricing-note">{c.note}</p>
+      </div>
+    </section>
+  );
+}
+
 /* ── EXPORT ── */
-Object.assign(window, { NavBar, Hero, Products, PerformanceChart });
+Object.assign(window, { NavBar, Hero, Products, PerformanceChart, Pricing });

--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -14,7 +14,7 @@ window.EQUITY_CURVE = {
 // Bilingual copy — window.COPY
 window.COPY = {
   ja: {
-    nav: { products: 'プロダクト', roadmap: 'ロードマップ', faq: 'FAQ', follow: 'フォロー' },
+    nav: { products: 'プロダクト', pricing: '料金', roadmap: 'ロードマップ', faq: 'FAQ', follow: 'フォロー' },
     hero: {
       tag: '開発進行中',
       h1a: 'アルゴリズムを、',
@@ -28,6 +28,51 @@ window.COPY = {
       { val: 'Sharpe 1.09', accent: true, lbl: 'バックテスト実績（CL=F・5年）' },
       { val: '2027', accent: false, lbl: '正式リリース目標' },
     ],
+    pricing: {
+      label: '料金',
+      title: 'シンプルな\n買い切りプラン',
+      subtitle: '月額課金なし。一度購入すれば、将来のバージョンアップも含まれます。',
+      plans: [
+        {
+          name: 'Lifetime',
+          badge: 'おすすめ',
+          featured: true,
+          price: '$299',
+          period: '買い切り',
+          desc: '一度の支払いで将来のメジャーバージョンアップを含む全機能を永続利用。',
+          features: [
+            'macOS / Linux / Windows 対応',
+            'バックテスト（回数無制限）',
+            'ベイズ最適化（Optuna）',
+            'ウォークフォワード分析',
+            'Pine Script v6 自動生成',
+            '将来バージョンのアップデート込み',
+            '1台のマシンでアクティベート',
+          ],
+          url: 'https://alforge-labs.lemonsqueezy.com',
+        },
+        {
+          name: 'Annual',
+          badge: null,
+          featured: false,
+          price: '$99',
+          period: '/ 年',
+          desc: '年間サブスクリプション。常に最新バージョンを利用できます。',
+          features: [
+            'macOS / Linux / Windows 対応',
+            'バックテスト（回数無制限）',
+            'ベイズ最適化（Optuna）',
+            'ウォークフォワード分析',
+            'Pine Script v6 自動生成',
+            '常に最新バージョン',
+            '1台のマシンでアクティベート',
+          ],
+          url: 'https://alforge-labs.lemonsqueezy.com',
+        },
+      ],
+      buyNow: '今すぐ購入',
+      note: '購入後にライセンスキーが発行されます。インストール後に forge license activate <KEY> で有効化してください。',
+    },
     products: {
       label: 'プロダクト',
       title: '3つの層で構成される\n統合トレーディングシステム',
@@ -176,7 +221,7 @@ window.COPY = {
   },
 
   en: {
-    nav: { products: 'Products', roadmap: 'Roadmap', faq: 'FAQ', follow: 'Follow' },
+    nav: { products: 'Products', pricing: 'Pricing', roadmap: 'Roadmap', faq: 'FAQ', follow: 'Follow' },
     hero: {
       tag: 'In Development',
       h1a: 'Turn Algorithms',
@@ -190,6 +235,51 @@ window.COPY = {
       { val: 'Sharpe 1.09', accent: true, lbl: 'Backtest Result (CL=F · 5yr)' },
       { val: '2027', accent: false, lbl: 'Target Release' },
     ],
+    pricing: {
+      label: 'Pricing',
+      title: 'Simple,\none-time pricing.',
+      subtitle: 'No monthly fees. Buy once, keep forever — future updates included.',
+      plans: [
+        {
+          name: 'Lifetime',
+          badge: 'Best Value',
+          featured: true,
+          price: '$299',
+          period: 'one-time',
+          desc: 'Pay once, use forever. All future major version upgrades included.',
+          features: [
+            'macOS / Linux / Windows',
+            'Unlimited backtests',
+            'Bayesian optimization (Optuna)',
+            'Walk-forward analysis',
+            'Pine Script v6 auto-generation',
+            'Future version updates included',
+            'Activate on 1 machine',
+          ],
+          url: 'https://alforge-labs.lemonsqueezy.com',
+        },
+        {
+          name: 'Annual',
+          badge: null,
+          featured: false,
+          price: '$99',
+          period: '/ year',
+          desc: 'Annual subscription. Always on the latest version.',
+          features: [
+            'macOS / Linux / Windows',
+            'Unlimited backtests',
+            'Bayesian optimization (Optuna)',
+            'Walk-forward analysis',
+            'Pine Script v6 auto-generation',
+            'Always latest version',
+            'Activate on 1 machine',
+          ],
+          url: 'https://alforge-labs.lemonsqueezy.com',
+        },
+      ],
+      buyNow: 'Buy Now',
+      note: 'A license key is issued after purchase. Activate with: forge license activate <KEY>',
+    },
     products: {
       label: 'Products',
       title: 'Three layers.\nOne integrated system.',

--- a/index.html
+++ b/index.html
@@ -392,6 +392,56 @@
       text-align: center;
     }
 
+    /* ── PRICING ── */
+    .pricing { padding: 6rem 0; border-bottom: 1px solid var(--border); }
+    .pricing-grid {
+      display: grid; grid-template-columns: repeat(2, 1fr);
+      gap: 1.5rem; max-width: 740px;
+    }
+    .pricing-card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--r); padding: 2rem;
+      display: flex; flex-direction: column; gap: 1.25rem;
+      position: relative; overflow: hidden; transition: border-color 0.2s;
+    }
+    .pricing-card.featured { border-color: var(--accent-glow); }
+    .pricing-card.featured::before {
+      content: ''; position: absolute;
+      top: 0; left: 0; right: 0; height: 2px; background: var(--accent);
+    }
+    .pricing-card-top { display: flex; align-items: center; justify-content: space-between; }
+    .pricing-plan {
+      font-family: var(--mono); font-size: 0.72rem; font-weight: 500;
+      letter-spacing: 0.1em; text-transform: uppercase; color: var(--text2);
+    }
+    .pricing-card.featured .pricing-plan { color: var(--accent); }
+    .pricing-badge {
+      font-family: var(--mono); font-size: 0.62rem; font-weight: 500;
+      letter-spacing: 0.08em; text-transform: uppercase;
+      padding: 0.18rem 0.55rem; border-radius: 100px;
+      background: var(--accent-bg); color: var(--accent); border: 1px solid var(--accent-glow);
+    }
+    .pricing-price { display: flex; align-items: baseline; gap: 0.4rem; }
+    .price-amount {
+      font-family: var(--mono); font-size: 2.75rem; font-weight: 600;
+      letter-spacing: -0.04em; color: var(--text);
+    }
+    .price-period { font-family: var(--mono); font-size: 0.78rem; color: var(--text3); }
+    .pricing-desc { font-size: 0.88rem; line-height: 1.65; color: var(--text2); }
+    .pricing-features { list-style: none; display: flex; flex-direction: column; gap: 0.55rem; flex: 1; }
+    .pricing-feature {
+      display: flex; align-items: flex-start; gap: 0.55rem;
+      font-size: 0.84rem; color: var(--text2); line-height: 1.4;
+    }
+    .feature-check {
+      color: var(--accent); font-family: var(--mono); font-size: 0.72rem;
+      font-weight: 600; flex-shrink: 0; margin-top: 0.05rem;
+    }
+    .pricing-note {
+      margin-top: 1.75rem; font-family: var(--mono); font-size: 0.7rem;
+      color: var(--text3); max-width: 740px;
+    }
+
     /* ── ROADMAP ── */
     .roadmap { padding: 6rem 0; border-bottom: 1px solid var(--border); }
     .roadmap-inner { margin-top: 3rem; max-width: 740px; }
@@ -595,6 +645,7 @@
     /* ── RESPONSIVE ── */
     @media (max-width: 768px) {
       .products-grid { grid-template-columns: 1fr; }
+      .pricing-grid { grid-template-columns: 1fr; }
       .nav-center { display: none; }
       .perf-stats { flex-wrap: wrap; }
       .perf-stat { min-width: 50%; }


### PR DESCRIPTION
## Summary

- PerformanceChart と Roadmap の間に Pricing セクションを新設
- 2 カラムのプランカード（Lifetime $299 買い切り＋Annual $99/年）
- Lifetime プランをアクセントカラーでハイライト（おすすめ表示）
- 各プランに機能チェックリスト・LemonSqueezy 購入ボタン
- ナビゲーションに「料金 / Pricing」を追加（`#pricing` アンカーリンク）
- モバイル（375px）・デスクトップ（1280px）の両レイアウトに対応

## 購入 URL について

現在は `https://alforge-labs.lemonsqueezy.com` を仮 URL として設定しています。  
LemonSqueezy でプロダクトバリアント URL が発行され次第、`homepage-copy.jsx` の `plans[].url` を実際の checkout URL に更新してください。

## Test Plan

- [ ] デスクトップ（1280px）で 2 カラム表示されること
- [ ] モバイル（375px）で 1 カラムに切り替わること
- [ ] Lifetime カードにアクセントボーダー + おすすめバッジが表示されること
- [ ] ナビの「料金」クリックで `#pricing` にスクロールされること
- [ ] ダーク / ライトテーマ切り替えで表示崩れがないこと
- [ ] 日本語 / 英語の言語切り替えで内容が切り替わること

Closes #153