### PR TITLE
全ページのヘッダーをReact共通化

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -56,19 +56,7 @@
   </script>
 </head>
 <body data-theme="dark">
-  <nav>
-    <a href="/" class="nav-logo">
-      <span>alforge</span><span class="dot">.</span><span class="labs">labs</span>
-    </a>
-    <ul class="nav-links">
-      <li><a href="install.html">インストール</a></li>
-      <li><a href="docs.html" class="active">ドキュメント</a></li>
-      <li><a href="/#pricing">料金</a></li>
-    </ul>
-    <div class="nav-right">
-      <button class="toggle-btn" id="themeBtn" title="テーマ切替">◑</button>
-    </div>
-  </nav>
+  <div id="site-header"></div>
 
   <div class="page-wrap" style="max-width: 1060px;">
     <div class="page-label">Documentation</div>
@@ -246,20 +234,12 @@ forge data update --full</code></pre>
     </div>
   </footer>
 
-  <script>
-    (function() {
-      var t = localStorage.getItem('al_theme') || 'dark';
-      document.body.setAttribute('data-theme', t);
-      document.getElementById('themeBtn').textContent = t === 'dark' ? '☀' : '◑';
-    })();
-
-    document.getElementById('themeBtn').addEventListener('click', function() {
-      var t = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-      document.body.setAttribute('data-theme', t);
-      document.documentElement.setAttribute('data-theme', t);
-      localStorage.setItem('al_theme', t);
-      this.textContent = t === 'dark' ? '☀' : '◑';
-    });
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <script type="text/babel" src="site-header.jsx"></script>
+  <script type="text/babel">
+    renderStandaloneHeader({ active: 'docs' });
   </script>
 </body>
 </html>

--- a/homepage-components.jsx
+++ b/homepage-components.jsx
@@ -24,45 +24,9 @@ function toFillPoints(arr) {
   return toPoints(arr) + ` ${chartX(n - 1, n).toFixed(1)},${bottom} ${CHART.PAD.l},${bottom}`;
 }
 
-/* ── X ICON ── */
-function XIcon({ size = 16 }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
-      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-    </svg>
-  );
-}
-
 /* ── NAV ── */
-function NavBar({ dark, setDark, lang, setLang, t }) {
-  return (
-    <nav>
-      <a href="#" className="nav-logo">
-        <span>alforge</span><span className="dot">.</span><span className="labs">labs</span>
-      </a>
-      <ul className="nav-center">
-        <li><a href="#products">{t.nav.products}</a></li>
-        <li><a href="#pricing">{t.nav.pricing}</a></li>
-        <li><a href="install.html">{t.nav.install}</a></li>
-        <li><a href="docs.html">{t.nav.docs}</a></li>
-        <li><a href="#roadmap">{t.nav.roadmap}</a></li>
-        <li><a href="#faq">{t.nav.faq}</a></li>
-      </ul>
-      <div className="nav-right">
-        <a className="nav-page-link" href="docs.html">{t.nav.docs}</a>
-        <button className="lang-btn" onClick={() => setLang(l => l === 'ja' ? 'en' : 'ja')}>
-          {lang === 'ja' ? 'EN' : 'JA'}
-        </button>
-        <button className="toggle-btn" onClick={() => setDark(d => !d)} title="Toggle theme">
-          {dark ? '☀' : '◑'}
-        </button>
-        <a className="follow-btn-nav" href="https://x.com/alforge_bot" target="_blank" rel="noopener">
-          <XIcon size={13} />
-          {t.nav.follow}
-        </a>
-      </div>
-    </nav>
-  );
+function NavBar({ dark, setDark, lang, setLang }) {
+  return <SiteHeader dark={dark} setDark={setDark} lang={lang} setLang={setLang} showLanguage={true} />;
 }
 
 /* ── HERO ── */

--- a/index.html
+++ b/index.html
@@ -685,6 +685,7 @@
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 
+  <script type="text/babel" src="site-header.jsx"></script>
   <script type="text/babel" src="homepage-copy.jsx"></script>
   <script type="text/babel" src="homepage-components.jsx"></script>
   <script type="text/babel" src="homepage-app.jsx"></script>

--- a/install.html
+++ b/install.html
@@ -20,19 +20,7 @@
   </script>
 </head>
 <body data-theme="dark">
-  <nav>
-    <a href="/" class="nav-logo">
-      <span>alforge</span><span class="dot">.</span><span class="labs">labs</span>
-    </a>
-    <ul class="nav-links">
-      <li><a href="install.html" class="active">インストール</a></li>
-      <li><a href="docs.html">ドキュメント</a></li>
-      <li><a href="/#pricing">料金</a></li>
-    </ul>
-    <div class="nav-right">
-      <button class="toggle-btn" id="themeBtn" title="テーマ切替">◑</button>
-    </div>
-  </nav>
+  <div id="site-header"></div>
 
   <div class="page-wrap">
     <div class="page-label">Getting Started</div>
@@ -159,22 +147,14 @@ rm -rf ~/.forge</code></pre>
     </div>
   </footer>
 
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <script type="text/babel" src="site-header.jsx"></script>
+  <script type="text/babel">
+    renderStandaloneHeader({ active: 'install' });
+  </script>
   <script>
-    // テーマ初期化
-    (function() {
-      var t = localStorage.getItem('al_theme') || 'dark';
-      document.body.setAttribute('data-theme', t);
-      document.getElementById('themeBtn').textContent = t === 'dark' ? '☀' : '◑';
-    })();
-
-    document.getElementById('themeBtn').addEventListener('click', function() {
-      var t = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-      document.body.setAttribute('data-theme', t);
-      document.documentElement.setAttribute('data-theme', t);
-      localStorage.setItem('al_theme', t);
-      this.textContent = t === 'dark' ? '☀' : '◑';
-    });
-
     // プラットフォームタブ
     function switchTab(id) {
       document.querySelectorAll('.platform-tab').forEach(function(el) { el.classList.remove('active'); });

--- a/page.css
+++ b/page.css
@@ -57,7 +57,7 @@ body {
 }
 
 /* ── NAV ── */
-nav {
+#site-header nav {
   position: fixed; top: 0; left: 0; right: 0; z-index: 100;
   height: var(--nav-h);
   display: flex; align-items: center; justify-content: space-between;
@@ -67,7 +67,7 @@ nav {
   -webkit-backdrop-filter: blur(20px) saturate(1.4);
   background: rgba(7,8,13,0.75);
 }
-[data-theme="light"] nav { background: rgba(242,244,249,0.8); }
+[data-theme="light"] #site-header nav { background: rgba(242,244,249,0.8); }
 
 .nav-logo {
   font-family: var(--sans); font-size: 1rem; font-weight: 700;
@@ -77,14 +77,31 @@ nav {
 .nav-logo .dot { color: var(--accent); }
 .nav-logo .labs { font-family: var(--mono); font-weight: 400; font-size: 0.78rem; color: var(--text2); margin-left: 1px; }
 
-.nav-links { display: flex; gap: 1.5rem; list-style: none; }
-.nav-links a {
-  font-size: 0.82rem; font-weight: 500; color: var(--text2);
-  text-decoration: none; transition: color 0.15s;
+.nav-center {
+  display: flex; gap: 2rem; list-style: none;
+  position: absolute; left: 50%; transform: translateX(-50%);
+  padding-left: 0; margin-bottom: 0;
 }
-.nav-links a:hover, .nav-links a.active { color: var(--accent); }
+.nav-center a {
+  font-size: 0.82rem; font-weight: 500; color: var(--text2);
+  text-decoration: none; transition: color 0.15s; letter-spacing: -0.01em;
+}
+.nav-center a:hover { color: var(--text); text-decoration: none; }
+.nav-center a.active { color: var(--accent); }
 
 .nav-right { display: flex; align-items: center; gap: 0.5rem; }
+
+.nav-page-link {
+  height: 32px; padding: 0 0.75rem;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--r); text-decoration: none;
+  display: none; align-items: center; justify-content: center;
+  font-family: var(--mono); font-size: 0.72rem; color: var(--text2);
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.nav-page-link:hover {
+  border-color: var(--border-h); color: var(--text); text-decoration: none;
+}
 
 .toggle-btn {
   display: flex; align-items: center; justify-content: center;
@@ -94,6 +111,17 @@ nav {
   font-size: 0.8rem; transition: border-color 0.15s, color 0.15s;
 }
 .toggle-btn:hover { border-color: var(--border-h); color: var(--text); }
+
+.follow-btn-nav {
+  height: 32px; padding: 0 1rem;
+  background: var(--accent-bg); border: 1px solid var(--accent-glow);
+  border-radius: var(--r); cursor: pointer; text-decoration: none;
+  display: flex; align-items: center; gap: 0.4rem;
+  font-family: var(--sans); font-size: 0.78rem; font-weight: 500;
+  color: var(--accent);
+  transition: background 0.15s, border-color 0.15s;
+}
+.follow-btn-nav:hover { background: var(--accent-glow); text-decoration: none; }
 
 /* ── LAYOUT ── */
 .page-wrap {
@@ -240,7 +268,12 @@ footer {
 .footer-links a:hover { color: var(--text2); }
 
 /* ── RESPONSIVE ── */
+@media (max-width: 1100px) {
+  .nav-center { display: none; }
+  .nav-page-link { display: flex; }
+}
+
 @media (max-width: 640px) {
-  .nav-links { display: none; }
+  .nav-page-link { padding: 0 0.55rem; }
   .page-wrap { padding-top: calc(var(--nav-h) + 2rem); }
 }

--- a/privacy.html
+++ b/privacy.html
@@ -20,19 +20,7 @@
   </script>
 </head>
 <body data-theme="dark">
-  <nav>
-    <a href="/" class="nav-logo">
-      <span>alforge</span><span class="dot">.</span><span class="labs">labs</span>
-    </a>
-    <ul class="nav-links">
-      <li><a href="install.html">インストール</a></li>
-      <li><a href="docs.html">ドキュメント</a></li>
-      <li><a href="/#pricing">料金</a></li>
-    </ul>
-    <div class="nav-right">
-      <button class="toggle-btn" id="themeBtn" title="テーマ切替">◑</button>
-    </div>
-  </nav>
+  <div id="site-header"></div>
 
   <div class="page-wrap">
     <div class="page-label">Legal</div>
@@ -150,20 +138,12 @@
     </div>
   </footer>
 
-  <script>
-    (function() {
-      var t = localStorage.getItem('al_theme') || 'dark';
-      document.body.setAttribute('data-theme', t);
-      document.getElementById('themeBtn').textContent = t === 'dark' ? '☀' : '◑';
-    })();
-
-    document.getElementById('themeBtn').addEventListener('click', function() {
-      var t = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-      document.body.setAttribute('data-theme', t);
-      document.documentElement.setAttribute('data-theme', t);
-      localStorage.setItem('al_theme', t);
-      this.textContent = t === 'dark' ? '☀' : '◑';
-    });
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <script type="text/babel" src="site-header.jsx"></script>
+  <script type="text/babel">
+    renderStandaloneHeader();
   </script>
 </body>
 </html>

--- a/site-header.jsx
+++ b/site-header.jsx
@@ -1,0 +1,99 @@
+// 全ページ共通ヘッダー
+
+const HEADER_COPY = {
+  ja: {
+    products: 'プロダクト',
+    pricing: '料金',
+    install: 'インストール',
+    docs: 'ドキュメント',
+    roadmap: 'ロードマップ',
+    faq: 'FAQ',
+    follow: 'フォロー',
+    toggleTheme: 'テーマ切替',
+  },
+  en: {
+    products: 'Products',
+    pricing: 'Pricing',
+    install: 'Install',
+    docs: 'Docs',
+    roadmap: 'Roadmap',
+    faq: 'FAQ',
+    follow: 'Follow',
+    toggleTheme: 'Toggle theme',
+  },
+};
+
+const HEADER_LINKS = [
+  { key: 'products', href: '/#products' },
+  { key: 'pricing', href: '/#pricing' },
+  { key: 'install', href: '/install.html' },
+  { key: 'docs', href: '/docs.html' },
+  { key: 'roadmap', href: '/#roadmap' },
+  { key: 'faq', href: '/#faq' },
+];
+
+function XIcon({ size = 16 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+    </svg>
+  );
+}
+
+function SiteHeader({ dark, setDark, lang = 'ja', setLang, active = '', showLanguage = false }) {
+  const c = HEADER_COPY[lang] || HEADER_COPY.ja;
+  const toggleLang = () => setLang && setLang(l => l === 'ja' ? 'en' : 'ja');
+
+  return (
+    <nav>
+      <a href="/" className="nav-logo">
+        <span>alforge</span><span className="dot">.</span><span className="labs">labs</span>
+      </a>
+      <ul className="nav-center">
+        {HEADER_LINKS.map(link => (
+          <li key={link.key}>
+            <a href={link.href} className={active === link.key ? 'active' : ''}>{c[link.key]}</a>
+          </li>
+        ))}
+      </ul>
+      <div className="nav-right">
+        <a className="nav-page-link" href="/docs.html">{c.docs}</a>
+        {showLanguage && (
+          <button className="lang-btn" onClick={toggleLang}>
+            {lang === 'ja' ? 'EN' : 'JA'}
+          </button>
+        )}
+        <button className="toggle-btn" onClick={() => setDark(d => !d)} title={c.toggleTheme}>
+          {dark ? '☀' : '◑'}
+        </button>
+        <a className="follow-btn-nav" href="https://x.com/alforge_bot" target="_blank" rel="noopener">
+          <XIcon size={13} />
+          {c.follow}
+        </a>
+      </div>
+    </nav>
+  );
+}
+
+function renderStandaloneHeader({ active = '' } = {}) {
+  const root = document.getElementById('site-header');
+  if (!root) return;
+
+  function StandaloneHeader() {
+    const savedTheme = localStorage.getItem('al_theme');
+    const [dark, setDark] = React.useState(savedTheme ? savedTheme === 'dark' : true);
+
+    React.useEffect(() => {
+      const theme = dark ? 'dark' : 'light';
+      document.documentElement.setAttribute('data-theme', theme);
+      document.body.setAttribute('data-theme', theme);
+      localStorage.setItem('al_theme', theme);
+    }, [dark]);
+
+    return <SiteHeader dark={dark} setDark={setDark} lang="ja" active={active} />;
+  }
+
+  ReactDOM.createRoot(root).render(<StandaloneHeader />);
+}
+
+Object.assign(window, { SiteHeader, renderStandaloneHeader });

--- a/terms.html
+++ b/terms.html
@@ -20,19 +20,7 @@
   </script>
 </head>
 <body data-theme="dark">
-  <nav>
-    <a href="/" class="nav-logo">
-      <span>alforge</span><span class="dot">.</span><span class="labs">labs</span>
-    </a>
-    <ul class="nav-links">
-      <li><a href="install.html">インストール</a></li>
-      <li><a href="docs.html">ドキュメント</a></li>
-      <li><a href="/#pricing">料金</a></li>
-    </ul>
-    <div class="nav-right">
-      <button class="toggle-btn" id="themeBtn" title="テーマ切替">◑</button>
-    </div>
-  </nav>
+  <div id="site-header"></div>
 
   <div class="page-wrap">
     <div class="page-label">Legal</div>
@@ -111,20 +99,12 @@
     </div>
   </footer>
 
-  <script>
-    (function() {
-      var t = localStorage.getItem('al_theme') || 'dark';
-      document.body.setAttribute('data-theme', t);
-      document.getElementById('themeBtn').textContent = t === 'dark' ? '☀' : '◑';
-    })();
-
-    document.getElementById('themeBtn').addEventListener('click', function() {
-      var t = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-      document.body.setAttribute('data-theme', t);
-      document.documentElement.setAttribute('data-theme', t);
-      localStorage.setItem('al_theme', t);
-      this.textContent = t === 'dark' ? '☀' : '◑';
-    });
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <script type="text/babel" src="site-header.jsx"></script>
+  <script type="text/babel">
+    renderStandaloneHeader();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## 概要
- 共通ヘッダーコンポーネント site-header.jsx を追加
- トップページの NavBar を共通ヘッダーのラッパーに変更
- install/docs/terms/privacy の静的ヘッダーを共通 React ヘッダー描画に置き換え
- 追加ページ用の page.css をトップページのヘッダー構成に合わせて更新

## 確認
- rg で各ページが site-header.jsx と renderStandaloneHeader を参照することを確認
- rg で旧 themeBtn / nav-links 参照が残っていないことを確認
- ローカル HTTP サーバーで /, install.html, docs.html, terms.html, privacy.html, site-header.jsx が 200 で取得できることを確認
- git diff --check