### PR TITLE
feat: インストール・ドキュメント・利用規約・プライバシーページを追加

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>コマンドリファレンス — Alforge Labs</title>
+  <meta name="description" content="AlphaForge CLI コマンドリファレンス。backtest・optimize・wft・license・data コマンドの使い方。" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="page.css" />
+  <style>
+    .cmd-nav {
+      position: sticky; top: calc(var(--nav-h) + 1rem);
+      align-self: start;
+    }
+    .cmd-nav-list { list-style: none; padding: 0; }
+    .cmd-nav-list li a {
+      display: block; padding: 0.35rem 0.75rem;
+      font-family: var(--mono); font-size: 0.78rem; color: var(--text3);
+      text-decoration: none; border-left: 2px solid var(--border);
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .cmd-nav-list li a:hover { color: var(--accent); border-left-color: var(--accent); }
+    .doc-layout {
+      display: grid; grid-template-columns: 200px 1fr; gap: 3rem;
+    }
+    .option-table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
+    .option-table th {
+      font-family: var(--mono); font-size: 0.65rem; color: var(--text3);
+      text-transform: uppercase; letter-spacing: 0.1em;
+      text-align: left; padding: 0.4rem 0.75rem;
+      border-bottom: 1px solid var(--border); background: var(--bg2);
+    }
+    .option-table td {
+      font-size: 0.85rem; color: var(--text2);
+      padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--border);
+      vertical-align: top;
+    }
+    .option-table td:first-child code { color: var(--accent); }
+    .option-table tr:last-child td { border-bottom: none; }
+    .cmd-section { scroll-margin-top: calc(var(--nav-h) + 2rem); }
+    @media (max-width: 768px) {
+      .doc-layout { grid-template-columns: 1fr; }
+      .cmd-nav { display: none; }
+    }
+  </style>
+  <script>
+    (function() {
+      var t = localStorage.getItem('al_theme') || 'dark';
+      document.documentElement.setAttribute('data-theme', t);
+      document.addEventListener('DOMContentLoaded', function() {
+        document.body.setAttribute('data-theme', t);
+      });
+    })();
+  </script>
+</head>
+<body data-theme="dark">
+  <nav>
+    <a href="/" class="nav-logo">
+      <span>alforge</span><span class="dot">.</span><span class="labs">labs</span>
+    </a>
+    <ul class="nav-links">
+      <li><a href="install.html">インストール</a></li>
+      <li><a href="docs.html" class="active">ドキュメント</a></li>
+      <li><a href="/#pricing">料金</a></li>
+    </ul>
+    <div class="nav-right">
+      <button class="toggle-btn" id="themeBtn" title="テーマ切替">◑</button>
+    </div>
+  </nav>
+
+  <div class="page-wrap" style="max-width: 1060px;">
+    <div class="page-label">Documentation</div>
+    <h1 class="page-title">コマンドリファレンス</h1>
+    <p class="page-subtitle">AlphaForge CLI の主要コマンド一覧と使用例です。</p>
+
+    <!-- クイックリファレンス -->
+    <table class="cmd-table">
+      <thead>
+        <tr>
+          <th>コマンド</th>
+          <th>概要</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td><a href="#backtest"><code>forge backtest run</code></a></td><td>戦略のバックテストを実行</td></tr>
+        <tr><td><a href="#optimize"><code>forge optimize run</code></a></td><td>ベイズ最適化でパラメータを探索</td></tr>
+        <tr><td><a href="#wft"><code>forge backtest wft</code></a></td><td>ウォークフォワードテストを実行</td></tr>
+        <tr><td><a href="#license"><code>forge license activate</code></a></td><td>ライセンスキーを認証</td></tr>
+        <tr><td><a href="#data"><code>forge data update</code></a></td><td>ヒストリカルデータを差分更新</td></tr>
+      </tbody>
+    </table>
+
+    <div class="doc-layout" style="margin-top: 2rem;">
+      <!-- サイドナビ -->
+      <nav class="cmd-nav">
+        <ul class="cmd-nav-list">
+          <li><a href="#backtest">backtest run</a></li>
+          <li><a href="#optimize">optimize run</a></li>
+          <li><a href="#wft">backtest wft</a></li>
+          <li><a href="#license">license activate</a></li>
+          <li><a href="#data">data update</a></li>
+        </ul>
+      </nav>
+
+      <!-- コンテンツ -->
+      <div>
+        <!-- backtest run -->
+        <section class="cmd-section" id="backtest">
+          <h2 class="section-heading">forge backtest run</h2>
+          <p>指定した戦略とシンボルでバックテストを実行します。結果は SQLite に保存され、JSON 出力も可能です。</p>
+          <pre><code>forge backtest run &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; [OPTIONS]</code></pre>
+
+          <h3 class="sub-heading">使用例</h3>
+          <pre><code># CL=F（原油先物）で HMM+BB+RSI 戦略をバックテスト
+forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1
+
+# JSON 出力
+forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1 --json
+
+# 特定期間を指定
+forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1 \
+  --start 2021-01-01 --end 2024-12-31</code></pre>
+
+          <h3 class="sub-heading">主要オプション</h3>
+          <table class="option-table">
+            <thead><tr><th>オプション</th><th>説明</th><th>デフォルト</th></tr></thead>
+            <tbody>
+              <tr><td><code>--strategy</code></td><td>戦略名（<code>alpha-strategies/</code> 内の JSON ファイル名）</td><td>必須</td></tr>
+              <tr><td><code>--start</code></td><td>バックテスト開始日 (YYYY-MM-DD)</td><td>データ最古</td></tr>
+              <tr><td><code>--end</code></td><td>バックテスト終了日 (YYYY-MM-DD)</td><td>最新日</td></tr>
+              <tr><td><code>--json</code></td><td>結果を JSON 形式で標準出力</td><td>なし</td></tr>
+              <tr><td><code>--config</code></td><td>設定ファイルパス</td><td><code>forge.yaml</code></td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <!-- optimize run -->
+        <section class="cmd-section" id="optimize">
+          <h2 class="section-heading">forge optimize run</h2>
+          <p>Optuna を使ったベイズ最適化でパラメータ空間を効率的に探索します。</p>
+          <pre><code>forge optimize run &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; [OPTIONS]</code></pre>
+
+          <h3 class="sub-heading">使用例</h3>
+          <pre><code># 200試行で最適化
+forge optimize run CL=F --strategy cl_hmm_bb_rsi_v1 --trials 200
+
+# 並列実行（4ジョブ）
+forge optimize run CL=F --strategy cl_hmm_bb_rsi_v1 --trials 200 -j 4</code></pre>
+
+          <h3 class="sub-heading">主要オプション</h3>
+          <table class="option-table">
+            <thead><tr><th>オプション</th><th>説明</th><th>デフォルト</th></tr></thead>
+            <tbody>
+              <tr><td><code>--trials</code></td><td>最適化試行回数</td><td>100</td></tr>
+              <tr><td><code>-j / --jobs</code></td><td>並列ジョブ数</td><td>1</td></tr>
+              <tr><td><code>--metric</code></td><td>最適化目標指標（sharpe / calmar / total_return）</td><td>sharpe</td></tr>
+              <tr><td><code>--sampler</code></td><td>Optuna サンプラー（tpe / random / cmaes）</td><td>tpe</td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <!-- wft -->
+        <section class="cmd-section" id="wft">
+          <h2 class="section-heading">forge backtest wft</h2>
+          <p>ウォークフォワードテスト（Walk-Forward Test）を実行します。過学習を検出するための標準的な検証手法です。</p>
+          <pre><code>forge backtest wft &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; [OPTIONS]</code></pre>
+
+          <h3 class="sub-heading">使用例</h3>
+          <pre><code># 5-fold WFT（訓練70% / 検証30%）
+forge backtest wft CL=F --strategy cl_hmm_bb_rsi_v1 --folds 5
+
+# カスタム分割比
+forge backtest wft CL=F --strategy cl_hmm_bb_rsi_v1 \
+  --train-ratio 0.75 --folds 4</code></pre>
+
+          <h3 class="sub-heading">主要オプション</h3>
+          <table class="option-table">
+            <thead><tr><th>オプション</th><th>説明</th><th>デフォルト</th></tr></thead>
+            <tbody>
+              <tr><td><code>--folds</code></td><td>分割数</td><td>5</td></tr>
+              <tr><td><code>--train-ratio</code></td><td>訓練期間の比率 (0–1)</td><td>0.70</td></tr>
+              <tr><td><code>--trials</code></td><td>各フォールドの最適化試行数</td><td>100</td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <!-- license -->
+        <section class="cmd-section" id="license">
+          <h2 class="section-heading">forge license activate</h2>
+          <p>LemonSqueezy のライセンスキーを認証します。認証情報は <code>~/.forge/license.json</code> にキャッシュされます。</p>
+          <pre><code>forge license activate &lt;LICENSE_KEY&gt;</code></pre>
+
+          <h3 class="sub-heading">使用例</h3>
+          <pre><code>forge license activate 3B111359-8449-481B-AE0F-887B8C85C1B7</code></pre>
+
+          <h3 class="sub-heading">その他のサブコマンド</h3>
+          <table class="option-table">
+            <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
+            <tbody>
+              <tr><td><code>forge license status</code></td><td>現在のライセンス状態を表示</td></tr>
+              <tr><td><code>forge license deactivate</code></td><td>このデバイスのライセンスを無効化（他機種への移行時）</td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <!-- data -->
+        <section class="cmd-section" id="data">
+          <h2 class="section-heading">forge data update</h2>
+          <p>ヒストリカルデータを最新日まで差分更新します。設定ファイル (<code>forge.yaml</code>) に記載されたシンボルをまとめて更新します。</p>
+          <pre><code>forge data update [OPTIONS]</code></pre>
+
+          <h3 class="sub-heading">使用例</h3>
+          <pre><code># 全シンボルを更新
+forge data update
+
+# 特定シンボルのみ
+forge data update --symbol CL=F
+
+# 強制フル再取得
+forge data update --full</code></pre>
+
+          <h3 class="sub-heading">主要オプション</h3>
+          <table class="option-table">
+            <thead><tr><th>オプション</th><th>説明</th><th>デフォルト</th></tr></thead>
+            <tbody>
+              <tr><td><code>--symbol</code></td><td>更新対象シンボル（省略時は全シンボル）</td><td>全シンボル</td></tr>
+              <tr><td><code>--full</code></td><td>差分ではなくフルで再取得</td><td>なし</td></tr>
+              <tr><td><code>--config</code></td><td>設定ファイルパス</td><td><code>forge.yaml</code></td></tr>
+            </tbody>
+          </table>
+        </section>
+      </div>
+    </div>
+  </div>
+
+  <footer>
+    <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
+    <div class="footer-links">
+      <a href="/">ホーム</a>
+      <a href="install.html">インストール</a>
+      <a href="docs.html">ドキュメント</a>
+      <a href="terms.html">利用規約</a>
+      <a href="privacy.html">プライバシー</a>
+    </div>
+  </footer>
+
+  <script>
+    (function() {
+      var t = localStorage.getItem('al_theme') || 'dark';
+      document.body.setAttribute('data-theme', t);
+      document.getElementById('themeBtn').textContent = t === 'dark' ? '☀' : '◑';
+    })();
+
+    document.getElementById('themeBtn').addEventListener('click', function() {
+      var t = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      document.body.setAttribute('data-theme', t);
+      document.documentElement.setAttribute('data-theme', t);
+      localStorage.setItem('al_theme', t);
+      this.textContent = t === 'dark' ? '☀' : '◑';
+    });
+  </script>
+</body>
+</html>

--- a/homepage-app.jsx
+++ b/homepage-app.jsx
@@ -126,6 +126,11 @@ function Footer({ t }) {
     <footer>
       <div className="footer-logo">alforge<span className="dot">.</span>labs</div>
       <div className="footer-right">
+        <div className="footer-links">
+          {c.links.map((l, i) => (
+            <a key={i} href={l.url}>{l.label}</a>
+          ))}
+        </div>
         <span className="footer-copy">{c.copy}</span>
         <span className="footer-note">{c.note}</span>
       </div>

--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -217,6 +217,12 @@ window.COPY = {
     footer: {
       copy: '© 2026 Alforge Labs.',
       note: 'このサイトの情報は投資助言ではありません。',
+      links: [
+        { label: 'インストール', url: '/install.html' },
+        { label: 'ドキュメント', url: '/docs.html' },
+        { label: '利用規約', url: '/terms.html' },
+        { label: 'プライバシー', url: '/privacy.html' },
+      ],
     },
   },
 
@@ -388,6 +394,12 @@ window.COPY = {
     footer: {
       copy: '© 2026 Alforge Labs.',
       note: 'Nothing on this site constitutes investment advice.',
+      links: [
+        { label: 'Install', url: '/install.html' },
+        { label: 'Docs', url: '/docs.html' },
+        { label: 'Terms', url: '/terms.html' },
+        { label: 'Privacy', url: '/privacy.html' },
+      ],
     },
   },
 };

--- a/index.html
+++ b/index.html
@@ -557,6 +557,9 @@
     .footer-right { display: flex; flex-direction: column; align-items: flex-end; gap: 0.25rem; }
     .footer-copy { font-family: var(--mono); font-size: 0.68rem; color: var(--text3); }
     .footer-note { font-size: 0.68rem; color: var(--text3); font-family: var(--mono); }
+    .footer-links { display: flex; gap: 1.25rem; flex-wrap: wrap; justify-content: flex-end; margin-bottom: 0.25rem; }
+    .footer-links a { font-family: var(--mono); font-size: 0.68rem; color: var(--text3); text-decoration: none; transition: color 0.15s; }
+    .footer-links a:hover { color: var(--text2); }
 
     /* ── DISCLAIMER ── */
     .disclaimer-section {

--- a/install.html
+++ b/install.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>インストールガイド — Alforge Labs</title>
+  <meta name="description" content="AlphaForge CLI のインストール手順。macOS・Linux・Windows 対応。" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="page.css" />
+  <script>
+    (function() {
+      var t = localStorage.getItem('al_theme') || 'dark';
+      document.documentElement.setAttribute('data-theme', t);
+      document.addEventListener('DOMContentLoaded', function() {
+        document.body.setAttribute('data-theme', t);
+      });
+    })();
+  </script>
+</head>
+<body data-theme="dark">
+  <nav>
+    <a href="/" class="nav-logo">
+      <span>alforge</span><span class="dot">.</span><span class="labs">labs</span>
+    </a>
+    <ul class="nav-links">
+      <li><a href="install.html" class="active">インストール</a></li>
+      <li><a href="docs.html">ドキュメント</a></li>
+      <li><a href="/#pricing">料金</a></li>
+    </ul>
+    <div class="nav-right">
+      <button class="toggle-btn" id="themeBtn" title="テーマ切替">◑</button>
+    </div>
+  </nav>
+
+  <div class="page-wrap">
+    <div class="page-label">Getting Started</div>
+    <h1 class="page-title">インストールガイド</h1>
+    <p class="page-subtitle">AlphaForge CLI をインストールしてライセンス認証するまでの手順です。所要時間は約5分です。</p>
+
+    <h2 class="section-heading">前提条件</h2>
+    <ul>
+      <li>macOS 12 (Monterey) 以降 / Ubuntu 22.04 以降 / Windows 11</li>
+      <li>インターネット接続（ライセンス認証時）</li>
+      <li>有効な AlphaForge ライセンスキー（<a href="/#pricing">購入ページ</a>から入手）</li>
+    </ul>
+
+    <h2 class="section-heading">インストール</h2>
+
+    <div class="platform-tabs">
+      <div class="platform-tab active" onclick="switchTab('mac')">macOS / Linux</div>
+      <div class="platform-tab" onclick="switchTab('win')">Windows</div>
+      <div class="platform-tab" onclick="switchTab('manual')">手動インストール</div>
+    </div>
+
+    <div id="tab-mac" class="platform-content active">
+      <p>ターミナルで以下のコマンドを実行してください。インストーラーが最新バイナリをダウンロードし、<code>/usr/local/bin</code> に配置します。</p>
+      <pre><code>curl -sSL https://alforge-labs.github.io/install.sh | bash</code></pre>
+      <div class="callout">
+        <p>インストール先を変更したい場合は <code>INSTALL_DIR</code> 環境変数で指定できます。例: <code>INSTALL_DIR=~/.local/bin curl -sSL ... | bash</code></p>
+      </div>
+    </div>
+
+    <div id="tab-win" class="platform-content">
+      <p>PowerShell（管理者権限不要）で以下を実行してください。バイナリを <code>%USERPROFILE%\.forge\bin</code> にインストールし、PATH を自動設定します。</p>
+      <pre><code>irm https://alforge-labs.github.io/install.ps1 | iex</code></pre>
+      <div class="callout">
+        <p>インストール後、新しいターミナルウィンドウを開いてから次の手順に進んでください。</p>
+      </div>
+    </div>
+
+    <div id="tab-manual" class="platform-content">
+      <ol>
+        <li>
+          <a href="https://github.com/ysakae/alpha-forge/releases/latest" target="_blank" rel="noopener">GitHub Releases</a>
+          から使用するプラットフォームのバイナリをダウンロードします。
+          <table class="cmd-table" style="margin-top: 0.75rem;">
+            <thead><tr><th>ファイル名</th><th>対象</th></tr></thead>
+            <tbody>
+              <tr><td><code>forge-macos-x86_64</code></td><td>macOS (Intel)</td></tr>
+              <tr><td><code>forge-macos-arm64</code></td><td>macOS (Apple Silicon)</td></tr>
+              <tr><td><code>forge-linux-x86_64</code></td><td>Linux (x86_64)</td></tr>
+              <tr><td><code>forge-windows-x86_64.exe</code></td><td>Windows 11</td></tr>
+            </tbody>
+          </table>
+        </li>
+        <li>macOS / Linux: 実行権限を付与して PATH の通ったディレクトリに配置します。<pre><code>chmod +x forge-macos-arm64
+sudo mv forge-macos-arm64 /usr/local/bin/forge</code></pre></li>
+        <li>Windows: バイナリを任意のフォルダに配置し、そのフォルダを PATH に追加します。</li>
+      </ol>
+    </div>
+
+    <h2 class="section-heading">ライセンス認証</h2>
+    <ol class="steps">
+      <li>
+        <div class="step-body">
+          <div class="step-title">インストール確認</div>
+          <p>インストールが成功したことを確認します。</p>
+          <pre><code>forge --version</code></pre>
+          <p>バージョン番号が表示されれば成功です。</p>
+        </div>
+      </li>
+      <li>
+        <div class="step-body">
+          <div class="step-title">ライセンスキーを認証</div>
+          <p>購入完了メールに記載されているライセンスキーで認証します。</p>
+          <pre><code>forge license activate &lt;YOUR_LICENSE_KEY&gt;</code></pre>
+          <p>認証情報は <code>~/.forge/license.json</code> に保存されます。オンライン接続が必要です。</p>
+        </div>
+      </li>
+      <li>
+        <div class="step-body">
+          <div class="step-title">動作確認</div>
+          <p>バックテストコマンドが利用可能なことを確認します。</p>
+          <pre><code>forge backtest --help</code></pre>
+        </div>
+      </li>
+    </ol>
+
+    <h2 class="section-heading">アンインストール</h2>
+    <p>バイナリと認証情報を削除するだけです。</p>
+    <pre><code># macOS / Linux
+sudo rm /usr/local/bin/forge
+rm -rf ~/.forge</code></pre>
+
+    <h2 class="section-heading">トラブルシューティング</h2>
+    <table class="cmd-table">
+      <thead><tr><th>症状</th><th>対処</th></tr></thead>
+      <tbody>
+        <tr>
+          <td><code>command not found: forge</code></td>
+          <td>新しいターミナルを開くか、<code>source ~/.bashrc</code> を実行してください。</td>
+        </tr>
+        <tr>
+          <td>ライセンス認証エラー</td>
+          <td>ネットワーク接続を確認し、キーに余分なスペースがないか確認してください。</td>
+        </tr>
+        <tr>
+          <td>macOS セキュリティ警告</td>
+          <td>システム設定 → プライバシーとセキュリティ → 「forge を開く」を許可してください。</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="callout" style="margin-top: 2rem;">
+      <p>問題が解決しない場合は <a href="mailto:support@alforge-labs.com">support@alforge-labs.com</a> までお問い合わせください。</p>
+    </div>
+  </div>
+
+  <footer>
+    <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
+    <div class="footer-links">
+      <a href="/">ホーム</a>
+      <a href="install.html">インストール</a>
+      <a href="docs.html">ドキュメント</a>
+      <a href="terms.html">利用規約</a>
+      <a href="privacy.html">プライバシー</a>
+    </div>
+  </footer>
+
+  <script>
+    // テーマ初期化
+    (function() {
+      var t = localStorage.getItem('al_theme') || 'dark';
+      document.body.setAttribute('data-theme', t);
+      document.getElementById('themeBtn').textContent = t === 'dark' ? '☀' : '◑';
+    })();
+
+    document.getElementById('themeBtn').addEventListener('click', function() {
+      var t = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      document.body.setAttribute('data-theme', t);
+      document.documentElement.setAttribute('data-theme', t);
+      localStorage.setItem('al_theme', t);
+      this.textContent = t === 'dark' ? '☀' : '◑';
+    });
+
+    // プラットフォームタブ
+    function switchTab(id) {
+      document.querySelectorAll('.platform-tab').forEach(function(el) { el.classList.remove('active'); });
+      document.querySelectorAll('.platform-content').forEach(function(el) { el.classList.remove('active'); });
+      event.currentTarget.classList.add('active');
+      document.getElementById('tab-' + id).classList.add('active');
+    }
+  </script>
+</body>
+</html>

--- a/page.css
+++ b/page.css
@@ -1,0 +1,246 @@
+/* page.css — 静的コンテンツページ共通スタイル */
+
+/* ── RESET ── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; font-size: 16px; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--text);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── TOKENS ── */
+:root {
+  --sans: 'Space Grotesk', sans-serif;
+  --mono: 'JetBrains Mono', monospace;
+  --nav-h: 60px;
+  --max-w: 860px;
+  --pad: clamp(1.25rem, 4vw, 2rem);
+  --r: 6px;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-theme="dark"] {
+  --bg: #07080d;
+  --bg2: #0c0f1a;
+  --surface: #111422;
+  --surface-h: #171c30;
+  --border: rgba(255,255,255,0.055);
+  --border-h: rgba(255,255,255,0.13);
+  --text: #dde0f0;
+  --text2: #737890;
+  --text3: #383d5a;
+  --accent: #00e49a;
+  --accent-d: #00b87d;
+  --accent-glow: rgba(0,228,154,0.18);
+  --accent-bg: rgba(0,228,154,0.07);
+  --shadow: 0 2px 8px rgba(0,0,0,0.5);
+  color-scheme: dark;
+}
+[data-theme="light"] {
+  --bg: #f2f4f9;
+  --bg2: #e9ecf4;
+  --surface: #ffffff;
+  --surface-h: #f5f7fc;
+  --border: rgba(0,0,0,0.065);
+  --border-h: rgba(0,0,0,0.14);
+  --text: #0c0e18;
+  --text2: #525670;
+  --text3: #b0b5cc;
+  --accent: #009e70;
+  --accent-d: #007a56;
+  --accent-glow: rgba(0,158,112,0.14);
+  --accent-bg: rgba(0,158,112,0.07);
+  --shadow: 0 2px 8px rgba(0,0,0,0.08);
+  color-scheme: light;
+}
+
+/* ── NAV ── */
+nav {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+  height: var(--nav-h);
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 var(--pad);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(20px) saturate(1.4);
+  -webkit-backdrop-filter: blur(20px) saturate(1.4);
+  background: rgba(7,8,13,0.75);
+}
+[data-theme="light"] nav { background: rgba(242,244,249,0.8); }
+
+.nav-logo {
+  font-family: var(--sans); font-size: 1rem; font-weight: 700;
+  color: var(--text); text-decoration: none; letter-spacing: -0.03em;
+  display: flex; align-items: center;
+}
+.nav-logo .dot { color: var(--accent); }
+.nav-logo .labs { font-family: var(--mono); font-weight: 400; font-size: 0.78rem; color: var(--text2); margin-left: 1px; }
+
+.nav-links { display: flex; gap: 1.5rem; list-style: none; }
+.nav-links a {
+  font-size: 0.82rem; font-weight: 500; color: var(--text2);
+  text-decoration: none; transition: color 0.15s;
+}
+.nav-links a:hover, .nav-links a.active { color: var(--accent); }
+
+.nav-right { display: flex; align-items: center; gap: 0.5rem; }
+
+.toggle-btn {
+  display: flex; align-items: center; justify-content: center;
+  width: 32px; height: 32px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--r); cursor: pointer; color: var(--text2);
+  font-size: 0.8rem; transition: border-color 0.15s, color 0.15s;
+}
+.toggle-btn:hover { border-color: var(--border-h); color: var(--text); }
+
+/* ── LAYOUT ── */
+.page-wrap {
+  max-width: var(--max-w); margin: 0 auto;
+  padding: calc(var(--nav-h) + 3rem) var(--pad) 5rem;
+}
+
+/* ── TYPOGRAPHY ── */
+.page-label {
+  font-family: var(--mono); font-size: 0.7rem; font-weight: 500;
+  color: var(--accent); letter-spacing: 0.12em; text-transform: uppercase;
+  margin-bottom: 0.75rem; display: flex; align-items: center; gap: 0.5rem;
+}
+.page-label::before { content: ''; width: 20px; height: 1px; background: var(--accent); }
+
+.page-title {
+  font-size: clamp(2rem, 5vw, 3rem); font-weight: 700;
+  letter-spacing: -0.04em; line-height: 1.1; color: var(--text);
+  margin-bottom: 0.75rem;
+}
+.page-subtitle {
+  font-size: 1rem; color: var(--text2); line-height: 1.7;
+  margin-bottom: 3rem; max-width: 600px;
+}
+
+h2.section-heading {
+  font-size: 1.2rem; font-weight: 600; color: var(--text);
+  letter-spacing: -0.02em; margin: 2.5rem 0 1rem;
+  padding-bottom: 0.5rem; border-bottom: 1px solid var(--border);
+}
+h3.sub-heading {
+  font-size: 0.95rem; font-weight: 600; color: var(--text);
+  margin: 1.5rem 0 0.5rem;
+}
+
+p { font-size: 0.92rem; color: var(--text2); line-height: 1.8; margin-bottom: 0.75rem; }
+ul, ol { padding-left: 1.4rem; margin-bottom: 0.75rem; }
+li { font-size: 0.92rem; color: var(--text2); line-height: 1.8; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ── CODE BLOCKS ── */
+pre {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--r); padding: 1rem 1.25rem;
+  overflow-x: auto; margin: 0.75rem 0 1.25rem;
+}
+code {
+  font-family: var(--mono); font-size: 0.82rem; color: var(--accent);
+}
+pre code { color: var(--text); font-size: 0.8rem; }
+
+/* ── CALLOUT ── */
+.callout {
+  background: var(--surface); border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--r); padding: 1rem 1.25rem;
+  margin: 1.25rem 0;
+}
+.callout.warn {
+  border-left-color: #f5a623;
+}
+.callout p { margin: 0; }
+
+/* ── TABLE ── */
+.cmd-table { width: 100%; border-collapse: collapse; margin: 1rem 0 1.5rem; }
+.cmd-table th {
+  font-family: var(--mono); font-size: 0.68rem; color: var(--text3);
+  text-transform: uppercase; letter-spacing: 0.1em;
+  text-align: left; padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+.cmd-table td {
+  font-size: 0.88rem; color: var(--text2);
+  padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.cmd-table td code { font-size: 0.78rem; }
+.cmd-table tr:last-child td { border-bottom: none; }
+
+/* ── STEP LIST ── */
+.steps { list-style: none; padding: 0; counter-reset: step; }
+.steps li {
+  counter-increment: step;
+  display: flex; gap: 1rem; align-items: flex-start;
+  margin-bottom: 1.25rem; padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+.steps li:last-child { border-bottom: none; }
+.steps li::before {
+  content: counter(step);
+  flex-shrink: 0;
+  width: 28px; height: 28px;
+  background: var(--accent-bg); border: 1px solid var(--accent-glow);
+  border-radius: 50%;
+  font-family: var(--mono); font-size: 0.75rem; font-weight: 600;
+  color: var(--accent);
+  display: flex; align-items: center; justify-content: center;
+}
+.steps li .step-body { flex: 1; }
+.steps li .step-title { font-size: 0.9rem; font-weight: 600; color: var(--text); margin-bottom: 0.35rem; }
+.steps li .step-body p { margin-bottom: 0.5rem; }
+
+/* ── PLATFORM TABS ── */
+.platform-tabs { display: flex; gap: 0.5rem; margin: 1.25rem 0 0; flex-wrap: wrap; }
+.platform-tab {
+  padding: 0.4rem 1rem; border-radius: var(--r);
+  background: var(--surface); border: 1px solid var(--border);
+  font-family: var(--mono); font-size: 0.75rem; color: var(--text2);
+  cursor: pointer; transition: border-color 0.15s, color 0.15s;
+}
+.platform-tab.active, .platform-tab:hover {
+  border-color: var(--accent); color: var(--accent); background: var(--accent-bg);
+}
+.platform-content { display: none; }
+.platform-content.active { display: block; }
+
+/* ── BUTTONS ── */
+.btn-primary {
+  display: inline-flex; align-items: center; gap: 0.5rem;
+  padding: 0.65rem 1.4rem; border-radius: var(--r);
+  background: var(--accent); color: #07080d;
+  font-size: 0.88rem; font-weight: 600;
+  text-decoration: none; transition: transform 0.15s, box-shadow 0.15s;
+}
+.btn-primary:hover { transform: translateY(-1px); box-shadow: 0 4px 20px var(--accent-glow); text-decoration: none; }
+
+/* ── FOOTER ── */
+footer {
+  border-top: 1px solid var(--border);
+  padding: 1.75rem var(--pad);
+  display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; gap: 1rem;
+}
+.footer-logo { font-family: var(--mono); font-size: 0.82rem; color: var(--text3); }
+.footer-logo .dot { color: var(--accent); }
+.footer-links {
+  display: flex; gap: 1.5rem; flex-wrap: wrap;
+}
+.footer-links a {
+  font-family: var(--mono); font-size: 0.68rem; color: var(--text3);
+  text-decoration: none; transition: color 0.15s;
+}
+.footer-links a:hover { color: var(--text2); }
+
+/* ── RESPONSIVE ── */
+@media (max-width: 640px) {
+  .nav-links { display: none; }
+  .page-wrap { padding-top: calc(var(--nav-h) + 2rem); }
+}

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>プライバシーポリシー — Alforge Labs</title>
+  <meta name="description" content="Alforge Labs のプライバシーポリシー。個人情報の収集・利用・管理方針。" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="page.css" />
+  <script>
+    (function() {
+      var t = localStorage.getItem('al_theme') || 'dark';
+      document.documentElement.setAttribute('data-theme', t);
+      document.addEventListener('DOMContentLoaded', function() {
+        document.body.setAttribute('data-theme', t);
+      });
+    })();
+  </script>
+</head>
+<body data-theme="dark">
+  <nav>
+    <a href="/" class="nav-logo">
+      <span>alforge</span><span class="dot">.</span><span class="labs">labs</span>
+    </a>
+    <ul class="nav-links">
+      <li><a href="install.html">インストール</a></li>
+      <li><a href="docs.html">ドキュメント</a></li>
+      <li><a href="/#pricing">料金</a></li>
+    </ul>
+    <div class="nav-right">
+      <button class="toggle-btn" id="themeBtn" title="テーマ切替">◑</button>
+    </div>
+  </nav>
+
+  <div class="page-wrap">
+    <div class="page-label">Legal</div>
+    <h1 class="page-title">プライバシーポリシー</h1>
+    <p class="page-subtitle">最終更新日: 2026年4月25日</p>
+
+    <p>Alforge Labs（以下「当社」）は、AlphaForge CLI の提供にあたり収集する個人情報の取り扱いについて、以下の通りプライバシーポリシー（以下「本ポリシー」）を定めます。</p>
+
+    <h2 class="section-heading">1. 収集する情報</h2>
+
+    <h3 class="sub-heading">1.1 購入時に収集する情報</h3>
+    <p>LemonSqueezy を通じたライセンス購入時に、以下の情報が収集されます。これらの情報は LemonSqueezy が直接収集・管理します。</p>
+    <ul>
+      <li>氏名（または会社名）</li>
+      <li>メールアドレス</li>
+      <li>決済情報（クレジットカード情報等 — LemonSqueezy の決済システムで処理され、当社は保持しません）</li>
+      <li>国・地域情報（税務目的）</li>
+    </ul>
+
+    <h3 class="sub-heading">1.2 ライセンス認証時に収集する情報</h3>
+    <p><code>forge license activate</code> 実行時に、以下の情報が LemonSqueezy の License API に送信されます。</p>
+    <ul>
+      <li>ライセンスキー</li>
+      <li>インスタンス名（デフォルト: マシンのホスト名）</li>
+      <li>アクティベーション日時</li>
+    </ul>
+
+    <h3 class="sub-heading">1.3 収集しない情報</h3>
+    <div class="callout">
+      <p>AlphaForge CLI はローカル完結型ソフトウェアです。以下の情報は当社のサーバーには一切送信されません。</p>
+    </div>
+    <ul>
+      <li>バックテストの設定・結果</li>
+      <li>最適化パラメータ・戦略データ</li>
+      <li>取引履歴・ポジション情報</li>
+      <li>ローカルのファイルシステム情報</li>
+      <li>使用状況・操作ログ（テレメトリ無効）</li>
+    </ul>
+
+    <h2 class="section-heading">2. 情報の利用目的</h2>
+    <p>収集した情報は以下の目的のみに使用します。</p>
+    <ul>
+      <li>ライセンスキーの発行・認証・管理</li>
+      <li>購入確認メール・領収書の送付</li>
+      <li>製品アップデートのお知らせ（登録ユーザーのみ、配信停止可）</li>
+      <li>サポート対応</li>
+      <li>法令上の義務履行（税務・会計処理）</li>
+    </ul>
+
+    <h2 class="section-heading">3. 第三者への情報提供</h2>
+    <p>当社は以下の場合を除き、個人情報を第三者に提供しません。</p>
+    <table class="cmd-table">
+      <thead><tr><th>提供先</th><th>提供する情報</th><th>目的</th></tr></thead>
+      <tbody>
+        <tr>
+          <td><a href="https://www.lemonsqueezy.com" target="_blank" rel="noopener">LemonSqueezy</a></td>
+          <td>購入情報・ライセンスキー</td>
+          <td>決済処理・ライセンス管理</td>
+        </tr>
+        <tr>
+          <td>法執行機関等</td>
+          <td>必要最小限の情報</td>
+          <td>法令上の要請がある場合のみ</td>
+        </tr>
+      </tbody>
+    </table>
+    <p>マーケティング目的での第三者へのデータ販売・共有は行いません。</p>
+
+    <h2 class="section-heading">4. データの保存期間</h2>
+    <ul>
+      <li>購入情報・ライセンス情報: LemonSqueezy のデータ保持ポリシーに準拠（通常は取引完了後7年間）</li>
+      <li>サポートメール: 対応完了後2年間</li>
+      <li>ローカルの認証キャッシュ (<code>~/.forge/license.json</code>): ユーザーが手動で削除するまで、または <code>forge license deactivate</code> を実行するまで保持</li>
+    </ul>
+
+    <h2 class="section-heading">5. セキュリティ</h2>
+    <p>当社は個人情報を保護するために適切な技術的・組織的措置を講じています。ただし、インターネット経由のデータ送信は完全に安全であることを保証できません。</p>
+
+    <h2 class="section-heading">6. ユーザーの権利</h2>
+    <p>以下の権利を行使する場合は、下記連絡先までお問い合わせください。</p>
+    <ul>
+      <li><strong>アクセス権:</strong> 保有する個人情報の開示を求める権利</li>
+      <li><strong>訂正権:</strong> 不正確な個人情報の訂正を求める権利</li>
+      <li><strong>削除権:</strong> 個人情報の削除を求める権利（法令上の保存義務がある場合を除く）</li>
+      <li><strong>処理制限権:</strong> 個人情報の処理制限を求める権利</li>
+    </ul>
+    <p>削除要求を受け付けた場合、当社が保持する情報と、LemonSqueezy に対する削除要求の代行を30日以内に行います。</p>
+
+    <h2 class="section-heading">7. Cookie・トラッキング</h2>
+    <p>本ウェブサイト（alforge-labs.github.io）では Google Analytics を使用してアクセス状況を分析しています。収集されるデータは匿名化されており、個人を特定する情報は含まれません。ブラウザの設定から Cookie を無効化することで計測を拒否できます。</p>
+
+    <h2 class="section-heading">8. 適用範囲</h2>
+    <p>本ポリシーは Alforge Labs が運営する以下に適用されます。</p>
+    <ul>
+      <li>ウェブサイト: alforge-labs.github.io</li>
+      <li>AlphaForge CLI ソフトウェア</li>
+    </ul>
+
+    <h2 class="section-heading">9. ポリシーの変更</h2>
+    <p>本ポリシーは予告なく変更される場合があります。重要な変更がある場合は登録メールアドレスへの通知またはウェブサイトへの掲載によりお知らせします。</p>
+
+    <h2 class="section-heading">10. お問い合わせ</h2>
+    <p>個人情報の取り扱いに関するお問い合わせ・開示・削除要求は以下にご連絡ください。</p>
+    <p>Email: <a href="mailto:support@alforge-labs.com">support@alforge-labs.com</a></p>
+  </div>
+
+  <footer>
+    <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
+    <div class="footer-links">
+      <a href="/">ホーム</a>
+      <a href="install.html">インストール</a>
+      <a href="docs.html">ドキュメント</a>
+      <a href="terms.html">利用規約</a>
+      <a href="privacy.html">プライバシー</a>
+    </div>
+  </footer>
+
+  <script>
+    (function() {
+      var t = localStorage.getItem('al_theme') || 'dark';
+      document.body.setAttribute('data-theme', t);
+      document.getElementById('themeBtn').textContent = t === 'dark' ? '☀' : '◑';
+    })();
+
+    document.getElementById('themeBtn').addEventListener('click', function() {
+      var t = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      document.body.setAttribute('data-theme', t);
+      document.documentElement.setAttribute('data-theme', t);
+      localStorage.setItem('al_theme', t);
+      this.textContent = t === 'dark' ? '☀' : '◑';
+    });
+  </script>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>利用規約・免責事項 — Alforge Labs</title>
+  <meta name="description" content="AlphaForge CLI の利用規約および免責事項。" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="page.css" />
+  <script>
+    (function() {
+      var t = localStorage.getItem('al_theme') || 'dark';
+      document.documentElement.setAttribute('data-theme', t);
+      document.addEventListener('DOMContentLoaded', function() {
+        document.body.setAttribute('data-theme', t);
+      });
+    })();
+  </script>
+</head>
+<body data-theme="dark">
+  <nav>
+    <a href="/" class="nav-logo">
+      <span>alforge</span><span class="dot">.</span><span class="labs">labs</span>
+    </a>
+    <ul class="nav-links">
+      <li><a href="install.html">インストール</a></li>
+      <li><a href="docs.html">ドキュメント</a></li>
+      <li><a href="/#pricing">料金</a></li>
+    </ul>
+    <div class="nav-right">
+      <button class="toggle-btn" id="themeBtn" title="テーマ切替">◑</button>
+    </div>
+  </nav>
+
+  <div class="page-wrap">
+    <div class="page-label">Legal</div>
+    <h1 class="page-title">利用規約・免責事項</h1>
+    <p class="page-subtitle">最終更新日: 2026年4月25日</p>
+
+    <div class="callout warn" style="margin-bottom: 2rem;">
+      <p><strong>重要な免責事項:</strong> AlphaForge CLI は投資判断の支援ツールではありません。本ソフトウェアのアウトプットは投資アドバイスを構成するものではなく、将来の収益を保証するものではありません。すべての投資・取引判断はご自身の責任において行ってください。</p>
+    </div>
+
+    <h2 class="section-heading">1. 免責事項（金融ツールに関する重要事項）</h2>
+    <ul>
+      <li>本ソフトウェアは<strong>投資助言業務を行うものではなく</strong>、いかなる有価証券・金融商品の売買を推奨するものでもありません。</li>
+      <li>バックテスト・最適化の結果は過去データに基づく統計的シミュレーションであり、<strong>将来の運用成績を保証しません</strong>。</li>
+      <li>実際の取引では、スリッページ・手数料・流動性リスク・市場急変など、シミュレーションでは再現できない要因が生じます。</li>
+      <li>本ソフトウェアを利用した取引によって損失が発生した場合、<strong>開発者・販売者は一切の責任を負いません</strong>。</li>
+      <li>本ソフトウェアの利用は、適用されるすべての法律・規制に準拠してユーザー自身の責任で行うものとします。</li>
+    </ul>
+
+    <h2 class="section-heading">2. ライセンス条件</h2>
+
+    <h3 class="sub-heading">2.1 付与されるライセンス</h3>
+    <p>有効なライセンスキーを購入したユーザーに対し、以下の条件の下で非独占的・非譲渡的な使用権を付与します。</p>
+    <ul>
+      <li>ライセンスキー1本につき<strong>1台のマシン</strong>でのみ有効です。</li>
+      <li>ライセンスは<strong>個人利用のみ</strong>を対象とします（商用利用・法人利用は別途お問い合わせください）。</li>
+      <li>Lifetime ライセンスは購入後の<strong>メジャーバージョンアップを含む</strong>将来のアップデートが対象です。</li>
+    </ul>
+
+    <h3 class="sub-heading">2.2 禁止事項</h3>
+    <ul>
+      <li>ライセンスキーの第三者への譲渡・共有・販売</li>
+      <li>バイナリのリバースエンジニアリング・逆コンパイル・逆アセンブル</li>
+      <li>本ソフトウェアを改変した派生物の再配布</li>
+      <li>ライセンス認証機構の回避・無効化</li>
+    </ul>
+
+    <h3 class="sub-heading">2.3 ライセンスの移行</h3>
+    <p>マシン変更時は <code>forge license deactivate</code> で旧デバイスのライセンスを解除してから、新デバイスで再認証してください。</p>
+
+    <h2 class="section-heading">3. 返金ポリシー</h2>
+    <ul>
+      <li><strong>購入後14日以内</strong>かつ<strong>ライセンスキーを未使用</strong>（アクティベーション未実施）の場合、全額返金を受け付けます。</li>
+      <li>返金を希望する場合は <a href="mailto:support@alforge-labs.com">support@alforge-labs.com</a> にご連絡ください。</li>
+      <li>ライセンスのアクティベーション後は、原則として返金対応外となります。</li>
+    </ul>
+
+    <h2 class="section-heading">4. サービスの変更・終了</h2>
+    <p>開発者は予告なく本ソフトウェアの機能変更・開発終了を行う権利を留保します。ただし Lifetime ライセンスユーザーへは、終了日の30日前までにメールにてご連絡します。</p>
+
+    <h2 class="section-heading">5. 保証の否認</h2>
+    <p>本ソフトウェアは「現状のまま」提供されます。商品性・特定目的への適合性・非侵害性についての黙示的な保証を含め、いかなる明示または黙示の保証も行いません。</p>
+
+    <h2 class="section-heading">6. 責任の制限</h2>
+    <p>適用法が許容する最大限の範囲において、開発者・販売者は、本ソフトウェアの使用または使用不能から生じる直接的・間接的・偶発的・特別・結果的損害について、その損害の可能性を事前に告知されていた場合でも責任を負いません。</p>
+
+    <h2 class="section-heading">7. 準拠法・管轄</h2>
+    <p>本規約は日本法に準拠し、日本国内の管轄裁判所を第一審の専属的合意管轄裁判所とします。</p>
+
+    <h2 class="section-heading">8. 規約の変更</h2>
+    <p>本規約は予告なく変更される場合があります。重要な変更がある場合は、登録メールアドレスへの通知またはウェブサイトへの掲載をもってお知らせします。変更後も継続して本ソフトウェアを使用した場合、変更後の規約に同意したものとみなします。</p>
+
+    <h2 class="section-heading">9. お問い合わせ</h2>
+    <p>本規約に関するお問い合わせは以下までご連絡ください。</p>
+    <p>Email: <a href="mailto:support@alforge-labs.com">support@alforge-labs.com</a></p>
+  </div>
+
+  <footer>
+    <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
+    <div class="footer-links">
+      <a href="/">ホーム</a>
+      <a href="install.html">インストール</a>
+      <a href="docs.html">ドキュメント</a>
+      <a href="terms.html">利用規約</a>
+      <a href="privacy.html">プライバシー</a>
+    </div>
+  </footer>
+
+  <script>
+    (function() {
+      var t = localStorage.getItem('al_theme') || 'dark';
+      document.body.setAttribute('data-theme', t);
+      document.getElementById('themeBtn').textContent = t === 'dark' ? '☀' : '◑';
+    })();
+
+    document.getElementById('themeBtn').addEventListener('click', function() {
+      var t = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      document.body.setAttribute('data-theme', t);
+      document.documentElement.setAttribute('data-theme', t);
+      localStorage.setItem('al_theme', t);
+      this.textContent = t === 'dark' ? '☀' : '◑';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `page.css`: 静的ページ共通スタイル（CSS変数・ナビ・フッター・コードブロック・ステップリスト等）
- `install.html`: プラットフォーム別インストールガイド（タブUI・ステップ形式・トラブルシューティング）
- `docs.html`: コマンドリファレンス（5コマンド・サイドナビ・オプションテーブル）
- `terms.html`: 利用規約・免責事項（金融ツール向け免責・ライセンス条件・返金ポリシー）
- `privacy.html`: プライバシーポリシー（GDPR/個人情報保護法対応・LemonSqueezy明記）
- ホームページフッターに Install / Docs / Terms / Privacy リンクを追加

## Test Plan

- [ ] 4ページが正常にレンダリングされる
- [ ] ダーク/ライトテーマ切替が動作する
- [ ] install.html のプラットフォームタブが切り替わる
- [ ] docs.html のサイドナビのアンカーリンクが機能する
- [ ] ホームページフッターの各リンクが正しいページに遷移する

Closes #7
Closes #8
Closes #9
Closes #10