### PR TITLE
サポートメールアドレスを修正

### DIFF
--- a/install.html
+++ b/install.html
@@ -132,7 +132,7 @@ rm -rf ~/.forge</code></pre>
     </table>
 
     <div class="callout" style="margin-top: 2rem;">
-      <p>問題が解決しない場合は <a href="mailto:support@alforge-labs.com">support@alforge-labs.com</a> までお問い合わせください。</p>
+      <p>問題が解決しない場合は <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a> までお問い合わせください。</p>
     </div>
   </div>
 

--- a/privacy.html
+++ b/privacy.html
@@ -124,7 +124,7 @@
 
     <h2 class="section-heading">10. お問い合わせ</h2>
     <p>個人情報の取り扱いに関するお問い合わせ・開示・削除要求は以下にご連絡ください。</p>
-    <p>Email: <a href="mailto:support@alforge-labs.com">support@alforge-labs.com</a></p>
+    <p>Email: <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a></p>
   </div>
 
   <footer>

--- a/terms.html
+++ b/terms.html
@@ -64,7 +64,7 @@
     <h2 class="section-heading">3. 返金ポリシー</h2>
     <ul>
       <li><strong>購入後14日以内</strong>かつ<strong>ライセンスキーを未使用</strong>（アクティベーション未実施）の場合、全額返金を受け付けます。</li>
-      <li>返金を希望する場合は <a href="mailto:support@alforge-labs.com">support@alforge-labs.com</a> にご連絡ください。</li>
+      <li>返金を希望する場合は <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a> にご連絡ください。</li>
       <li>ライセンスのアクティベーション後は、原則として返金対応外となります。</li>
     </ul>
 
@@ -85,7 +85,7 @@
 
     <h2 class="section-heading">9. お問い合わせ</h2>
     <p>本規約に関するお問い合わせは以下までご連絡ください。</p>
-    <p>Email: <a href="mailto:support@alforge-labs.com">support@alforge-labs.com</a></p>
+    <p>Email: <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a></p>
   </div>
 
   <footer>


### PR DESCRIPTION
## 概要
- install.html / terms.html / privacy.html のサポートメールを support@alforgelabs.com に統一
- mailto リンクも同じアドレスに更新

## 確認
- 旧アドレス support@alforge-labs.com が残っていないことを rg で確認
- 新アドレス support@alforgelabs.com が該当ページに含まれることを rg で確認
- git diff --check