### PR TITLE
静的ページの英語表示切替を追加

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>コマンドリファレンス — Alforge Labs</title>
-  <meta name="description" content="AlphaForge CLI コマンドリファレンス。backtest・optimize・wft・license・data コマンドの使い方。" />
+  <meta name="description" content="AlphaForge CLI command reference for backtest, optimize, walk-forward, license, and data commands." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -48,190 +48,171 @@
   <script>
     (function() {
       var t = localStorage.getItem('al_theme') || 'dark';
+      var l = localStorage.getItem('al_lang') || 'ja';
       document.documentElement.setAttribute('data-theme', t);
+      document.documentElement.setAttribute('lang', l);
       document.addEventListener('DOMContentLoaded', function() {
         document.body.setAttribute('data-theme', t);
+        document.body.setAttribute('data-lang', l);
       });
     })();
   </script>
 </head>
-<body data-theme="dark">
+<body data-theme="dark" data-lang="ja">
   <div id="site-header"></div>
 
   <div class="page-wrap" style="max-width: 1060px;">
-    <div class="page-label">Documentation</div>
-    <h1 class="page-title">コマンドリファレンス</h1>
-    <p class="page-subtitle">AlphaForge CLI の主要コマンド一覧と使用例です。</p>
+    <div class="lang-content lang-ja">
+      <div class="page-label">Documentation</div>
+      <h1 class="page-title">コマンドリファレンス</h1>
+      <p class="page-subtitle">AlphaForge CLI の主要コマンド一覧と使用例です。</p>
 
-    <!-- クイックリファレンス -->
-    <table class="cmd-table">
-      <thead>
-        <tr>
-          <th>コマンド</th>
-          <th>概要</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr><td><a href="#backtest"><code>forge backtest run</code></a></td><td>戦略のバックテストを実行</td></tr>
-        <tr><td><a href="#optimize"><code>forge optimize run</code></a></td><td>ベイズ最適化でパラメータを探索</td></tr>
-        <tr><td><a href="#wft"><code>forge backtest wft</code></a></td><td>ウォークフォワードテストを実行</td></tr>
-        <tr><td><a href="#license"><code>forge license activate</code></a></td><td>ライセンスキーを認証</td></tr>
-        <tr><td><a href="#data"><code>forge data update</code></a></td><td>ヒストリカルデータを差分更新</td></tr>
-      </tbody>
-    </table>
+      <table class="cmd-table">
+        <thead><tr><th>コマンド</th><th>概要</th></tr></thead>
+        <tbody>
+          <tr><td><a href="#ja-backtest"><code>forge backtest run</code></a></td><td>戦略のバックテストを実行</td></tr>
+          <tr><td><a href="#ja-optimize"><code>forge optimize run</code></a></td><td>ベイズ最適化でパラメータを探索</td></tr>
+          <tr><td><a href="#ja-wft"><code>forge backtest wft</code></a></td><td>ウォークフォワードテストを実行</td></tr>
+          <tr><td><a href="#ja-license"><code>forge license activate</code></a></td><td>ライセンスキーを認証</td></tr>
+          <tr><td><a href="#ja-data"><code>forge data update</code></a></td><td>ヒストリカルデータを差分更新</td></tr>
+        </tbody>
+      </table>
 
-    <div class="doc-layout" style="margin-top: 2rem;">
-      <!-- サイドナビ -->
-      <nav class="cmd-nav">
-        <ul class="cmd-nav-list">
-          <li><a href="#backtest">backtest run</a></li>
-          <li><a href="#optimize">optimize run</a></li>
-          <li><a href="#wft">backtest wft</a></li>
-          <li><a href="#license">license activate</a></li>
-          <li><a href="#data">data update</a></li>
-        </ul>
-      </nav>
-
-      <!-- コンテンツ -->
-      <div>
-        <!-- backtest run -->
-        <section class="cmd-section" id="backtest">
-          <h2 class="section-heading">forge backtest run</h2>
-          <p>指定した戦略とシンボルでバックテストを実行します。結果は SQLite に保存され、JSON 出力も可能です。</p>
-          <pre><code>forge backtest run &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; [OPTIONS]</code></pre>
-
-          <h3 class="sub-heading">使用例</h3>
-          <pre><code># CL=F（原油先物）で HMM+BB+RSI 戦略をバックテスト
-forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1
-
-# JSON 出力
+      <div class="doc-layout" style="margin-top: 2rem;">
+        <nav class="cmd-nav">
+          <ul class="cmd-nav-list">
+            <li><a href="#ja-backtest">backtest run</a></li>
+            <li><a href="#ja-optimize">optimize run</a></li>
+            <li><a href="#ja-wft">backtest wft</a></li>
+            <li><a href="#ja-license">license activate</a></li>
+            <li><a href="#ja-data">data update</a></li>
+          </ul>
+        </nav>
+        <div>
+          <section class="cmd-section" id="ja-backtest">
+            <h2 class="section-heading">forge backtest run</h2>
+            <p>指定した戦略とシンボルでバックテストを実行します。結果は SQLite に保存され、JSON 出力も可能です。</p>
+            <pre><code>forge backtest run &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; [OPTIONS]</code></pre>
+            <h3 class="sub-heading">使用例</h3>
+            <pre><code>forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1
 forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1 --json
+forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1 --start 2021-01-01 --end 2024-12-31</code></pre>
+          </section>
 
-# 特定期間を指定
-forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1 \
-  --start 2021-01-01 --end 2024-12-31</code></pre>
+          <section class="cmd-section" id="ja-optimize">
+            <h2 class="section-heading">forge optimize run</h2>
+            <p>Optuna を使ったベイズ最適化でパラメータ空間を効率的に探索します。</p>
+            <pre><code>forge optimize run &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; --trials 200 -j 4</code></pre>
+          </section>
 
-          <h3 class="sub-heading">主要オプション</h3>
-          <table class="option-table">
-            <thead><tr><th>オプション</th><th>説明</th><th>デフォルト</th></tr></thead>
-            <tbody>
-              <tr><td><code>--strategy</code></td><td>戦略名（<code>alpha-strategies/</code> 内の JSON ファイル名）</td><td>必須</td></tr>
-              <tr><td><code>--start</code></td><td>バックテスト開始日 (YYYY-MM-DD)</td><td>データ最古</td></tr>
-              <tr><td><code>--end</code></td><td>バックテスト終了日 (YYYY-MM-DD)</td><td>最新日</td></tr>
-              <tr><td><code>--json</code></td><td>結果を JSON 形式で標準出力</td><td>なし</td></tr>
-              <tr><td><code>--config</code></td><td>設定ファイルパス</td><td><code>forge.yaml</code></td></tr>
-            </tbody>
-          </table>
-        </section>
+          <section class="cmd-section" id="ja-wft">
+            <h2 class="section-heading">forge backtest wft</h2>
+            <p>ウォークフォワードテストを実行します。過学習を検出するための標準的な検証手法です。</p>
+            <pre><code>forge backtest wft CL=F --strategy cl_hmm_bb_rsi_v1 --folds 5</code></pre>
+          </section>
 
-        <!-- optimize run -->
-        <section class="cmd-section" id="optimize">
-          <h2 class="section-heading">forge optimize run</h2>
-          <p>Optuna を使ったベイズ最適化でパラメータ空間を効率的に探索します。</p>
-          <pre><code>forge optimize run &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; [OPTIONS]</code></pre>
+          <section class="cmd-section" id="ja-license">
+            <h2 class="section-heading">forge license activate</h2>
+            <p>LemonSqueezy のライセンスキーを認証します。認証情報は <code>~/.forge/license.json</code> にキャッシュされます。</p>
+            <pre><code>forge license activate &lt;LICENSE_KEY&gt;</code></pre>
+            <table class="option-table">
+              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge license status</code></td><td>現在のライセンス状態を表示</td></tr>
+                <tr><td><code>forge license deactivate</code></td><td>このデバイスのライセンスを無効化</td></tr>
+              </tbody>
+            </table>
+          </section>
 
-          <h3 class="sub-heading">使用例</h3>
-          <pre><code># 200試行で最適化
-forge optimize run CL=F --strategy cl_hmm_bb_rsi_v1 --trials 200
-
-# 並列実行（4ジョブ）
-forge optimize run CL=F --strategy cl_hmm_bb_rsi_v1 --trials 200 -j 4</code></pre>
-
-          <h3 class="sub-heading">主要オプション</h3>
-          <table class="option-table">
-            <thead><tr><th>オプション</th><th>説明</th><th>デフォルト</th></tr></thead>
-            <tbody>
-              <tr><td><code>--trials</code></td><td>最適化試行回数</td><td>100</td></tr>
-              <tr><td><code>-j / --jobs</code></td><td>並列ジョブ数</td><td>1</td></tr>
-              <tr><td><code>--metric</code></td><td>最適化目標指標（sharpe / calmar / total_return）</td><td>sharpe</td></tr>
-              <tr><td><code>--sampler</code></td><td>Optuna サンプラー（tpe / random / cmaes）</td><td>tpe</td></tr>
-            </tbody>
-          </table>
-        </section>
-
-        <!-- wft -->
-        <section class="cmd-section" id="wft">
-          <h2 class="section-heading">forge backtest wft</h2>
-          <p>ウォークフォワードテスト（Walk-Forward Test）を実行します。過学習を検出するための標準的な検証手法です。</p>
-          <pre><code>forge backtest wft &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; [OPTIONS]</code></pre>
-
-          <h3 class="sub-heading">使用例</h3>
-          <pre><code># 5-fold WFT（訓練70% / 検証30%）
-forge backtest wft CL=F --strategy cl_hmm_bb_rsi_v1 --folds 5
-
-# カスタム分割比
-forge backtest wft CL=F --strategy cl_hmm_bb_rsi_v1 \
-  --train-ratio 0.75 --folds 4</code></pre>
-
-          <h3 class="sub-heading">主要オプション</h3>
-          <table class="option-table">
-            <thead><tr><th>オプション</th><th>説明</th><th>デフォルト</th></tr></thead>
-            <tbody>
-              <tr><td><code>--folds</code></td><td>分割数</td><td>5</td></tr>
-              <tr><td><code>--train-ratio</code></td><td>訓練期間の比率 (0–1)</td><td>0.70</td></tr>
-              <tr><td><code>--trials</code></td><td>各フォールドの最適化試行数</td><td>100</td></tr>
-            </tbody>
-          </table>
-        </section>
-
-        <!-- license -->
-        <section class="cmd-section" id="license">
-          <h2 class="section-heading">forge license activate</h2>
-          <p>LemonSqueezy のライセンスキーを認証します。認証情報は <code>~/.forge/license.json</code> にキャッシュされます。</p>
-          <pre><code>forge license activate &lt;LICENSE_KEY&gt;</code></pre>
-
-          <h3 class="sub-heading">使用例</h3>
-          <pre><code>forge license activate 3B111359-8449-481B-AE0F-887B8C85C1B7</code></pre>
-
-          <h3 class="sub-heading">その他のサブコマンド</h3>
-          <table class="option-table">
-            <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-            <tbody>
-              <tr><td><code>forge license status</code></td><td>現在のライセンス状態を表示</td></tr>
-              <tr><td><code>forge license deactivate</code></td><td>このデバイスのライセンスを無効化（他機種への移行時）</td></tr>
-            </tbody>
-          </table>
-        </section>
-
-        <!-- data -->
-        <section class="cmd-section" id="data">
-          <h2 class="section-heading">forge data update</h2>
-          <p>ヒストリカルデータを最新日まで差分更新します。設定ファイル (<code>forge.yaml</code>) に記載されたシンボルをまとめて更新します。</p>
-          <pre><code>forge data update [OPTIONS]</code></pre>
-
-          <h3 class="sub-heading">使用例</h3>
-          <pre><code># 全シンボルを更新
-forge data update
-
-# 特定シンボルのみ
+          <section class="cmd-section" id="ja-data">
+            <h2 class="section-heading">forge data update</h2>
+            <p>設定ファイルに記載されたシンボルのヒストリカルデータを最新日まで差分更新します。</p>
+            <pre><code>forge data update
 forge data update --symbol CL=F
-
-# 強制フル再取得
 forge data update --full</code></pre>
+          </section>
+        </div>
+      </div>
+    </div>
 
-          <h3 class="sub-heading">主要オプション</h3>
-          <table class="option-table">
-            <thead><tr><th>オプション</th><th>説明</th><th>デフォルト</th></tr></thead>
-            <tbody>
-              <tr><td><code>--symbol</code></td><td>更新対象シンボル（省略時は全シンボル）</td><td>全シンボル</td></tr>
-              <tr><td><code>--full</code></td><td>差分ではなくフルで再取得</td><td>なし</td></tr>
-              <tr><td><code>--config</code></td><td>設定ファイルパス</td><td><code>forge.yaml</code></td></tr>
-            </tbody>
-          </table>
-        </section>
+    <div class="lang-content lang-en">
+      <div class="page-label">Documentation</div>
+      <h1 class="page-title">Command Reference</h1>
+      <p class="page-subtitle">Core AlphaForge CLI commands and practical examples.</p>
+
+      <table class="cmd-table">
+        <thead><tr><th>Command</th><th>Summary</th></tr></thead>
+        <tbody>
+          <tr><td><a href="#en-backtest"><code>forge backtest run</code></a></td><td>Run a strategy backtest</td></tr>
+          <tr><td><a href="#en-optimize"><code>forge optimize run</code></a></td><td>Search parameters with Bayesian optimization</td></tr>
+          <tr><td><a href="#en-wft"><code>forge backtest wft</code></a></td><td>Run a walk-forward test</td></tr>
+          <tr><td><a href="#en-license"><code>forge license activate</code></a></td><td>Activate a license key</td></tr>
+          <tr><td><a href="#en-data"><code>forge data update</code></a></td><td>Update historical market data</td></tr>
+        </tbody>
+      </table>
+
+      <div class="doc-layout" style="margin-top: 2rem;">
+        <nav class="cmd-nav">
+          <ul class="cmd-nav-list">
+            <li><a href="#en-backtest">backtest run</a></li>
+            <li><a href="#en-optimize">optimize run</a></li>
+            <li><a href="#en-wft">backtest wft</a></li>
+            <li><a href="#en-license">license activate</a></li>
+            <li><a href="#en-data">data update</a></li>
+          </ul>
+        </nav>
+        <div>
+          <section class="cmd-section" id="en-backtest">
+            <h2 class="section-heading">forge backtest run</h2>
+            <p>Runs a backtest for a symbol and strategy. Results are stored in SQLite and can also be printed as JSON.</p>
+            <pre><code>forge backtest run &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; [OPTIONS]</code></pre>
+            <h3 class="sub-heading">Examples</h3>
+            <pre><code>forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1
+forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1 --json
+forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1 --start 2021-01-01 --end 2024-12-31</code></pre>
+          </section>
+
+          <section class="cmd-section" id="en-optimize">
+            <h2 class="section-heading">forge optimize run</h2>
+            <p>Uses Optuna to search the strategy parameter space efficiently.</p>
+            <pre><code>forge optimize run &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; --trials 200 -j 4</code></pre>
+          </section>
+
+          <section class="cmd-section" id="en-wft">
+            <h2 class="section-heading">forge backtest wft</h2>
+            <p>Runs a walk-forward test to validate robustness and reduce overfitting risk.</p>
+            <pre><code>forge backtest wft CL=F --strategy cl_hmm_bb_rsi_v1 --folds 5</code></pre>
+          </section>
+
+          <section class="cmd-section" id="en-license">
+            <h2 class="section-heading">forge license activate</h2>
+            <p>Activates a LemonSqueezy license key. Activation data is cached in <code>~/.forge/license.json</code>.</p>
+            <pre><code>forge license activate &lt;LICENSE_KEY&gt;</code></pre>
+            <table class="option-table">
+              <thead><tr><th>Command</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge license status</code></td><td>Show the current license status</td></tr>
+                <tr><td><code>forge license deactivate</code></td><td>Deactivate this device</td></tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section class="cmd-section" id="en-data">
+            <h2 class="section-heading">forge data update</h2>
+            <p>Updates historical data for symbols defined in the configuration file.</p>
+            <pre><code>forge data update
+forge data update --symbol CL=F
+forge data update --full</code></pre>
+          </section>
+        </div>
       </div>
     </div>
   </div>
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="footer-links">
-      <a href="/">ホーム</a>
-      <a href="install.html">インストール</a>
-      <a href="docs.html">ドキュメント</a>
-      <a href="terms.html">利用規約</a>
-      <a href="privacy.html">プライバシー</a>
-    </div>
+    <div class="lang-content lang-ja"><div class="footer-links"><a href="/">ホーム</a><a href="install.html">インストール</a><a href="docs.html">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a></div></div>
+    <div class="lang-content lang-en"><div class="footer-links"><a href="/">Home</a><a href="install.html">Install</a><a href="docs.html">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a></div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>

--- a/install.html
+++ b/install.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>インストールガイド — Alforge Labs</title>
-  <meta name="description" content="AlphaForge CLI のインストール手順。macOS・Linux・Windows 対応。" />
+  <meta name="description" content="AlphaForge CLI installation guide for macOS, Linux, and Windows." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -12,138 +12,185 @@
   <script>
     (function() {
       var t = localStorage.getItem('al_theme') || 'dark';
+      var l = localStorage.getItem('al_lang') || 'ja';
       document.documentElement.setAttribute('data-theme', t);
+      document.documentElement.setAttribute('lang', l);
       document.addEventListener('DOMContentLoaded', function() {
         document.body.setAttribute('data-theme', t);
+        document.body.setAttribute('data-lang', l);
       });
     })();
   </script>
 </head>
-<body data-theme="dark">
+<body data-theme="dark" data-lang="ja">
   <div id="site-header"></div>
 
   <div class="page-wrap">
-    <div class="page-label">Getting Started</div>
-    <h1 class="page-title">インストールガイド</h1>
-    <p class="page-subtitle">AlphaForge CLI をインストールしてライセンス認証するまでの手順です。所要時間は約5分です。</p>
+    <div class="lang-content lang-ja">
+      <div class="page-label">Getting Started</div>
+      <h1 class="page-title">インストールガイド</h1>
+      <p class="page-subtitle">AlphaForge CLI をインストールしてライセンス認証するまでの手順です。所要時間は約5分です。</p>
 
-    <h2 class="section-heading">前提条件</h2>
-    <ul>
-      <li>macOS 12 (Monterey) 以降 / Ubuntu 22.04 以降 / Windows 11</li>
-      <li>インターネット接続（ライセンス認証時）</li>
-      <li>有効な AlphaForge ライセンスキー（<a href="/#pricing">購入ページ</a>から入手）</li>
-    </ul>
+      <h2 class="section-heading">前提条件</h2>
+      <ul>
+        <li>macOS 12 (Monterey) 以降 / Ubuntu 22.04 以降 / Windows 11</li>
+        <li>インターネット接続（ライセンス認証時）</li>
+        <li>有効な AlphaForge ライセンスキー（<a href="/#pricing">購入ページ</a>から入手）</li>
+      </ul>
 
-    <h2 class="section-heading">インストール</h2>
-
-    <div class="platform-tabs">
-      <div class="platform-tab active" onclick="switchTab('mac')">macOS / Linux</div>
-      <div class="platform-tab" onclick="switchTab('win')">Windows</div>
-      <div class="platform-tab" onclick="switchTab('manual')">手動インストール</div>
-    </div>
-
-    <div id="tab-mac" class="platform-content active">
-      <p>ターミナルで以下のコマンドを実行してください。インストーラーが最新バイナリをダウンロードし、<code>/usr/local/bin</code> に配置します。</p>
-      <pre><code>curl -sSL https://alforge-labs.github.io/install.sh | bash</code></pre>
-      <div class="callout">
-        <p>インストール先を変更したい場合は <code>INSTALL_DIR</code> 環境変数で指定できます。例: <code>INSTALL_DIR=~/.local/bin curl -sSL ... | bash</code></p>
+      <h2 class="section-heading">インストール</h2>
+      <div class="platform-tabs">
+        <div class="platform-tab active" onclick="switchTab('ja', 'mac', event)">macOS / Linux</div>
+        <div class="platform-tab" onclick="switchTab('ja', 'win', event)">Windows</div>
+        <div class="platform-tab" onclick="switchTab('ja', 'manual', event)">手動インストール</div>
       </div>
-    </div>
 
-    <div id="tab-win" class="platform-content">
-      <p>PowerShell（管理者権限不要）で以下を実行してください。バイナリを <code>%USERPROFILE%\.forge\bin</code> にインストールし、PATH を自動設定します。</p>
-      <pre><code>irm https://alforge-labs.github.io/install.ps1 | iex</code></pre>
-      <div class="callout">
-        <p>インストール後、新しいターミナルウィンドウを開いてから次の手順に進んでください。</p>
+      <div id="tab-ja-mac" class="platform-content active">
+        <p>ターミナルで以下のコマンドを実行してください。インストーラーが最新バイナリをダウンロードし、<code>/usr/local/bin</code> に配置します。</p>
+        <pre><code>curl -sSL https://alforge-labs.github.io/install.sh | bash</code></pre>
+        <div class="callout">
+          <p>インストール先を変更したい場合は <code>INSTALL_DIR</code> 環境変数で指定できます。例: <code>INSTALL_DIR=~/.local/bin curl -sSL ... | bash</code></p>
+        </div>
       </div>
-    </div>
 
-    <div id="tab-manual" class="platform-content">
-      <ol>
-        <li>
-          <a href="https://github.com/ysakae/alpha-forge/releases/latest" target="_blank" rel="noopener">GitHub Releases</a>
-          から使用するプラットフォームのバイナリをダウンロードします。
-          <table class="cmd-table" style="margin-top: 0.75rem;">
-            <thead><tr><th>ファイル名</th><th>対象</th></tr></thead>
-            <tbody>
-              <tr><td><code>forge-macos-x86_64</code></td><td>macOS (Intel)</td></tr>
-              <tr><td><code>forge-macos-arm64</code></td><td>macOS (Apple Silicon)</td></tr>
-              <tr><td><code>forge-linux-x86_64</code></td><td>Linux (x86_64)</td></tr>
-              <tr><td><code>forge-windows-x86_64.exe</code></td><td>Windows 11</td></tr>
-            </tbody>
-          </table>
-        </li>
-        <li>macOS / Linux: 実行権限を付与して PATH の通ったディレクトリに配置します。<pre><code>chmod +x forge-macos-arm64
+      <div id="tab-ja-win" class="platform-content">
+        <p>PowerShell（管理者権限不要）で以下を実行してください。バイナリを <code>%USERPROFILE%\.forge\bin</code> にインストールし、PATH を自動設定します。</p>
+        <pre><code>irm https://alforge-labs.github.io/install.ps1 | iex</code></pre>
+        <div class="callout">
+          <p>インストール後、新しいターミナルウィンドウを開いてから次の手順に進んでください。</p>
+        </div>
+      </div>
+
+      <div id="tab-ja-manual" class="platform-content">
+        <ol>
+          <li>
+            <a href="https://github.com/ysakae/alpha-forge/releases/latest" target="_blank" rel="noopener">GitHub Releases</a>
+            から使用するプラットフォームのバイナリをダウンロードします。
+          </li>
+          <li>macOS / Linux: 実行権限を付与して PATH の通ったディレクトリに配置します。<pre><code>chmod +x forge-macos-arm64
 sudo mv forge-macos-arm64 /usr/local/bin/forge</code></pre></li>
-        <li>Windows: バイナリを任意のフォルダに配置し、そのフォルダを PATH に追加します。</li>
+          <li>Windows: バイナリを任意のフォルダに配置し、そのフォルダを PATH に追加します。</li>
+        </ol>
+      </div>
+
+      <h2 class="section-heading">ライセンス認証</h2>
+      <ol class="steps">
+        <li><div class="step-body"><div class="step-title">インストール確認</div><p>インストールが成功したことを確認します。</p><pre><code>forge --version</code></pre></div></li>
+        <li><div class="step-body"><div class="step-title">ライセンスキーを認証</div><p>購入完了メールに記載されているライセンスキーで認証します。</p><pre><code>forge license activate &lt;YOUR_LICENSE_KEY&gt;</code></pre><p>認証情報は <code>~/.forge/license.json</code> に保存されます。オンライン接続が必要です。</p></div></li>
+        <li><div class="step-body"><div class="step-title">動作確認</div><p>バックテストコマンドが利用可能なことを確認します。</p><pre><code>forge backtest --help</code></pre></div></li>
       </ol>
-    </div>
 
-    <h2 class="section-heading">ライセンス認証</h2>
-    <ol class="steps">
-      <li>
-        <div class="step-body">
-          <div class="step-title">インストール確認</div>
-          <p>インストールが成功したことを確認します。</p>
-          <pre><code>forge --version</code></pre>
-          <p>バージョン番号が表示されれば成功です。</p>
-        </div>
-      </li>
-      <li>
-        <div class="step-body">
-          <div class="step-title">ライセンスキーを認証</div>
-          <p>購入完了メールに記載されているライセンスキーで認証します。</p>
-          <pre><code>forge license activate &lt;YOUR_LICENSE_KEY&gt;</code></pre>
-          <p>認証情報は <code>~/.forge/license.json</code> に保存されます。オンライン接続が必要です。</p>
-        </div>
-      </li>
-      <li>
-        <div class="step-body">
-          <div class="step-title">動作確認</div>
-          <p>バックテストコマンドが利用可能なことを確認します。</p>
-          <pre><code>forge backtest --help</code></pre>
-        </div>
-      </li>
-    </ol>
-
-    <h2 class="section-heading">アンインストール</h2>
-    <p>バイナリと認証情報を削除するだけです。</p>
-    <pre><code># macOS / Linux
+      <h2 class="section-heading">アンインストール</h2>
+      <pre><code># macOS / Linux
 sudo rm /usr/local/bin/forge
 rm -rf ~/.forge</code></pre>
 
-    <h2 class="section-heading">トラブルシューティング</h2>
-    <table class="cmd-table">
-      <thead><tr><th>症状</th><th>対処</th></tr></thead>
-      <tbody>
-        <tr>
-          <td><code>command not found: forge</code></td>
-          <td>新しいターミナルを開くか、<code>source ~/.bashrc</code> を実行してください。</td>
-        </tr>
-        <tr>
-          <td>ライセンス認証エラー</td>
-          <td>ネットワーク接続を確認し、キーに余分なスペースがないか確認してください。</td>
-        </tr>
-        <tr>
-          <td>macOS セキュリティ警告</td>
-          <td>システム設定 → プライバシーとセキュリティ → 「forge を開く」を許可してください。</td>
-        </tr>
-      </tbody>
-    </table>
+      <h2 class="section-heading">トラブルシューティング</h2>
+      <table class="cmd-table">
+        <thead><tr><th>症状</th><th>対処</th></tr></thead>
+        <tbody>
+          <tr><td><code>command not found: forge</code></td><td>新しいターミナルを開くか、<code>source ~/.bashrc</code> を実行してください。</td></tr>
+          <tr><td>ライセンス認証エラー</td><td>ネットワーク接続を確認し、キーに余分なスペースがないか確認してください。</td></tr>
+          <tr><td>macOS セキュリティ警告</td><td>システム設定 → プライバシーとセキュリティ → 「forge を開く」を許可してください。</td></tr>
+        </tbody>
+      </table>
 
-    <div class="callout" style="margin-top: 2rem;">
-      <p>問題が解決しない場合は <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a> までお問い合わせください。</p>
+      <div class="callout" style="margin-top: 2rem;">
+        <p>問題が解決しない場合は <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a> までお問い合わせください。</p>
+      </div>
+    </div>
+
+    <div class="lang-content lang-en">
+      <div class="page-label">Getting Started</div>
+      <h1 class="page-title">Installation Guide</h1>
+      <p class="page-subtitle">Install AlphaForge CLI and activate your license in about five minutes.</p>
+
+      <h2 class="section-heading">Requirements</h2>
+      <ul>
+        <li>macOS 12 Monterey or later / Ubuntu 22.04 or later / Windows 11</li>
+        <li>Internet access for license activation</li>
+        <li>A valid AlphaForge license key from the <a href="/#pricing">pricing page</a></li>
+      </ul>
+
+      <h2 class="section-heading">Install</h2>
+      <div class="platform-tabs">
+        <div class="platform-tab active" onclick="switchTab('en', 'mac', event)">macOS / Linux</div>
+        <div class="platform-tab" onclick="switchTab('en', 'win', event)">Windows</div>
+        <div class="platform-tab" onclick="switchTab('en', 'manual', event)">Manual</div>
+      </div>
+
+      <div id="tab-en-mac" class="platform-content active">
+        <p>Run the following command in your terminal. The installer downloads the latest binary and places it in <code>/usr/local/bin</code>.</p>
+        <pre><code>curl -sSL https://alforge-labs.github.io/install.sh | bash</code></pre>
+        <div class="callout">
+          <p>Set <code>INSTALL_DIR</code> if you want to install elsewhere. Example: <code>INSTALL_DIR=~/.local/bin curl -sSL ... | bash</code></p>
+        </div>
+      </div>
+
+      <div id="tab-en-win" class="platform-content">
+        <p>Run this in PowerShell. It installs the binary into <code>%USERPROFILE%\.forge\bin</code> and updates PATH.</p>
+        <pre><code>irm https://alforge-labs.github.io/install.ps1 | iex</code></pre>
+        <div class="callout">
+          <p>Open a new terminal window after installation before continuing.</p>
+        </div>
+      </div>
+
+      <div id="tab-en-manual" class="platform-content">
+        <ol>
+          <li>Download the binary for your platform from <a href="https://github.com/ysakae/alpha-forge/releases/latest" target="_blank" rel="noopener">GitHub Releases</a>.</li>
+          <li>macOS / Linux: make it executable and move it to a directory on your PATH.<pre><code>chmod +x forge-macos-arm64
+sudo mv forge-macos-arm64 /usr/local/bin/forge</code></pre></li>
+          <li>Windows: place the binary in any folder and add that folder to PATH.</li>
+        </ol>
+      </div>
+
+      <h2 class="section-heading">License Activation</h2>
+      <ol class="steps">
+        <li><div class="step-body"><div class="step-title">Check installation</div><p>Confirm that the binary is available.</p><pre><code>forge --version</code></pre></div></li>
+        <li><div class="step-body"><div class="step-title">Activate your license</div><p>Use the license key from your purchase email.</p><pre><code>forge license activate &lt;YOUR_LICENSE_KEY&gt;</code></pre><p>Activation data is cached at <code>~/.forge/license.json</code>. Internet access is required.</p></div></li>
+        <li><div class="step-body"><div class="step-title">Verify commands</div><p>Confirm that backtest commands are available.</p><pre><code>forge backtest --help</code></pre></div></li>
+      </ol>
+
+      <h2 class="section-heading">Uninstall</h2>
+      <pre><code># macOS / Linux
+sudo rm /usr/local/bin/forge
+rm -rf ~/.forge</code></pre>
+
+      <h2 class="section-heading">Troubleshooting</h2>
+      <table class="cmd-table">
+        <thead><tr><th>Issue</th><th>Fix</th></tr></thead>
+        <tbody>
+          <tr><td><code>command not found: forge</code></td><td>Open a new terminal or run <code>source ~/.bashrc</code>.</td></tr>
+          <tr><td>License activation error</td><td>Check your network connection and make sure the key has no extra spaces.</td></tr>
+          <tr><td>macOS security warning</td><td>Open System Settings → Privacy & Security and allow <code>forge</code>.</td></tr>
+        </tbody>
+      </table>
+
+      <div class="callout" style="margin-top: 2rem;">
+        <p>If the issue persists, contact <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a>.</p>
+      </div>
     </div>
   </div>
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="footer-links">
-      <a href="/">ホーム</a>
-      <a href="install.html">インストール</a>
-      <a href="docs.html">ドキュメント</a>
-      <a href="terms.html">利用規約</a>
-      <a href="privacy.html">プライバシー</a>
+    <div class="lang-content lang-ja">
+      <div class="footer-links">
+        <a href="/">ホーム</a>
+        <a href="install.html">インストール</a>
+        <a href="docs.html">ドキュメント</a>
+        <a href="terms.html">利用規約</a>
+        <a href="privacy.html">プライバシー</a>
+      </div>
+    </div>
+    <div class="lang-content lang-en">
+      <div class="footer-links">
+        <a href="/">Home</a>
+        <a href="install.html">Install</a>
+        <a href="docs.html">Docs</a>
+        <a href="terms.html">Terms</a>
+        <a href="privacy.html">Privacy</a>
+      </div>
     </div>
   </footer>
 
@@ -155,12 +202,12 @@ rm -rf ~/.forge</code></pre>
     renderStandaloneHeader({ active: 'install' });
   </script>
   <script>
-    // プラットフォームタブ
-    function switchTab(id) {
-      document.querySelectorAll('.platform-tab').forEach(function(el) { el.classList.remove('active'); });
-      document.querySelectorAll('.platform-content').forEach(function(el) { el.classList.remove('active'); });
+    function switchTab(lang, id, event) {
+      var scope = document.querySelector('.lang-' + lang);
+      scope.querySelectorAll('.platform-tab').forEach(function(el) { el.classList.remove('active'); });
+      scope.querySelectorAll('.platform-content').forEach(function(el) { el.classList.remove('active'); });
       event.currentTarget.classList.add('active');
-      document.getElementById('tab-' + id).classList.add('active');
+      document.getElementById('tab-' + lang + '-' + id).classList.add('active');
     }
   </script>
 </body>

--- a/page.css
+++ b/page.css
@@ -113,6 +113,16 @@ body {
 }
 .toggle-btn:hover { border-color: var(--border-h); color: var(--text); }
 
+.lang-btn {
+  height: 32px; padding: 0 0.75rem;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--r); cursor: pointer;
+  display: flex; align-items: center; gap: 0.35rem;
+  font-family: var(--mono); font-size: 0.72rem; color: var(--text2);
+  transition: border-color 0.15s, color 0.15s;
+}
+.lang-btn:hover { border-color: var(--border-h); color: var(--text); }
+
 .follow-btn-nav {
   height: 32px; padding: 0 1rem;
   background: var(--accent-bg); border: 1px solid var(--accent-glow);
@@ -130,6 +140,10 @@ body {
   max-width: var(--max-w); margin: 0 auto;
   padding: calc(var(--nav-h) + 3rem) var(--pad) 5rem;
 }
+.lang-content { display: none; }
+body:not([data-lang]) .lang-ja,
+body[data-lang="ja"] .lang-ja,
+body[data-lang="en"] .lang-en { display: block; }
 
 /* ── TYPOGRAPHY ── */
 .page-label {
@@ -277,6 +291,7 @@ footer {
 
 @media (max-width: 640px) {
   .nav-page-link { padding: 0 0.55rem; }
+  .lang-btn { padding: 0 0.55rem; }
   .follow-btn-nav {
     width: 32px; padding: 0;
     justify-content: center; flex: 0 0 32px;

--- a/privacy.html
+++ b/privacy.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>プライバシーポリシー — Alforge Labs</title>
-  <meta name="description" content="Alforge Labs のプライバシーポリシー。個人情報の収集・利用・管理方針。" />
+  <meta name="description" content="Alforge Labs privacy policy for purchase, license activation, and support data." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -12,130 +12,117 @@
   <script>
     (function() {
       var t = localStorage.getItem('al_theme') || 'dark';
+      var l = localStorage.getItem('al_lang') || 'ja';
       document.documentElement.setAttribute('data-theme', t);
+      document.documentElement.setAttribute('lang', l);
       document.addEventListener('DOMContentLoaded', function() {
         document.body.setAttribute('data-theme', t);
+        document.body.setAttribute('data-lang', l);
       });
     })();
   </script>
 </head>
-<body data-theme="dark">
+<body data-theme="dark" data-lang="ja">
   <div id="site-header"></div>
 
   <div class="page-wrap">
-    <div class="page-label">Legal</div>
-    <h1 class="page-title">プライバシーポリシー</h1>
-    <p class="page-subtitle">最終更新日: 2026年4月25日</p>
+    <div class="lang-content lang-ja">
+      <div class="page-label">Legal</div>
+      <h1 class="page-title">プライバシーポリシー</h1>
+      <p class="page-subtitle">最終更新日: 2026年4月25日</p>
 
-    <p>Alforge Labs（以下「当社」）は、AlphaForge CLI の提供にあたり収集する個人情報の取り扱いについて、以下の通りプライバシーポリシー（以下「本ポリシー」）を定めます。</p>
+      <p>Alforge Labs（以下「当社」）は、AlphaForge CLI の提供にあたり収集する個人情報の取り扱いについて、以下の通りプライバシーポリシーを定めます。</p>
 
-    <h2 class="section-heading">1. 収集する情報</h2>
+      <h2 class="section-heading">1. 収集する情報</h2>
+      <h3 class="sub-heading">1.1 購入時に収集する情報</h3>
+      <p>LemonSqueezy を通じたライセンス購入時に、氏名または会社名、メールアドレス、決済情報、国・地域情報が収集されます。決済情報は LemonSqueezy が処理し、当社は保持しません。</p>
 
-    <h3 class="sub-heading">1.1 購入時に収集する情報</h3>
-    <p>LemonSqueezy を通じたライセンス購入時に、以下の情報が収集されます。これらの情報は LemonSqueezy が直接収集・管理します。</p>
-    <ul>
-      <li>氏名（または会社名）</li>
-      <li>メールアドレス</li>
-      <li>決済情報（クレジットカード情報等 — LemonSqueezy の決済システムで処理され、当社は保持しません）</li>
-      <li>国・地域情報（税務目的）</li>
-    </ul>
+      <h3 class="sub-heading">1.2 ライセンス認証時に収集する情報</h3>
+      <p><code>forge license activate</code> 実行時に、ライセンスキー、インスタンス名、アクティベーション日時が LemonSqueezy の License API に送信されます。</p>
 
-    <h3 class="sub-heading">1.2 ライセンス認証時に収集する情報</h3>
-    <p><code>forge license activate</code> 実行時に、以下の情報が LemonSqueezy の License API に送信されます。</p>
-    <ul>
-      <li>ライセンスキー</li>
-      <li>インスタンス名（デフォルト: マシンのホスト名）</li>
-      <li>アクティベーション日時</li>
-    </ul>
+      <h3 class="sub-heading">1.3 収集しない情報</h3>
+      <div class="callout">
+        <p>AlphaForge CLI はローカル完結型ソフトウェアです。バックテスト設定、最適化パラメータ、戦略データ、取引履歴、ポジション情報、ローカルファイル、操作ログは当社サーバーへ送信されません。</p>
+      </div>
 
-    <h3 class="sub-heading">1.3 収集しない情報</h3>
-    <div class="callout">
-      <p>AlphaForge CLI はローカル完結型ソフトウェアです。以下の情報は当社のサーバーには一切送信されません。</p>
+      <h2 class="section-heading">2. 情報の利用目的</h2>
+      <ul>
+        <li>ライセンスキーの発行・認証・管理</li>
+        <li>購入確認メール・領収書の送付</li>
+        <li>製品アップデートのお知らせ（登録ユーザーのみ、配信停止可）</li>
+        <li>サポート対応</li>
+        <li>法令上の義務履行（税務・会計処理）</li>
+      </ul>
+
+      <h2 class="section-heading">3. 第三者への情報提供</h2>
+      <p>当社は、決済処理・ライセンス管理のために LemonSqueezy と必要な情報を共有する場合、および法令上の要請がある場合を除き、個人情報を第三者に提供しません。マーケティング目的でのデータ販売・共有は行いません。</p>
+
+      <h2 class="section-heading">4. データの保存期間</h2>
+      <ul>
+        <li>購入情報・ライセンス情報: LemonSqueezy のデータ保持ポリシーに準拠</li>
+        <li>サポートメール: 対応完了後2年間</li>
+        <li>ローカル認証キャッシュ: ユーザーが削除するまで、または <code>forge license deactivate</code> 実行まで保持</li>
+      </ul>
+
+      <h2 class="section-heading">5. Cookie・トラッキング</h2>
+      <p>本ウェブサイトでは Google Analytics を使用してアクセス状況を分析しています。ブラウザの設定から Cookie を無効化することで計測を拒否できます。</p>
+
+      <h2 class="section-heading">6. お問い合わせ</h2>
+      <p>個人情報の取り扱いに関するお問い合わせ・開示・削除要求は以下にご連絡ください。</p>
+      <p>Email: <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a></p>
     </div>
-    <ul>
-      <li>バックテストの設定・結果</li>
-      <li>最適化パラメータ・戦略データ</li>
-      <li>取引履歴・ポジション情報</li>
-      <li>ローカルのファイルシステム情報</li>
-      <li>使用状況・操作ログ（テレメトリ無効）</li>
-    </ul>
 
-    <h2 class="section-heading">2. 情報の利用目的</h2>
-    <p>収集した情報は以下の目的のみに使用します。</p>
-    <ul>
-      <li>ライセンスキーの発行・認証・管理</li>
-      <li>購入確認メール・領収書の送付</li>
-      <li>製品アップデートのお知らせ（登録ユーザーのみ、配信停止可）</li>
-      <li>サポート対応</li>
-      <li>法令上の義務履行（税務・会計処理）</li>
-    </ul>
+    <div class="lang-content lang-en">
+      <div class="page-label">Legal</div>
+      <h1 class="page-title">Privacy Policy</h1>
+      <p class="page-subtitle">Last Updated: April 25, 2026</p>
 
-    <h2 class="section-heading">3. 第三者への情報提供</h2>
-    <p>当社は以下の場合を除き、個人情報を第三者に提供しません。</p>
-    <table class="cmd-table">
-      <thead><tr><th>提供先</th><th>提供する情報</th><th>目的</th></tr></thead>
-      <tbody>
-        <tr>
-          <td><a href="https://www.lemonsqueezy.com" target="_blank" rel="noopener">LemonSqueezy</a></td>
-          <td>購入情報・ライセンスキー</td>
-          <td>決済処理・ライセンス管理</td>
-        </tr>
-        <tr>
-          <td>法執行機関等</td>
-          <td>必要最小限の情報</td>
-          <td>法令上の要請がある場合のみ</td>
-        </tr>
-      </tbody>
-    </table>
-    <p>マーケティング目的での第三者へのデータ販売・共有は行いません。</p>
+      <p>Alforge Labs defines this privacy policy to explain how personal information is handled in connection with AlphaForge CLI.</p>
 
-    <h2 class="section-heading">4. データの保存期間</h2>
-    <ul>
-      <li>購入情報・ライセンス情報: LemonSqueezy のデータ保持ポリシーに準拠（通常は取引完了後7年間）</li>
-      <li>サポートメール: 対応完了後2年間</li>
-      <li>ローカルの認証キャッシュ (<code>~/.forge/license.json</code>): ユーザーが手動で削除するまで、または <code>forge license deactivate</code> を実行するまで保持</li>
-    </ul>
+      <h2 class="section-heading">1. Information We Collect</h2>
+      <h3 class="sub-heading">1.1 Purchase Information</h3>
+      <p>When you purchase a license through LemonSqueezy, information such as your name or company name, email address, payment details, and country or region may be collected. Payment details are processed by LemonSqueezy and are not stored by Alforge Labs.</p>
 
-    <h2 class="section-heading">5. セキュリティ</h2>
-    <p>当社は個人情報を保護するために適切な技術的・組織的措置を講じています。ただし、インターネット経由のデータ送信は完全に安全であることを保証できません。</p>
+      <h3 class="sub-heading">1.2 License Activation Information</h3>
+      <p>When you run <code>forge license activate</code>, the license key, instance name, and activation timestamp are sent to the LemonSqueezy License API.</p>
 
-    <h2 class="section-heading">6. ユーザーの権利</h2>
-    <p>以下の権利を行使する場合は、下記連絡先までお問い合わせください。</p>
-    <ul>
-      <li><strong>アクセス権:</strong> 保有する個人情報の開示を求める権利</li>
-      <li><strong>訂正権:</strong> 不正確な個人情報の訂正を求める権利</li>
-      <li><strong>削除権:</strong> 個人情報の削除を求める権利（法令上の保存義務がある場合を除く）</li>
-      <li><strong>処理制限権:</strong> 個人情報の処理制限を求める権利</li>
-    </ul>
-    <p>削除要求を受け付けた場合、当社が保持する情報と、LemonSqueezy に対する削除要求の代行を30日以内に行います。</p>
+      <h3 class="sub-heading">1.3 Information We Do Not Collect</h3>
+      <div class="callout">
+        <p>AlphaForge CLI is local-first software. Backtest settings, optimization parameters, strategy data, trading history, positions, local files, and usage logs are not sent to Alforge Labs servers.</p>
+      </div>
 
-    <h2 class="section-heading">7. Cookie・トラッキング</h2>
-    <p>本ウェブサイト（alforge-labs.github.io）では Google Analytics を使用してアクセス状況を分析しています。収集されるデータは匿名化されており、個人を特定する情報は含まれません。ブラウザの設定から Cookie を無効化することで計測を拒否できます。</p>
+      <h2 class="section-heading">2. How We Use Information</h2>
+      <ul>
+        <li>Issuing, activating, and managing license keys</li>
+        <li>Sending purchase confirmations and receipts</li>
+        <li>Sending product update notices to registered users, with opt-out available</li>
+        <li>Providing technical support</li>
+        <li>Meeting legal, tax, and accounting obligations</li>
+      </ul>
 
-    <h2 class="section-heading">8. 適用範囲</h2>
-    <p>本ポリシーは Alforge Labs が運営する以下に適用されます。</p>
-    <ul>
-      <li>ウェブサイト: alforge-labs.github.io</li>
-      <li>AlphaForge CLI ソフトウェア</li>
-    </ul>
+      <h2 class="section-heading">3. Third-Party Sharing</h2>
+      <p>We do not share personal information with third parties except when necessary for payment processing and license management through LemonSqueezy, or when required by law. We do not sell or share data for marketing purposes.</p>
 
-    <h2 class="section-heading">9. ポリシーの変更</h2>
-    <p>本ポリシーは予告なく変更される場合があります。重要な変更がある場合は登録メールアドレスへの通知またはウェブサイトへの掲載によりお知らせします。</p>
+      <h2 class="section-heading">4. Data Retention</h2>
+      <ul>
+        <li>Purchase and license information: retained according to LemonSqueezy's data retention policy</li>
+        <li>Support email: retained for two years after the support request is resolved</li>
+        <li>Local authentication cache: retained until the user removes it or runs <code>forge license deactivate</code></li>
+      </ul>
 
-    <h2 class="section-heading">10. お問い合わせ</h2>
-    <p>個人情報の取り扱いに関するお問い合わせ・開示・削除要求は以下にご連絡ください。</p>
-    <p>Email: <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a></p>
+      <h2 class="section-heading">5. Cookies and Tracking</h2>
+      <p>This website uses Google Analytics to analyze site traffic. You can opt out of measurement by disabling cookies in your browser settings.</p>
+
+      <h2 class="section-heading">6. Contact</h2>
+      <p>For privacy inquiries, disclosure requests, or deletion requests, please contact:</p>
+      <p>Email: <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a></p>
+    </div>
   </div>
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="footer-links">
-      <a href="/">ホーム</a>
-      <a href="install.html">インストール</a>
-      <a href="docs.html">ドキュメント</a>
-      <a href="terms.html">利用規約</a>
-      <a href="privacy.html">プライバシー</a>
-    </div>
+    <div class="lang-content lang-ja"><div class="footer-links"><a href="/">ホーム</a><a href="install.html">インストール</a><a href="docs.html">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a></div></div>
+    <div class="lang-content lang-en"><div class="footer-links"><a href="/">Home</a><a href="install.html">Install</a><a href="docs.html">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a></div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>

--- a/site-header.jsx
+++ b/site-header.jsx
@@ -82,6 +82,7 @@ function renderStandaloneHeader({ active = '' } = {}) {
   function StandaloneHeader() {
     const savedTheme = localStorage.getItem('al_theme');
     const [dark, setDark] = React.useState(savedTheme ? savedTheme === 'dark' : true);
+    const [lang, setLang] = React.useState(localStorage.getItem('al_lang') || 'ja');
 
     React.useEffect(() => {
       const theme = dark ? 'dark' : 'light';
@@ -90,7 +91,13 @@ function renderStandaloneHeader({ active = '' } = {}) {
       localStorage.setItem('al_theme', theme);
     }, [dark]);
 
-    return <SiteHeader dark={dark} setDark={setDark} lang="ja" active={active} />;
+    React.useEffect(() => {
+      localStorage.setItem('al_lang', lang);
+      document.documentElement.setAttribute('lang', lang);
+      document.body.setAttribute('data-lang', lang);
+    }, [lang]);
+
+    return <SiteHeader dark={dark} setDark={setDark} lang={lang} setLang={setLang} active={active} showLanguage={true} />;
   }
 
   ReactDOM.createRoot(root).render(<StandaloneHeader />);

--- a/terms.html
+++ b/terms.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>利用規約・免責事項 — Alforge Labs</title>
-  <meta name="description" content="AlphaForge CLI の利用規約および免責事項。" />
+  <title>利用規約・リスク免責事項 — Alforge Labs</title>
+  <meta name="description" content="AlphaForge の利用規約、リスク免責事項、およびサポート連絡先。" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -12,91 +12,84 @@
   <script>
     (function() {
       var t = localStorage.getItem('al_theme') || 'dark';
+      var l = localStorage.getItem('al_lang') || 'ja';
       document.documentElement.setAttribute('data-theme', t);
+      document.documentElement.setAttribute('lang', l);
       document.addEventListener('DOMContentLoaded', function() {
         document.body.setAttribute('data-theme', t);
+        document.body.setAttribute('data-lang', l);
       });
     })();
   </script>
 </head>
-<body data-theme="dark">
+<body data-theme="dark" data-lang="ja">
   <div id="site-header"></div>
 
   <div class="page-wrap">
-    <div class="page-label">Legal</div>
-    <h1 class="page-title">利用規約・免責事項</h1>
-    <p class="page-subtitle">最終更新日: 2026年4月25日</p>
+    <div class="lang-content lang-ja">
+      <div class="page-label">Legal</div>
+      <h1 class="page-title">利用規約・リスク免責事項</h1>
 
-    <div class="callout warn" style="margin-bottom: 2rem;">
-      <p><strong>重要な免責事項:</strong> AlphaForge CLI は投資判断の支援ツールではありません。本ソフトウェアのアウトプットは投資アドバイスを構成するものではなく、将来の収益を保証するものではありません。すべての投資・取引判断はご自身の責任において行ってください。</p>
+      <div class="callout warn" style="margin-bottom: 2rem;">
+        <p><strong>重要なお知らせ:</strong> AlphaForge はバックテストとローカル実行のためのソフトウェア開発フレームワークです。Alforge Labs は金融助言、売買シグナル、運用受託サービスを提供しません。</p>
+      </div>
+
+      <h2 class="section-heading">1. ソフトウェアの性質</h2>
+      <p>AlphaForge および Alforge Labs の関連ツールは、ソフトウェア開発者およびクオンツ研究者向けの技術インフラ・研究フレームワークです。ユーザー自身のハードウェア上で取引アルゴリズムをシミュレーションし、ローカル環境で実行するための機能を提供します。Alforge Labs は金融データ、証券仲介サービス、投資推奨を提供しません。</p>
+
+      <h2 class="section-heading">2. 金融助言ではありません</h2>
+      <p>本ウェブサイトおよび本ソフトウェアを通じて提供されるコンテンツは、情報提供および教育目的のみを意図しています。金融、法律、税務上の助言として解釈されるべきものではありません。金融市場での取引には重大な損失リスクがあります。</p>
+
+      <h2 class="section-heading">3. ローカル実行とデータプライバシー</h2>
+      <p>AlphaForge はユーザーのローカルマシン上で動作します。Alforge Labs はユーザーの API キー、証券会社の認証情報、個人の取引データへアクセスせず、これらを保存しません。実行環境および認証情報のセキュリティと管理は、ユーザー自身が単独で責任を負います。</p>
+
+      <h2 class="section-heading">4. リスク免責事項</h2>
+      <p>過去の実績は将来の結果を示すものではありません。仮想またはシミュレーションされたパフォーマンス結果には固有の制約があります。いかなる口座も、バックテストで示された利益または損失と同様の結果を達成する、または達成する可能性が高いと表明するものではありません。</p>
+
+      <h2 class="section-heading">5. 返金ポリシー</h2>
+      <p>本ソフトウェアはデジタル製品であり、該当する場合は完全なソースコードアクセスが提供される性質を持つため、すべての販売は最終的なものです。購入前にドキュメントと技術要件を十分に確認してください。</p>
+
+      <h2 class="section-heading">6. お問い合わせ</h2>
+      <p>技術サポートまたはお問い合わせは以下までご連絡ください。</p>
+      <p>Email: <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a></p>
+
+      <p class="page-subtitle" style="margin-top: 3rem;">最終更新日: 2026年4月25日</p>
     </div>
 
-    <h2 class="section-heading">1. 免責事項（金融ツールに関する重要事項）</h2>
-    <ul>
-      <li>本ソフトウェアは<strong>投資助言業務を行うものではなく</strong>、いかなる有価証券・金融商品の売買を推奨するものでもありません。</li>
-      <li>バックテスト・最適化の結果は過去データに基づく統計的シミュレーションであり、<strong>将来の運用成績を保証しません</strong>。</li>
-      <li>実際の取引では、スリッページ・手数料・流動性リスク・市場急変など、シミュレーションでは再現できない要因が生じます。</li>
-      <li>本ソフトウェアを利用した取引によって損失が発生した場合、<strong>開発者・販売者は一切の責任を負いません</strong>。</li>
-      <li>本ソフトウェアの利用は、適用されるすべての法律・規制に準拠してユーザー自身の責任で行うものとします。</li>
-    </ul>
+    <div class="lang-content lang-en">
+      <div class="page-label">Legal</div>
+      <h1 class="page-title">Terms of Service &amp; Risk Disclaimer</h1>
 
-    <h2 class="section-heading">2. ライセンス条件</h2>
+      <div class="callout warn" style="margin-bottom: 2rem;">
+        <p><strong>IMPORTANT NOTICE:</strong> AlphaForge is a software development framework for backtesting and local execution. We do not provide financial advice, trading signals, or managed fund services.</p>
+      </div>
 
-    <h3 class="sub-heading">2.1 付与されるライセンス</h3>
-    <p>有効なライセンスキーを購入したユーザーに対し、以下の条件の下で非独占的・非譲渡的な使用権を付与します。</p>
-    <ul>
-      <li>ライセンスキー1本につき<strong>1台のマシン</strong>でのみ有効です。</li>
-      <li>ライセンスは<strong>個人利用のみ</strong>を対象とします（商用利用・法人利用は別途お問い合わせください）。</li>
-      <li>Lifetime ライセンスは購入後の<strong>メジャーバージョンアップを含む</strong>将来のアップデートが対象です。</li>
-    </ul>
+      <h2 class="section-heading">1. Nature of the Software</h2>
+      <p>AlphaForge (and its related tools under Alforge Labs) is a technical infrastructure and research framework designed for software developers and quantitative researchers. It allows users to simulate and execute trading algorithms locally on their own hardware. Alforge Labs does not provide any financial data, brokerage services, or investment recommendations.</p>
 
-    <h3 class="sub-heading">2.2 禁止事項</h3>
-    <ul>
-      <li>ライセンスキーの第三者への譲渡・共有・販売</li>
-      <li>バイナリのリバースエンジニアリング・逆コンパイル・逆アセンブル</li>
-      <li>本ソフトウェアを改変した派生物の再配布</li>
-      <li>ライセンス認証機構の回避・無効化</li>
-    </ul>
+      <h2 class="section-heading">2. No Financial Advice</h2>
+      <p>The content provided through this website and the software itself is for informational and educational purposes only. Nothing should be construed as financial, legal, or tax advice. Trading in financial markets involves significant risk of loss.</p>
 
-    <h3 class="sub-heading">2.3 ライセンスの移行</h3>
-    <p>マシン変更時は <code>forge license deactivate</code> で旧デバイスのライセンスを解除してから、新デバイスで再認証してください。</p>
+      <h2 class="section-heading">3. Local Execution &amp; Data Privacy</h2>
+      <p>AlphaForge operates entirely on the user's local machine. Alforge Labs does not have access to, nor does it store, any user API keys, brokerage credentials, or personal trading data. The user is solely responsible for the security and management of their own execution environment and credentials.</p>
 
-    <h2 class="section-heading">3. 返金ポリシー</h2>
-    <ul>
-      <li><strong>購入後14日以内</strong>かつ<strong>ライセンスキーを未使用</strong>（アクティベーション未実施）の場合、全額返金を受け付けます。</li>
-      <li>返金を希望する場合は <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a> にご連絡ください。</li>
-      <li>ライセンスのアクティベーション後は、原則として返金対応外となります。</li>
-    </ul>
+      <h2 class="section-heading">4. Risk Disclaimer</h2>
+      <p>Past performance is not indicative of future results. Hypothetical or simulated performance results have certain inherent limitations. No representation is being made that any account will or is likely to achieve profits or losses similar to those shown in any backtest.</p>
 
-    <h2 class="section-heading">4. サービスの変更・終了</h2>
-    <p>開発者は予告なく本ソフトウェアの機能変更・開発終了を行う権利を留保します。ただし Lifetime ライセンスユーザーへは、終了日の30日前までにメールにてご連絡します。</p>
+      <h2 class="section-heading">5. Refund Policy</h2>
+      <p>Due to the digital nature of the software and the provision of full source code access (if applicable), all sales are final. Please review the documentation and technical requirements thoroughly before purchase.</p>
 
-    <h2 class="section-heading">5. 保証の否認</h2>
-    <p>本ソフトウェアは「現状のまま」提供されます。商品性・特定目的への適合性・非侵害性についての黙示的な保証を含め、いかなる明示または黙示の保証も行いません。</p>
+      <h2 class="section-heading">6. Contact Information</h2>
+      <p>For technical support or inquiries, please contact: <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a></p>
 
-    <h2 class="section-heading">6. 責任の制限</h2>
-    <p>適用法が許容する最大限の範囲において、開発者・販売者は、本ソフトウェアの使用または使用不能から生じる直接的・間接的・偶発的・特別・結果的損害について、その損害の可能性を事前に告知されていた場合でも責任を負いません。</p>
-
-    <h2 class="section-heading">7. 準拠法・管轄</h2>
-    <p>本規約は日本法に準拠し、日本国内の管轄裁判所を第一審の専属的合意管轄裁判所とします。</p>
-
-    <h2 class="section-heading">8. 規約の変更</h2>
-    <p>本規約は予告なく変更される場合があります。重要な変更がある場合は、登録メールアドレスへの通知またはウェブサイトへの掲載をもってお知らせします。変更後も継続して本ソフトウェアを使用した場合、変更後の規約に同意したものとみなします。</p>
-
-    <h2 class="section-heading">9. お問い合わせ</h2>
-    <p>本規約に関するお問い合わせは以下までご連絡ください。</p>
-    <p>Email: <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a></p>
+      <p class="page-subtitle" style="margin-top: 3rem;">Last Updated: April 25, 2026</p>
+    </div>
   </div>
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="footer-links">
-      <a href="/">ホーム</a>
-      <a href="install.html">インストール</a>
-      <a href="docs.html">ドキュメント</a>
-      <a href="terms.html">利用規約</a>
-      <a href="privacy.html">プライバシー</a>
-    </div>
+    <div class="lang-content lang-ja"><div class="footer-links"><a href="/">ホーム</a><a href="install.html">インストール</a><a href="docs.html">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a></div></div>
+    <div class="lang-content lang-en"><div class="footer-links"><a href="/">Home</a><a href="install.html">Install</a><a href="docs.html">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a></div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>


### PR DESCRIPTION
## 概要
- install/docs/terms/privacy に日本語・英語コンテンツを追加し、ヘッダーの言語ボタンで切り替えられるようにする
- 共通ヘッダーの standalone 表示で al_lang を読み書きし、body[data-lang] を更新する
- 利用規約・リスク免責事項を指定内容に合わせて更新
- 静的ページのフッターも日英で切り替える

## 確認
- rg で各ページの lang-content / data-lang / 英語見出しを確認
- rg で Terms of Service & Risk Disclaimer、IMPORTANT NOTICE、all sales are final、support@alforgelabs.com を確認
- 旧返金ポリシー文言が terms.html に残っていないことを確認
- ローカル HTTP サーバーで install.html / docs.html / terms.html / privacy.html が 200 で取得できることを確認
- git diff --check