### PR TITLE
利用規約に不足していたライセンス条項を補足

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -49,7 +49,42 @@
       <h2 class="section-heading">5. 返金ポリシー</h2>
       <p>本ソフトウェアはデジタル製品であり、該当する場合は完全なソースコードアクセスが提供される性質を持つため、すべての販売は最終的なものです。購入前にドキュメントと技術要件を十分に確認してください。</p>
 
-      <h2 class="section-heading">6. お問い合わせ</h2>
+      <h2 class="section-heading">6. ライセンス条件</h2>
+      <h3 class="sub-heading">6.1 付与されるライセンス</h3>
+      <p>有効なライセンスキーを購入したユーザーに対し、非独占的・非譲渡的な使用権を付与します。</p>
+      <ul>
+        <li>ライセンスキー1本につき1台のマシンでのみ有効です。</li>
+        <li>ライセンスは個人利用を対象とします。法人利用または商用利用については別途お問い合わせください。</li>
+        <li>Lifetime ライセンスには、購入後の将来バージョンアップが含まれます。</li>
+      </ul>
+
+      <h3 class="sub-heading">6.2 禁止事項</h3>
+      <ul>
+        <li>ライセンスキーの第三者への譲渡、共有、販売</li>
+        <li>バイナリのリバースエンジニアリング、逆コンパイル、逆アセンブル</li>
+        <li>本ソフトウェアを改変した派生物の再配布</li>
+        <li>ライセンス認証機構の回避または無効化</li>
+      </ul>
+
+      <h3 class="sub-heading">6.3 ライセンスの移行</h3>
+      <p>マシン変更時は <code>forge license deactivate</code> で旧デバイスのライセンスを解除してから、新デバイスで再認証してください。</p>
+
+      <h2 class="section-heading">7. サービスの変更・終了</h2>
+      <p>Alforge Labs は、予告なく本ソフトウェアの機能変更、提供条件の変更、または開発終了を行う権利を留保します。重要な変更がある場合は、ウェブサイトへの掲載または登録メールアドレスへの通知によりお知らせします。</p>
+
+      <h2 class="section-heading">8. 保証の否認</h2>
+      <p>本ソフトウェアは「現状のまま」提供されます。商品性、特定目的への適合性、非侵害性、継続利用可能性について、明示または黙示を問わずいかなる保証も行いません。</p>
+
+      <h2 class="section-heading">9. 責任の制限</h2>
+      <p>適用法が許容する最大限の範囲において、Alforge Labs は、本ソフトウェアの使用または使用不能から生じる直接的、間接的、偶発的、特別、結果的損害について、その損害の可能性を事前に告知されていた場合でも責任を負いません。</p>
+
+      <h2 class="section-heading">10. 準拠法・管轄</h2>
+      <p>本規約は日本法に準拠します。本規約に関連して紛争が生じた場合、日本国内の管轄裁判所を第一審の専属的合意管轄裁判所とします。</p>
+
+      <h2 class="section-heading">11. 規約の変更</h2>
+      <p>本規約は予告なく変更される場合があります。変更後も継続して本ソフトウェアを使用した場合、変更後の規約に同意したものとみなします。</p>
+
+      <h2 class="section-heading">12. お問い合わせ</h2>
       <p>技術サポートまたはお問い合わせは以下までご連絡ください。</p>
       <p>Email: <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a></p>
 
@@ -79,7 +114,42 @@
       <h2 class="section-heading">5. Refund Policy</h2>
       <p>Due to the digital nature of the software and the provision of full source code access (if applicable), all sales are final. Please review the documentation and technical requirements thoroughly before purchase.</p>
 
-      <h2 class="section-heading">6. Contact Information</h2>
+      <h2 class="section-heading">6. License Terms</h2>
+      <h3 class="sub-heading">6.1 License Grant</h3>
+      <p>Users who purchase a valid license key receive a non-exclusive, non-transferable right to use the software.</p>
+      <ul>
+        <li>Each license key is valid for one machine only.</li>
+        <li>The license is intended for personal use. Please contact us separately for corporate or commercial use.</li>
+        <li>Lifetime licenses include future version updates after purchase.</li>
+      </ul>
+
+      <h3 class="sub-heading">6.2 Prohibited Actions</h3>
+      <ul>
+        <li>Transferring, sharing, or selling license keys to third parties</li>
+        <li>Reverse engineering, decompiling, or disassembling binaries</li>
+        <li>Redistributing modified derivatives of the software</li>
+        <li>Circumventing or disabling the license activation mechanism</li>
+      </ul>
+
+      <h3 class="sub-heading">6.3 License Transfer</h3>
+      <p>When changing machines, deactivate the old device with <code>forge license deactivate</code> before activating the license on the new device.</p>
+
+      <h2 class="section-heading">7. Service Changes and Termination</h2>
+      <p>Alforge Labs reserves the right to change software features, terms of availability, or discontinue development without prior notice. Material changes may be announced on the website or by email to registered users.</p>
+
+      <h2 class="section-heading">8. Disclaimer of Warranties</h2>
+      <p>The software is provided "as is" without warranties of any kind, whether express or implied, including warranties of merchantability, fitness for a particular purpose, non-infringement, or continued availability.</p>
+
+      <h2 class="section-heading">9. Limitation of Liability</h2>
+      <p>To the maximum extent permitted by applicable law, Alforge Labs shall not be liable for any direct, indirect, incidental, special, or consequential damages arising from the use of, or inability to use, the software, even if advised of the possibility of such damages.</p>
+
+      <h2 class="section-heading">10. Governing Law and Jurisdiction</h2>
+      <p>These terms are governed by the laws of Japan. Any dispute related to these terms shall be subject to the exclusive jurisdiction of the competent courts in Japan as the court of first instance.</p>
+
+      <h2 class="section-heading">11. Changes to These Terms</h2>
+      <p>These terms may be changed without prior notice. Continued use of the software after changes are published constitutes acceptance of the updated terms.</p>
+
+      <h2 class="section-heading">12. Contact Information</h2>
       <p>For technical support or inquiries, please contact: <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a></p>
 
       <p class="page-subtitle" style="margin-top: 3rem;">Last Updated: April 25, 2026</p>


### PR DESCRIPTION
## 概要
- 旧版に含まれていたライセンス条件、禁止事項、ライセンス移行を日英で追加
- サービス変更・終了、保証否認、責任制限、準拠法・管轄、規約変更を日英で追加
- 現行の all sales are final の返金ポリシーと矛盾する旧返金条件は追加しない

## 確認
- 追加した日英見出しを rg で確認
- 旧返金条件の文言が terms.html に残っていないことを確認
- ローカル HTTP サーバーで terms.html が 200 で取得できることを確認
- git diff --check