### PR TITLE
返金ポリシーの提供物表現を修正

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -47,7 +47,7 @@
       <p>過去の実績は将来の結果を示すものではありません。仮想またはシミュレーションされたパフォーマンス結果には固有の制約があります。いかなる口座も、バックテストで示された利益または損失と同様の結果を達成する、または達成する可能性が高いと表明するものではありません。</p>
 
       <h2 class="section-heading">5. 返金ポリシー</h2>
-      <p>本ソフトウェアはデジタル製品であり、該当する場合は完全なソースコードアクセスが提供される性質を持つため、すべての販売は最終的なものです。購入前にドキュメントと技術要件を十分に確認してください。</p>
+      <p>本ソフトウェアはデジタル製品であり、ライセンスキーおよび実行可能バイナリが即時に提供される性質を持つため、すべての販売は最終的なもの（返金不可）とします。購入前にドキュメントと技術要件を十分に確認してください。</p>
 
       <h2 class="section-heading">6. ライセンス条件</h2>
       <h3 class="sub-heading">6.1 付与されるライセンス</h3>
@@ -112,7 +112,7 @@
       <p>Past performance is not indicative of future results. Hypothetical or simulated performance results have certain inherent limitations. No representation is being made that any account will or is likely to achieve profits or losses similar to those shown in any backtest.</p>
 
       <h2 class="section-heading">5. Refund Policy</h2>
-      <p>Due to the digital nature of the software and the provision of full source code access (if applicable), all sales are final. Please review the documentation and technical requirements thoroughly before purchase.</p>
+      <p>Due to the digital nature of the software and the immediate delivery of license keys and executable binaries, all sales are final. Please review the documentation and technical requirements thoroughly before purchase.</p>
 
       <h2 class="section-heading">6. License Terms</h2>
       <h3 class="sub-heading">6.1 License Grant</h3>


### PR DESCRIPTION
## 概要
- 返金ポリシーからソースコードアクセスに関する表現を削除
- ライセンスキーおよび実行可能バイナリの即時提供を理由とする返金不可表現に更新
- 英語版も同趣旨に更新

## 確認
- rg で旧ソースコードアクセス文言が残っていないことを確認
- rg で新しい日英文言を確認
- git diff --check