### PR TITLE
feat: ヒーローセクションに Buy Now CTA を追加（Closes #154）

### DIFF
--- a/homepage-components.jsx
+++ b/homepage-components.jsx
@@ -76,10 +76,10 @@ function Hero({ t }) {
         </h1>
         <p className="hero-desc">{c.desc}</p>
         <div className="hero-cta">
-          <a href="https://x.com/alforge_bot" target="_blank" rel="noopener" className="btn-primary">
-            <XIcon size={14} />{c.cta1}
+          <a href="#" className="btn-primary">
+            {c.cta1}
           </a>
-          <a href="#roadmap" className="btn-secondary">{c.cta2} →</a>
+          <a href="#pricing" className="btn-secondary">{c.cta2} →</a>
         </div>
         <div className="hero-stats">
           {stats.map((s, i) => (

--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -20,8 +20,8 @@ window.COPY = {
       h1a: 'アルゴリズムを、',
       h1b: '武器にする。',
       desc: 'バックテスト・最適化・自動執行を一気通貫。AI連携設計の定量的トレーディングシステムを個人トレーダーへ。',
-      cta1: 'X でフォローする',
-      cta2: 'ロードマップ',
+      cta1: '今すぐ購入 — $299',
+      cta2: 'プランを見る',
     },
     heroStats: [
       { val: '3', accent: false, lbl: '開発中プロダクト' },
@@ -227,8 +227,8 @@ window.COPY = {
       h1a: 'Turn Algorithms',
       h1b: 'Into Edge.',
       desc: 'End-to-end backtesting, optimization, and automated execution. AI-native quantitative trading systems built for serious traders.',
-      cta1: 'Follow on X',
-      cta2: 'Roadmap',
+      cta1: 'Buy Now — $299',
+      cta2: 'See Plans',
     },
     heroStats: [
       { val: '3', accent: false, lbl: 'Products in Dev' },


### PR DESCRIPTION
## Summary

- Hero の Primary CTA を「今すぐ購入 — $299 / Buy Now — $299」に変更
- Secondary CTA を「プランを見る → #pricing / See Plans → #pricing」に変更
- X フォロー導線は NavBar および FollowCTA セクションに残存

## 変更ファイル

- `homepage-copy.jsx`: `hero.cta1/cta2` を ja/en 両言語で更新
- `homepage-components.jsx`: Hero の href を購入導線（`#` 仮置き + `#pricing`）に変更

## TODO（LemonSqueezy 設定後）

- `homepage-components.jsx` の `href="#"` を実際の LemonSqueezy Checkout URL に差し替える
  ```
  https://alforge-labs.lemonsqueezy.com/checkout/buy/<VARIANT_ID>
  ```

## Test Plan

- [ ] ヒーローセクションに「今すぐ購入 — $299」ボタンが表示される
- [ ] 「プランを見る」クリックで Pricing セクションにスクロールする
- [ ] 日英切替でそれぞれのテキストが表示される