### PR TITLE
トップページから追加ページへの導線を追加

### DIFF
--- a/homepage-components.jsx
+++ b/homepage-components.jsx
@@ -43,10 +43,13 @@ function NavBar({ dark, setDark, lang, setLang, t }) {
       <ul className="nav-center">
         <li><a href="#products">{t.nav.products}</a></li>
         <li><a href="#pricing">{t.nav.pricing}</a></li>
+        <li><a href="install.html">{t.nav.install}</a></li>
+        <li><a href="docs.html">{t.nav.docs}</a></li>
         <li><a href="#roadmap">{t.nav.roadmap}</a></li>
         <li><a href="#faq">{t.nav.faq}</a></li>
       </ul>
       <div className="nav-right">
+        <a className="nav-page-link" href="docs.html">{t.nav.docs}</a>
         <button className="lang-btn" onClick={() => setLang(l => l === 'ja' ? 'en' : 'ja')}>
           {lang === 'ja' ? 'EN' : 'JA'}
         </button>
@@ -76,7 +79,7 @@ function Hero({ t }) {
         </h1>
         <p className="hero-desc">{c.desc}</p>
         <div className="hero-cta">
-          <a href="#" className="btn-primary">
+          <a href="#pricing" className="btn-primary">
             {c.cta1}
           </a>
           <a href="#pricing" className="btn-secondary">{c.cta2} →</a>

--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -14,7 +14,7 @@ window.EQUITY_CURVE = {
 // Bilingual copy — window.COPY
 window.COPY = {
   ja: {
-    nav: { products: 'プロダクト', pricing: '料金', roadmap: 'ロードマップ', faq: 'FAQ', follow: 'フォロー' },
+    nav: { products: 'プロダクト', pricing: '料金', install: 'インストール', docs: 'ドキュメント', roadmap: 'ロードマップ', faq: 'FAQ', follow: 'フォロー' },
     hero: {
       tag: '開発進行中',
       h1a: 'アルゴリズムを、',
@@ -227,7 +227,7 @@ window.COPY = {
   },
 
   en: {
-    nav: { products: 'Products', pricing: 'Pricing', roadmap: 'Roadmap', faq: 'FAQ', follow: 'Follow' },
+    nav: { products: 'Products', pricing: 'Pricing', install: 'Install', docs: 'Docs', roadmap: 'Roadmap', faq: 'FAQ', follow: 'Follow' },
     hero: {
       tag: 'In Development',
       h1a: 'Turn Algorithms',

--- a/index.html
+++ b/index.html
@@ -153,6 +153,16 @@
 
     .nav-right { display: flex; align-items: center; gap: 0.5rem; }
 
+    .nav-page-link {
+      height: 32px; padding: 0 0.75rem;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--r); text-decoration: none;
+      display: none; align-items: center; justify-content: center;
+      font-family: var(--mono); font-size: 0.72rem; color: var(--text2);
+      transition: border-color 0.15s, color 0.15s, background 0.15s;
+    }
+    .nav-page-link:hover { border-color: var(--border-h); color: var(--text); }
+
     .toggle-btn {
       display: flex; align-items: center; justify-content: center;
       width: 32px; height: 32px;
@@ -646,10 +656,15 @@
     .tweaks-opt.active { border-color: var(--accent); color: var(--accent); background: var(--accent-bg); }
 
     /* ── RESPONSIVE ── */
+    @media (max-width: 1100px) {
+      .nav-center { display: none; }
+      .nav-page-link { display: flex; }
+    }
+
     @media (max-width: 768px) {
       .products-grid { grid-template-columns: 1fr; }
       .pricing-grid { grid-template-columns: 1fr; }
-      .nav-center { display: none; }
+      .nav-page-link { padding: 0 0.55rem; }
       .perf-stats { flex-wrap: wrap; }
       .perf-stat { min-width: 50%; }
       .rm-item { grid-template-columns: 80px 1fr; gap: 1rem; }


### PR DESCRIPTION
## 概要
- トップページの中央ナビにインストール / ドキュメントへのリンクを追加
- 狭い画面では右側ナビにドキュメント入口を表示
- ヒーローの購入ボタンが空リンクになっていたため料金セクションへ遷移するよう修正

## 確認
- rg による静的確認で homepage-components.jsx に install.html / docs.html のリンクが存在することを確認
- ローカル HTTP サーバーで /, docs.html, homepage-components.jsx, homepage-copy.jsx が 200 で取得できることを確認
- git diff --check

Related #7
Related #8
Related #9
Related #10