### PR TITLE
feat: ドキュメントページを大幅拡充

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>コマンドリファレンス — Alforge Labs</title>
-  <meta name="description" content="AlphaForge CLI command reference for backtest, optimize, walk-forward, license, and data commands." />
+  <title>ドキュメント — Alforge Labs</title>
+  <meta name="description" content="AlphaForge CLI ドキュメント。コマンドリファレンス、戦略開発ワークフロー、TradingView連携ガイド。" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -16,14 +16,19 @@
     }
     .cmd-nav-list { list-style: none; padding: 0; }
     .cmd-nav-list li a {
-      display: block; padding: 0.35rem 0.75rem;
-      font-family: var(--mono); font-size: 0.78rem; color: var(--text3);
+      display: block; padding: 0.3rem 0.75rem;
+      font-family: var(--mono); font-size: 0.75rem; color: var(--text3);
       text-decoration: none; border-left: 2px solid var(--border);
       transition: color 0.15s, border-color 0.15s;
     }
     .cmd-nav-list li a:hover { color: var(--accent); border-left-color: var(--accent); }
+    .cmd-nav-list .nav-group {
+      font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.12em;
+      color: var(--text3); padding: 0.7rem 0.75rem 0.2rem; font-family: var(--mono);
+      border-left: 2px solid transparent;
+    }
     .doc-layout {
-      display: grid; grid-template-columns: 200px 1fr; gap: 3rem;
+      display: grid; grid-template-columns: 190px 1fr; gap: 3rem;
     }
     .option-table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
     .option-table th {
@@ -37,9 +42,49 @@
       padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--border);
       vertical-align: top;
     }
-    .option-table td:first-child code { color: var(--accent); }
+    .option-table td:first-child code { color: var(--accent); font-family: var(--mono); font-size: 0.82rem; }
     .option-table tr:last-child td { border-bottom: none; }
-    .cmd-section { scroll-margin-top: calc(var(--nav-h) + 2rem); }
+    .cmd-section { scroll-margin-top: calc(var(--nav-h) + 2rem); margin-bottom: 3rem; }
+    .section-divider { border: none; border-top: 1px solid var(--border); margin: 3rem 0 2.5rem; }
+    .section-category {
+      font-size: 0.65rem; font-family: var(--mono); text-transform: uppercase;
+      letter-spacing: 0.14em; color: var(--accent); margin-bottom: 0.5rem;
+    }
+    .step-list { list-style: none; padding: 0; counter-reset: steps; }
+    .step-list li {
+      counter-increment: steps;
+      display: grid; grid-template-columns: 2rem 1fr; gap: 1rem;
+      margin-bottom: 1.5rem; align-items: start;
+    }
+    .step-list li::before {
+      content: counter(steps);
+      display: flex; align-items: center; justify-content: center;
+      width: 1.75rem; height: 1.75rem;
+      background: var(--accent); color: var(--bg); border-radius: 50%;
+      font-size: 0.8rem; font-weight: 700; flex-shrink: 0; margin-top: 0.1rem;
+    }
+    .step-list li > div > strong { display: block; margin-bottom: 0.3rem; }
+    .callout {
+      background: var(--bg2); border-left: 3px solid var(--accent);
+      padding: 0.85rem 1rem; border-radius: 0 6px 6px 0;
+      font-size: 0.88rem; color: var(--text2); margin: 0.75rem 0 1rem;
+    }
+    .callout code { font-family: var(--mono); font-size: 0.82rem; color: var(--accent); }
+    .payload-table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
+    .payload-table th {
+      font-family: var(--mono); font-size: 0.65rem; color: var(--text3);
+      text-transform: uppercase; letter-spacing: 0.1em;
+      text-align: left; padding: 0.4rem 0.75rem;
+      border-bottom: 1px solid var(--border); background: var(--bg2);
+    }
+    .payload-table td {
+      font-size: 0.83rem; color: var(--text2);
+      padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border);
+      vertical-align: top;
+    }
+    .payload-table td:first-child code { color: var(--amber); font-family: var(--mono); font-size: 0.8rem; }
+    .payload-table td .req { font-size: 0.7rem; color: var(--red, #f87171); }
+    .payload-table tr:last-child td { border-bottom: none; }
     @media (max-width: 768px) {
       .doc-layout { grid-template-columns: 1fr; }
       .cmd-nav { display: none; }
@@ -62,151 +107,877 @@
   <div id="site-header"></div>
 
   <div class="page-wrap" style="max-width: 1060px;">
+
+    <!-- ==================== 日本語版 ==================== -->
     <div class="lang-content lang-ja">
       <div class="page-label">Documentation</div>
-      <h1 class="page-title">コマンドリファレンス</h1>
-      <p class="page-subtitle">AlphaForge CLI の主要コマンド一覧と使用例です。</p>
-
-      <table class="cmd-table">
-        <thead><tr><th>コマンド</th><th>概要</th></tr></thead>
-        <tbody>
-          <tr><td><a href="#ja-backtest"><code>forge backtest run</code></a></td><td>戦略のバックテストを実行</td></tr>
-          <tr><td><a href="#ja-optimize"><code>forge optimize run</code></a></td><td>ベイズ最適化でパラメータを探索</td></tr>
-          <tr><td><a href="#ja-wft"><code>forge backtest wft</code></a></td><td>ウォークフォワードテストを実行</td></tr>
-          <tr><td><a href="#ja-license"><code>forge license activate</code></a></td><td>ライセンスキーを認証</td></tr>
-          <tr><td><a href="#ja-data"><code>forge data update</code></a></td><td>ヒストリカルデータを差分更新</td></tr>
-        </tbody>
-      </table>
+      <h1 class="page-title">ドキュメント</h1>
+      <p class="page-subtitle">コマンドリファレンス、戦略開発ワークフロー、TradingView 連携ガイド。</p>
 
       <div class="doc-layout" style="margin-top: 2rem;">
         <nav class="cmd-nav">
           <ul class="cmd-nav-list">
-            <li><a href="#ja-backtest">backtest run</a></li>
-            <li><a href="#ja-optimize">optimize run</a></li>
-            <li><a href="#ja-wft">backtest wft</a></li>
-            <li><a href="#ja-license">license activate</a></li>
-            <li><a href="#ja-data">data update</a></li>
+            <li class="nav-group">データ</li>
+            <li><a href="#ja-data">data</a></li>
+            <li class="nav-group">戦略</li>
+            <li><a href="#ja-strategy">strategy</a></li>
+            <li class="nav-group">バックテスト</li>
+            <li><a href="#ja-backtest">backtest</a></li>
+            <li class="nav-group">最適化</li>
+            <li><a href="#ja-optimize">optimize</a></li>
+            <li class="nav-group">Pine Script</li>
+            <li><a href="#ja-pine">pine</a></li>
+            <li class="nav-group">その他</li>
+            <li><a href="#ja-dashboard">dashboard</a></li>
+            <li><a href="#ja-license">license</a></li>
+            <li class="nav-group">ガイド</li>
+            <li><a href="#ja-workflow">開発ワークフロー</a></li>
+            <li><a href="#ja-tradingview">TradingView連携</a></li>
+            <li><a href="#ja-strike">alpha-strike連携</a></li>
           </ul>
         </nav>
+
         <div>
-          <section class="cmd-section" id="ja-backtest">
-            <h2 class="section-heading">forge backtest run</h2>
-            <p>指定した戦略とシンボルでバックテストを実行します。結果は SQLite に保存され、JSON 出力も可能です。</p>
-            <pre><code>forge backtest run &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; [OPTIONS]</code></pre>
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code>forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1
-forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1 --json
-forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1 --start 2021-01-01 --end 2024-12-31</code></pre>
-          </section>
 
-          <section class="cmd-section" id="ja-optimize">
-            <h2 class="section-heading">forge optimize run</h2>
-            <p>Optuna を使ったベイズ最適化でパラメータ空間を効率的に探索します。</p>
-            <pre><code>forge optimize run &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; --trials 200 -j 4</code></pre>
-          </section>
+          <!-- data -->
+          <section class="cmd-section" id="ja-data">
+            <div class="section-category">データ管理</div>
+            <h2 class="section-heading">forge data</h2>
+            <p>ヒストリカル市場データの取得・更新・管理を行います。データは <code>alpha-strategies/data/historical/</code> に Parquet 形式で保存されます。</p>
 
-          <section class="cmd-section" id="ja-wft">
-            <h2 class="section-heading">forge backtest wft</h2>
-            <p>ウォークフォワードテストを実行します。過学習を検出するための標準的な検証手法です。</p>
-            <pre><code>forge backtest wft CL=F --strategy cl_hmm_bb_rsi_v1 --folds 5</code></pre>
-          </section>
-
-          <section class="cmd-section" id="ja-license">
-            <h2 class="section-heading">forge license activate</h2>
-            <p>LemonSqueezy のライセンスキーを認証します。認証情報は <code>~/.forge/license.json</code> にキャッシュされます。</p>
-            <pre><code>forge license activate &lt;LICENSE_KEY&gt;</code></pre>
             <table class="option-table">
               <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
               <tbody>
+                <tr><td><code>forge data fetch &lt;SYMBOL&gt;</code></td><td>指定シンボルのヒストリカルデータを取得・保存</td></tr>
+                <tr><td><code>forge data update</code></td><td>保存済み全データを最新日まで差分更新</td></tr>
+                <tr><td><code>forge data update --symbol &lt;SYMBOL&gt;</code></td><td>特定シンボルのみ更新</td></tr>
+                <tr><td><code>forge data list</code></td><td>保存済みデータ一覧を表示</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">使用例</h3>
+            <pre><code># 初回取得
+forge data fetch USDJPY
+forge data fetch CL=F
+forge data fetch SPY QQQ NAS100
+
+# 一括差分更新
+forge data update
+
+# 特定シンボルのみ更新
+forge data update --symbol USDJPY
+
+# 保存済みデータを確認
+forge data list</code></pre>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- strategy -->
+          <section class="cmd-section" id="ja-strategy">
+            <div class="section-category">戦略管理</div>
+            <h2 class="section-heading">forge strategy</h2>
+            <p>戦略 JSON の作成・登録・確認を行います。戦略は JSON ファイルで定義し、バックテストや最適化の対象として登録します。</p>
+
+            <table class="option-table">
+              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge strategy list</code></td><td>登録済み戦略を一覧表示</td></tr>
+                <tr><td><code>forge strategy create</code></td><td>テンプレートから戦略 JSON を作成</td></tr>
+                <tr><td><code>forge strategy save &lt;FILE&gt;</code></td><td>JSON ファイルから戦略を登録</td></tr>
+                <tr><td><code>forge strategy show &lt;ID&gt;</code></td><td>戦略定義 (JSON) を表示</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">使用例</h3>
+            <pre><code># テンプレートから新規作成
+forge strategy create --template ema_crossover --id usdjpy_ema_v1 \
+  --out data/strategies/usdjpy_ema_v1.json
+
+# JSON ファイルを登録
+forge strategy save data/strategies/usdjpy_ema_v1.json
+
+# 登録済み戦略を確認
+forge strategy list
+
+# 戦略定義を表示
+forge strategy show usdjpy_ema_v1</code></pre>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- backtest -->
+          <section class="cmd-section" id="ja-backtest">
+            <div class="section-category">バックテスト</div>
+            <h2 class="section-heading">forge backtest</h2>
+            <p>戦略のバックテスト実行・履歴確認・分析を行います。結果は SQLite DB に自動保存されます。</p>
+
+            <table class="option-table">
+              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge backtest run &lt;SYMBOL&gt;</code></td><td>バックテストを実行</td></tr>
+                <tr><td><code>forge backtest wft &lt;SYMBOL&gt;</code></td><td>ウォークフォワードテストを実行</td></tr>
+                <tr><td><code>forge backtest list</code></td><td>保存済みバックテスト結果を一覧表示</td></tr>
+                <tr><td><code>forge backtest report &lt;ID&gt;</code></td><td>バックテスト結果の詳細を表示</td></tr>
+                <tr><td><code>forge backtest compare</code></td><td>複数の戦略結果を並べて比較</td></tr>
+                <tr><td><code>forge backtest chart &lt;SYMBOL&gt;</code></td><td>インタラクティブ HTML チャートを生成</td></tr>
+                <tr><td><code>forge backtest diagnose &lt;SYMBOL&gt;</code></td><td>パフォーマンス問題を自動診断</td></tr>
+                <tr><td><code>forge backtest monte-carlo &lt;SYMBOL&gt;</code></td><td>モンテカルロシミュレーションを実行</td></tr>
+                <tr><td><code>forge backtest portfolio</code></td><td>ポートフォリオバックテストを実行</td></tr>
+                <tr><td><code>forge backtest batch</code></td><td>複数戦略を並列バックテスト</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">使用例</h3>
+            <pre><code># 基本的なバックテスト
+forge backtest run USDJPY --strategy usdjpy_ema_v1
+
+# 期間指定
+forge backtest run USDJPY --strategy usdjpy_ema_v1 \
+  --start 2021-01-01 --end 2024-12-31
+
+# JSON 形式で出力
+forge backtest run USDJPY --strategy usdjpy_ema_v1 --json
+
+# ウォークフォワードテスト（5 フォールド）
+forge backtest wft USDJPY --strategy usdjpy_ema_v1 --folds 5
+
+# 結果一覧（Sharpe 降順）
+forge backtest list --sort sharpe --limit 20
+
+# 特定戦略の結果のみ
+forge backtest list --strategy usdjpy_ema_v1
+
+# インタラクティブチャートを生成してブラウザで開く
+forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- optimize -->
+          <section class="cmd-section" id="ja-optimize">
+            <div class="section-category">最適化</div>
+            <h2 class="section-heading">forge optimize</h2>
+            <p>Optuna を使ったベイズ最適化でパラメータを効率的に探索します。過学習リスクの評価や、最適化結果の戦略への適用もできます。</p>
+
+            <table class="option-table">
+              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge optimize run &lt;SYMBOL&gt;</code></td><td>ベイズ最適化を実行</td></tr>
+                <tr><td><code>forge optimize apply &lt;RESULT&gt;</code></td><td>最適化結果を戦略に適用して新規保存</td></tr>
+                <tr><td><code>forge optimize walk-forward &lt;SYMBOL&gt;</code></td><td>ウォークフォワード最適化を実行</td></tr>
+                <tr><td><code>forge optimize sensitivity &lt;SYMBOL&gt;</code></td><td>パラメータ感度分析（過学習リスク評価）</td></tr>
+                <tr><td><code>forge optimize history</code></td><td>過去の最適化結果をスコアボード表示</td></tr>
+                <tr><td><code>forge optimize portfolio</code></td><td>ポートフォリオ最適配分を最適化</td></tr>
+                <tr><td><code>forge optimize cross-symbol</code></td><td>複数銘柄への汎化性を最適化</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">使用例</h3>
+            <pre><code># Sharpe Ratio を指標に 200 トライアル、4 並列で最適化
+forge optimize run USDJPY --strategy usdjpy_ema_v1 \
+  --metric sharpe_ratio --trials 200 -j 4 --save
+
+# 最適化履歴を確認
+forge optimize history --strategy usdjpy_ema_v1 --sort score
+
+# 最適化結果を新しい戦略として保存
+forge optimize apply data/results/usdjpy_ema_v1_opt.json \
+  --to-strategy usdjpy_ema_v1_optimized
+
+# 感度分析で過学習リスクを評価
+forge optimize sensitivity USDJPY --strategy usdjpy_ema_v1_optimized</code></pre>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- pine -->
+          <section class="cmd-section" id="ja-pine">
+            <div class="section-category">Pine Script</div>
+            <h2 class="section-heading">forge pine</h2>
+            <p>戦略定義から TradingView 用の Pine Script v6 を自動生成します。HMM などの機械学習インジケータにも対応しています。</p>
+
+            <table class="option-table">
+              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge pine generate --strategy &lt;ID&gt;</code></td><td>Pine Script を生成してファイルに出力</td></tr>
+                <tr><td><code>forge pine preview --strategy &lt;ID&gt;</code></td><td>生成される Pine Script を標準出力でプレビュー</td></tr>
+                <tr><td><code>forge pine import &lt;FILE&gt;</code></td><td>.pine ファイルを戦略定義として取り込み</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">使用例</h3>
+            <pre><code># Pine Script を生成（output/pinescript/ に保存）
+forge pine generate --strategy usdjpy_ema_v1_optimized
+
+# HMM モデルの学習済みパラメータを埋め込んで生成
+forge pine generate --strategy cl_hmm_bb_rsi_v1 --with-training-data
+
+# 内容をプレビュー（ファイル出力なし）
+forge pine preview --strategy usdjpy_ema_v1_optimized
+
+# 既存 .pine ファイルをインポート
+forge pine import output/pinescript/usdjpy_ema_v1.pine --id usdjpy_ema_imported</code></pre>
+
+            <div class="callout">
+              生成ファイルの保存先は <code>forge.yaml</code> の <code>pinescript.output_path</code> で設定します。デフォルトは <code>output/pinescript/</code> です。
+            </div>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- dashboard & license -->
+          <section class="cmd-section" id="ja-dashboard">
+            <div class="section-category">Web UI</div>
+            <h2 class="section-heading">forge dashboard</h2>
+            <p>Streamlit ベースの Web UI を起動します。バックテスト結果の可視化、戦略ランキング、アイデア管理を一画面で確認できます。</p>
+            <pre><code>forge dashboard
+forge dashboard --port 8501 --no-open</code></pre>
+          </section>
+
+          <section class="cmd-section" id="ja-license" style="margin-top:2rem;">
+            <div class="section-category">ライセンス</div>
+            <h2 class="section-heading">forge license</h2>
+            <p>LemonSqueezy のライセンスキーを認証します。認証情報は <code>~/.forge/license.json</code> にキャッシュされます。</p>
+
+            <table class="option-table">
+              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge license activate &lt;KEY&gt;</code></td><td>ライセンスキーを認証</td></tr>
                 <tr><td><code>forge license status</code></td><td>現在のライセンス状態を表示</td></tr>
                 <tr><td><code>forge license deactivate</code></td><td>このデバイスのライセンスを無効化</td></tr>
               </tbody>
             </table>
           </section>
 
-          <section class="cmd-section" id="ja-data">
-            <h2 class="section-heading">forge data update</h2>
-            <p>設定ファイルに記載されたシンボルのヒストリカルデータを最新日まで差分更新します。</p>
-            <pre><code>forge data update
-forge data update --symbol CL=F
-forge data update --full</code></pre>
+          <hr class="section-divider" />
+
+          <!-- workflow -->
+          <section class="cmd-section" id="ja-workflow">
+            <div class="section-category">ガイド</div>
+            <h2 class="section-heading">エンドツーエンド 戦略開発ワークフロー</h2>
+            <p>ヒストリカルデータの取得から自動発注まで、典型的な開発フローを示します。Claude Code などのコーディングエージェントと組み合わせると、各ステップの自動化やパラメータ探索を高速化できます。</p>
+
+            <div class="callout">
+              以下のコマンドはすべて <code>alpha-strategies/</code> ディレクトリから <code>FORGE_CONFIG=forge.yaml uv run</code> 付きで実行することを想定しています。
+            </div>
+
+            <ul class="step-list">
+              <li>
+                <div>
+                  <strong>データ取得</strong>
+                  対象シンボルのヒストリカルデータをローカルに保存します。
+                  <pre><code>forge data fetch USDJPY</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>戦略テンプレート作成</strong>
+                  テンプレートから戦略 JSON の雛形を生成し、パラメータを編集します。
+                  <pre><code>forge strategy create --template ema_crossover \
+  --id usdjpy_ema_v1 \
+  --out data/strategies/usdjpy_ema_v1.json
+
+# 生成されたファイルをエディタで編集し、パラメータを調整
+forge strategy save data/strategies/usdjpy_ema_v1.json</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>バックテスト実行</strong>
+                  定義した戦略のパフォーマンスを過去データで検証します。
+                  <pre><code>forge backtest run USDJPY --strategy usdjpy_ema_v1
+
+# インタラクティブチャートで視覚的に確認
+forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>パラメータ最適化</strong>
+                  Optuna のベイズ最適化で最適なパラメータを探索します。
+                  <pre><code>forge optimize run USDJPY --strategy usdjpy_ema_v1 \
+  --metric sharpe_ratio --trials 300 -j 4 --save
+
+# 結果を新しい戦略として保存
+forge optimize apply data/results/usdjpy_ema_v1_opt.json \
+  --to-strategy usdjpy_ema_v1_optimized</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>ウォークフォワード検証</strong>
+                  過学習を検出するために、訓練期間とテスト期間を分けた検証を行います。
+                  <pre><code>forge backtest wft USDJPY --strategy usdjpy_ema_v1_optimized \
+  --folds 5
+
+# 感度分析でパラメータの堅牢性を確認
+forge optimize sensitivity USDJPY \
+  --strategy usdjpy_ema_v1_optimized</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>Pine Script 生成</strong>
+                  TradingView 用のアラートスクリプトを自動生成します。
+                  <pre><code>forge pine generate --strategy usdjpy_ema_v1_optimized</code></pre>
+                  出力先: <code>output/pinescript/usdjpy_ema_v1_optimized.pine</code>
+                </div>
+              </li>
+            </ul>
           </section>
+
+          <hr class="section-divider" />
+
+          <!-- tradingview -->
+          <section class="cmd-section" id="ja-tradingview">
+            <div class="section-category">ガイド</div>
+            <h2 class="section-heading">TradingView への Pine Script 反映</h2>
+            <p><code>forge pine generate</code> で生成した <code>.pine</code> ファイルを TradingView に貼り付けてアラートを設定します。</p>
+
+            <ul class="step-list">
+              <li>
+                <div>
+                  <strong>Pine Script を開く</strong>
+                  TradingView でチャートを開き、画面下部の「Pine エディタ」タブをクリックします。
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>スクリプトを貼り付ける</strong>
+                  生成した <code>.pine</code> ファイルの内容をエディタに貼り付け、「スクリプトを追加」（▶ ボタン）をクリックします。
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>アラートを設定する</strong>
+                  チャート右上のベルアイコン（アラート）→「アラートを追加」をクリック。
+                  <ul style="margin-top:0.4rem; padding-left:1.2rem; font-size:0.88rem; color:var(--text2);">
+                    <li>条件: 追加したスクリプト名を選択</li>
+                    <li>「Webhook URL」にチェックを入れ、alpha-strike のエンドポイントを入力</li>
+                    <li>「メッセージ」に後述の JSON ペイロードを入力</li>
+                  </ul>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>アラートメッセージのヒント</strong>
+                  Pine Script 内でシグナル変数（例: <code>longSignal</code>）を定義しておくと、アラートの条件設定が簡単になります。
+                  <pre><code>// Pine Script 内でのアラート定義例
+longSignal = ta.crossover(ema_fast, ema_slow)
+shortSignal = ta.crossunder(ema_fast, ema_slow)
+alertcondition(longSignal, title="Long Entry", message="long")</code></pre>
+                </div>
+              </li>
+            </ul>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- alpha-strike -->
+          <section class="cmd-section" id="ja-strike">
+            <div class="section-category">ガイド</div>
+            <h2 class="section-heading">TradingView と alpha-strike の連携</h2>
+            <p>alpha-strike は TradingView のアラートを Webhook で受け取り、OANDA・moomoo 証券に自動発注します。</p>
+
+            <h3 class="sub-heading">1. 環境変数の設定</h3>
+            <p><code>alpha-strike/.env</code> を作成して以下を設定します。</p>
+            <pre><code># 必須
+WEBHOOK_PASSPHRASE=your-secret-passphrase   # 任意の秘密文字列
+
+# OANDA 使用時
+OANDA_API_KEY=your-personal-access-token
+OANDA_ACCOUNT_ID=your-account-id
+OANDA_ENV=PRACTICE    # 本番は LIVE
+
+# moomoo 使用時
+MOOMOO_HOST=127.0.0.1
+MOOMOO_PORT=11111
+MOOMOO_TRD_ENV=SIMULATE   # 本番は REAL</code></pre>
+
+            <h3 class="sub-heading">2. Webhook URL</h3>
+            <div class="callout">
+              TradingView のアラート Webhook URL に以下を設定します:<br/>
+              <code>http://&lt;your-server&gt;:8080/webhook</code>
+            </div>
+
+            <h3 class="sub-heading">3. ペイロード仕様</h3>
+            <p>TradingView のアラートメッセージに JSON を記述します。</p>
+            <pre><code>{
+  "passphrase": "your-secret-passphrase",
+  "broker": "oanda",
+  "asset_class": "FX",
+  "action": "buy",
+  "ticker": "USDJPY",
+  "quantity": 1000
+}</code></pre>
+
+            <table class="payload-table">
+              <thead><tr><th>フィールド</th><th>説明</th><th>値の例</th></tr></thead>
+              <tbody>
+                <tr><td><code>passphrase</code><br/><span class="req">必須</span></td><td>.env の WEBHOOK_PASSPHRASE と一致させること</td><td>"my-secret"</td></tr>
+                <tr><td><code>broker</code><br/><span class="req">必須</span></td><td>発注先の証券会社</td><td>"oanda" / "moomoo"</td></tr>
+                <tr><td><code>asset_class</code><br/><span class="req">必須</span></td><td>アセットクラス</td><td>"FX" / "COMMODITY" / "US" / "INDEX"</td></tr>
+                <tr><td><code>action</code><br/><span class="req">必須</span></td><td>注文方向</td><td>"buy" / "sell"</td></tr>
+                <tr><td><code>ticker</code><br/><span class="req">必須</span></td><td>銘柄コード（TradingView のシンボル名）</td><td>"USDJPY" / "XAUUSD"</td></tr>
+                <tr><td><code>quantity</code><br/><span class="req">必須</span></td><td>注文数量（0 より大きい正の数）</td><td>1000 / 0.1</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">4. ティッカーと OANDA instrument の対応</h3>
+            <table class="option-table">
+              <thead><tr><th>asset_class</th><th>ticker 例</th><th>OANDA instrument</th></tr></thead>
+              <tbody>
+                <tr><td>FX</td><td>USDJPY</td><td>USD_JPY</td></tr>
+                <tr><td>COMMODITY</td><td>XAUUSD</td><td>XAU_USD</td></tr>
+                <tr><td>INDEX</td><td>NAS100</td><td>NAS100_USD</td></tr>
+                <tr><td>US</td><td>AAPL</td><td>AAPL_USD</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">5. 動作確認</h3>
+            <pre><code># ヘルスチェック
+curl http://localhost:8080/health
+# → {"status":"ok"}
+
+# テスト発注（PRACTICE / SIMULATE 環境で確認）
+curl -X POST http://localhost:8080/webhook \
+  -H "Content-Type: application/json" \
+  -d '{"passphrase":"your-secret","broker":"oanda","asset_class":"FX","action":"buy","ticker":"USDJPY","quantity":1000}'</code></pre>
+          </section>
+
         </div>
       </div>
-    </div>
+    </div><!-- /lang-ja -->
 
+
+    <!-- ==================== English version ==================== -->
     <div class="lang-content lang-en">
       <div class="page-label">Documentation</div>
-      <h1 class="page-title">Command Reference</h1>
-      <p class="page-subtitle">Core AlphaForge CLI commands and practical examples.</p>
-
-      <table class="cmd-table">
-        <thead><tr><th>Command</th><th>Summary</th></tr></thead>
-        <tbody>
-          <tr><td><a href="#en-backtest"><code>forge backtest run</code></a></td><td>Run a strategy backtest</td></tr>
-          <tr><td><a href="#en-optimize"><code>forge optimize run</code></a></td><td>Search parameters with Bayesian optimization</td></tr>
-          <tr><td><a href="#en-wft"><code>forge backtest wft</code></a></td><td>Run a walk-forward test</td></tr>
-          <tr><td><a href="#en-license"><code>forge license activate</code></a></td><td>Activate a license key</td></tr>
-          <tr><td><a href="#en-data"><code>forge data update</code></a></td><td>Update historical market data</td></tr>
-        </tbody>
-      </table>
+      <h1 class="page-title">Documentation</h1>
+      <p class="page-subtitle">Command reference, strategy development workflow, and TradingView integration guide.</p>
 
       <div class="doc-layout" style="margin-top: 2rem;">
         <nav class="cmd-nav">
           <ul class="cmd-nav-list">
-            <li><a href="#en-backtest">backtest run</a></li>
-            <li><a href="#en-optimize">optimize run</a></li>
-            <li><a href="#en-wft">backtest wft</a></li>
-            <li><a href="#en-license">license activate</a></li>
-            <li><a href="#en-data">data update</a></li>
+            <li class="nav-group">Data</li>
+            <li><a href="#en-data">data</a></li>
+            <li class="nav-group">Strategy</li>
+            <li><a href="#en-strategy">strategy</a></li>
+            <li class="nav-group">Backtest</li>
+            <li><a href="#en-backtest">backtest</a></li>
+            <li class="nav-group">Optimize</li>
+            <li><a href="#en-optimize">optimize</a></li>
+            <li class="nav-group">Pine Script</li>
+            <li><a href="#en-pine">pine</a></li>
+            <li class="nav-group">Other</li>
+            <li><a href="#en-dashboard">dashboard</a></li>
+            <li><a href="#en-license">license</a></li>
+            <li class="nav-group">Guides</li>
+            <li><a href="#en-workflow">Workflow</a></li>
+            <li><a href="#en-tradingview">TradingView</a></li>
+            <li><a href="#en-strike">alpha-strike</a></li>
           </ul>
         </nav>
+
         <div>
-          <section class="cmd-section" id="en-backtest">
-            <h2 class="section-heading">forge backtest run</h2>
-            <p>Runs a backtest for a symbol and strategy. Results are stored in SQLite and can also be printed as JSON.</p>
-            <pre><code>forge backtest run &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; [OPTIONS]</code></pre>
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code>forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1
-forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1 --json
-forge backtest run CL=F --strategy cl_hmm_bb_rsi_v1 --start 2021-01-01 --end 2024-12-31</code></pre>
-          </section>
 
-          <section class="cmd-section" id="en-optimize">
-            <h2 class="section-heading">forge optimize run</h2>
-            <p>Uses Optuna to search the strategy parameter space efficiently.</p>
-            <pre><code>forge optimize run &lt;SYMBOL&gt; --strategy &lt;STRATEGY_NAME&gt; --trials 200 -j 4</code></pre>
-          </section>
+          <!-- data -->
+          <section class="cmd-section" id="en-data">
+            <div class="section-category">Data Management</div>
+            <h2 class="section-heading">forge data</h2>
+            <p>Fetch, update, and manage historical market data. Data is stored as Parquet files under <code>alpha-strategies/data/historical/</code>.</p>
 
-          <section class="cmd-section" id="en-wft">
-            <h2 class="section-heading">forge backtest wft</h2>
-            <p>Runs a walk-forward test to validate robustness and reduce overfitting risk.</p>
-            <pre><code>forge backtest wft CL=F --strategy cl_hmm_bb_rsi_v1 --folds 5</code></pre>
-          </section>
-
-          <section class="cmd-section" id="en-license">
-            <h2 class="section-heading">forge license activate</h2>
-            <p>Activates a LemonSqueezy license key. Activation data is cached in <code>~/.forge/license.json</code>.</p>
-            <pre><code>forge license activate &lt;LICENSE_KEY&gt;</code></pre>
             <table class="option-table">
               <thead><tr><th>Command</th><th>Description</th></tr></thead>
               <tbody>
-                <tr><td><code>forge license status</code></td><td>Show the current license status</td></tr>
+                <tr><td><code>forge data fetch &lt;SYMBOL&gt;</code></td><td>Fetch and save historical data for a symbol</td></tr>
+                <tr><td><code>forge data update</code></td><td>Incrementally update all saved data to today</td></tr>
+                <tr><td><code>forge data update --symbol &lt;SYMBOL&gt;</code></td><td>Update a specific symbol only</td></tr>
+                <tr><td><code>forge data list</code></td><td>List all saved datasets</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">Examples</h3>
+            <pre><code># Initial fetch
+forge data fetch USDJPY
+forge data fetch CL=F
+forge data fetch SPY QQQ NAS100
+
+# Incremental update (all symbols)
+forge data update
+
+# Update a single symbol
+forge data update --symbol USDJPY
+
+# Check what's saved
+forge data list</code></pre>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- strategy -->
+          <section class="cmd-section" id="en-strategy">
+            <div class="section-category">Strategy Management</div>
+            <h2 class="section-heading">forge strategy</h2>
+            <p>Create, register, and inspect strategy JSON definitions. Strategies must be registered before use in backtests or optimization.</p>
+
+            <table class="option-table">
+              <thead><tr><th>Command</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge strategy list</code></td><td>List all registered strategies</td></tr>
+                <tr><td><code>forge strategy create</code></td><td>Generate a strategy JSON from a template</td></tr>
+                <tr><td><code>forge strategy save &lt;FILE&gt;</code></td><td>Register a strategy from a JSON file</td></tr>
+                <tr><td><code>forge strategy show &lt;ID&gt;</code></td><td>Print the strategy definition (JSON)</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">Examples</h3>
+            <pre><code># Create from template
+forge strategy create --template ema_crossover --id usdjpy_ema_v1 \
+  --out data/strategies/usdjpy_ema_v1.json
+
+# Register after editing the JSON
+forge strategy save data/strategies/usdjpy_ema_v1.json
+
+# List registered strategies
+forge strategy list
+
+# Inspect a strategy definition
+forge strategy show usdjpy_ema_v1</code></pre>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- backtest -->
+          <section class="cmd-section" id="en-backtest">
+            <div class="section-category">Backtesting</div>
+            <h2 class="section-heading">forge backtest</h2>
+            <p>Run backtests, view history, and analyse results. All results are automatically saved to SQLite.</p>
+
+            <table class="option-table">
+              <thead><tr><th>Command</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge backtest run &lt;SYMBOL&gt;</code></td><td>Run a backtest</td></tr>
+                <tr><td><code>forge backtest wft &lt;SYMBOL&gt;</code></td><td>Run a walk-forward test</td></tr>
+                <tr><td><code>forge backtest list</code></td><td>List saved backtest results</td></tr>
+                <tr><td><code>forge backtest report &lt;ID&gt;</code></td><td>Show detailed result for a run</td></tr>
+                <tr><td><code>forge backtest compare</code></td><td>Compare multiple strategy results side by side</td></tr>
+                <tr><td><code>forge backtest chart &lt;SYMBOL&gt;</code></td><td>Generate an interactive HTML chart</td></tr>
+                <tr><td><code>forge backtest diagnose &lt;SYMBOL&gt;</code></td><td>Auto-diagnose performance issues</td></tr>
+                <tr><td><code>forge backtest monte-carlo &lt;SYMBOL&gt;</code></td><td>Run Monte Carlo simulation</td></tr>
+                <tr><td><code>forge backtest portfolio</code></td><td>Run a portfolio backtest</td></tr>
+                <tr><td><code>forge backtest batch</code></td><td>Parallel backtest across multiple strategies</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">Examples</h3>
+            <pre><code># Basic backtest
+forge backtest run USDJPY --strategy usdjpy_ema_v1
+
+# With date range
+forge backtest run USDJPY --strategy usdjpy_ema_v1 \
+  --start 2021-01-01 --end 2024-12-31
+
+# JSON output
+forge backtest run USDJPY --strategy usdjpy_ema_v1 --json
+
+# Walk-forward test (5 folds)
+forge backtest wft USDJPY --strategy usdjpy_ema_v1 --folds 5
+
+# List results sorted by Sharpe
+forge backtest list --sort sharpe --limit 20
+
+# Open interactive chart in browser
+forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- optimize -->
+          <section class="cmd-section" id="en-optimize">
+            <div class="section-category">Optimization</div>
+            <h2 class="section-heading">forge optimize</h2>
+            <p>Bayesian parameter search with Optuna. Includes overfitting risk evaluation, walk-forward optimization, and one-click apply.</p>
+
+            <table class="option-table">
+              <thead><tr><th>Command</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge optimize run &lt;SYMBOL&gt;</code></td><td>Run Bayesian optimization</td></tr>
+                <tr><td><code>forge optimize apply &lt;RESULT&gt;</code></td><td>Apply results to a new strategy</td></tr>
+                <tr><td><code>forge optimize walk-forward &lt;SYMBOL&gt;</code></td><td>Walk-forward optimization</td></tr>
+                <tr><td><code>forge optimize sensitivity &lt;SYMBOL&gt;</code></td><td>Parameter sensitivity analysis (overfitting check)</td></tr>
+                <tr><td><code>forge optimize history</code></td><td>Scoreboard of past optimization runs</td></tr>
+                <tr><td><code>forge optimize portfolio</code></td><td>Optimize portfolio allocation weights</td></tr>
+                <tr><td><code>forge optimize cross-symbol</code></td><td>Optimize across multiple symbols for generalization</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">Examples</h3>
+            <pre><code># 300 trials, 4 workers, maximize Sharpe
+forge optimize run USDJPY --strategy usdjpy_ema_v1 \
+  --metric sharpe_ratio --trials 300 -j 4 --save
+
+# View optimization history
+forge optimize history --strategy usdjpy_ema_v1 --sort score
+
+# Apply best result as a new strategy
+forge optimize apply data/results/usdjpy_ema_v1_opt.json \
+  --to-strategy usdjpy_ema_v1_optimized
+
+# Check parameter robustness
+forge optimize sensitivity USDJPY --strategy usdjpy_ema_v1_optimized</code></pre>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- pine -->
+          <section class="cmd-section" id="en-pine">
+            <div class="section-category">Pine Script</div>
+            <h2 class="section-heading">forge pine</h2>
+            <p>Auto-generate TradingView Pine Script v6 from a strategy definition. Supports machine-learning indicators such as HMM by embedding trained parameters.</p>
+
+            <table class="option-table">
+              <thead><tr><th>Command</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge pine generate --strategy &lt;ID&gt;</code></td><td>Generate Pine Script and write to file</td></tr>
+                <tr><td><code>forge pine preview --strategy &lt;ID&gt;</code></td><td>Preview Pine Script in stdout (no file written)</td></tr>
+                <tr><td><code>forge pine import &lt;FILE&gt;</code></td><td>Parse a .pine file and import as a strategy</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">Examples</h3>
+            <pre><code># Generate Pine Script (saved to output/pinescript/)
+forge pine generate --strategy usdjpy_ema_v1_optimized
+
+# Embed trained HMM parameters
+forge pine generate --strategy cl_hmm_bb_rsi_v1 --with-training-data
+
+# Preview without writing to disk
+forge pine preview --strategy usdjpy_ema_v1_optimized
+
+# Import existing .pine file as a strategy
+forge pine import output/pinescript/usdjpy_ema_v1.pine --id usdjpy_ema_imported</code></pre>
+
+            <div class="callout">
+              The output path is configured via <code>pinescript.output_path</code> in <code>forge.yaml</code>. Default: <code>output/pinescript/</code>.
+            </div>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- dashboard & license -->
+          <section class="cmd-section" id="en-dashboard">
+            <div class="section-category">Web UI</div>
+            <h2 class="section-heading">forge dashboard</h2>
+            <p>Launch the Streamlit-based Web UI for backtest visualisation, strategy rankings, and idea tracking.</p>
+            <pre><code>forge dashboard
+forge dashboard --port 8501 --no-open</code></pre>
+          </section>
+
+          <section class="cmd-section" id="en-license" style="margin-top:2rem;">
+            <div class="section-category">License</div>
+            <h2 class="section-heading">forge license</h2>
+            <p>Activate and manage your LemonSqueezy license. Activation data is cached in <code>~/.forge/license.json</code>.</p>
+
+            <table class="option-table">
+              <thead><tr><th>Command</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge license activate &lt;KEY&gt;</code></td><td>Activate a license key on this device</td></tr>
+                <tr><td><code>forge license status</code></td><td>Show current license status</td></tr>
                 <tr><td><code>forge license deactivate</code></td><td>Deactivate this device</td></tr>
               </tbody>
             </table>
           </section>
 
-          <section class="cmd-section" id="en-data">
-            <h2 class="section-heading">forge data update</h2>
-            <p>Updates historical data for symbols defined in the configuration file.</p>
-            <pre><code>forge data update
-forge data update --symbol CL=F
-forge data update --full</code></pre>
+          <hr class="section-divider" />
+
+          <!-- workflow -->
+          <section class="cmd-section" id="en-workflow">
+            <div class="section-category">Guide</div>
+            <h2 class="section-heading">End-to-End Strategy Development Workflow</h2>
+            <p>A typical flow from raw data to live execution. This pairs naturally with a coding agent (e.g. Claude Code) for automated parameter exploration and strategy generation.</p>
+
+            <div class="callout">
+              All commands below assume you are running from <code>alpha-strategies/</code> with <code>FORGE_CONFIG=forge.yaml uv run</code> prepended.
+            </div>
+
+            <ul class="step-list">
+              <li>
+                <div>
+                  <strong>Fetch historical data</strong>
+                  <pre><code>forge data fetch USDJPY</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>Create a strategy from a template</strong>
+                  Generate a JSON scaffold, edit parameters, then register it.
+                  <pre><code>forge strategy create --template ema_crossover \
+  --id usdjpy_ema_v1 \
+  --out data/strategies/usdjpy_ema_v1.json
+
+# Edit the JSON, then register
+forge strategy save data/strategies/usdjpy_ema_v1.json</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>Run a backtest</strong>
+                  <pre><code>forge backtest run USDJPY --strategy usdjpy_ema_v1
+
+# Visual equity curve
+forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>Optimize parameters</strong>
+                  Bayesian search with Optuna, then apply the best result.
+                  <pre><code>forge optimize run USDJPY --strategy usdjpy_ema_v1 \
+  --metric sharpe_ratio --trials 300 -j 4 --save
+
+forge optimize apply data/results/usdjpy_ema_v1_opt.json \
+  --to-strategy usdjpy_ema_v1_optimized</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>Walk-forward validation</strong>
+                  Detect overfitting with out-of-sample testing.
+                  <pre><code>forge backtest wft USDJPY --strategy usdjpy_ema_v1_optimized \
+  --folds 5
+
+forge optimize sensitivity USDJPY \
+  --strategy usdjpy_ema_v1_optimized</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>Generate Pine Script</strong>
+                  Export a TradingView alert script from the optimized strategy.
+                  <pre><code>forge pine generate --strategy usdjpy_ema_v1_optimized</code></pre>
+                  Output: <code>output/pinescript/usdjpy_ema_v1_optimized.pine</code>
+                </div>
+              </li>
+            </ul>
           </section>
+
+          <hr class="section-divider" />
+
+          <!-- tradingview -->
+          <section class="cmd-section" id="en-tradingview">
+            <div class="section-category">Guide</div>
+            <h2 class="section-heading">Deploying Pine Script to TradingView</h2>
+            <p>Paste the generated <code>.pine</code> file into TradingView and set up an alert to trigger alpha-strike.</p>
+
+            <ul class="step-list">
+              <li>
+                <div>
+                  <strong>Open the Pine Editor</strong>
+                  Open a chart in TradingView and click the "Pine Editor" tab at the bottom.
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>Paste the script</strong>
+                  Copy the contents of the generated <code>.pine</code> file and paste it into the editor. Click "Add to chart" (▶).
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>Create an alert</strong>
+                  Click the bell icon (Alerts) → "Create alert". Set the condition to your script, enable "Webhook URL", and paste the alpha-strike endpoint.
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>Tip: in-script alert conditions</strong>
+                  Define <code>alertcondition</code> in Pine Script for cleaner alert setup.
+                  <pre><code>longSignal = ta.crossover(ema_fast, ema_slow)
+alertcondition(longSignal, title="Long Entry", message="long")</code></pre>
+                </div>
+              </li>
+            </ul>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- alpha-strike -->
+          <section class="cmd-section" id="en-strike">
+            <div class="section-category">Guide</div>
+            <h2 class="section-heading">Connecting TradingView to alpha-strike</h2>
+            <p>alpha-strike receives TradingView webhook alerts and forwards orders to OANDA or moomoo.</p>
+
+            <h3 class="sub-heading">1. Configure environment variables</h3>
+            <p>Create <code>alpha-strike/.env</code> from the provided example:</p>
+            <pre><code># Required
+WEBHOOK_PASSPHRASE=your-secret-passphrase
+
+# OANDA
+OANDA_API_KEY=your-personal-access-token
+OANDA_ACCOUNT_ID=your-account-id
+OANDA_ENV=PRACTICE    # or LIVE
+
+# moomoo
+MOOMOO_HOST=127.0.0.1
+MOOMOO_PORT=11111
+MOOMOO_TRD_ENV=SIMULATE   # or REAL</code></pre>
+
+            <h3 class="sub-heading">2. Webhook URL</h3>
+            <div class="callout">
+              Set the TradingView alert Webhook URL to:<br/>
+              <code>http://&lt;your-server&gt;:8080/webhook</code>
+            </div>
+
+            <h3 class="sub-heading">3. Payload format</h3>
+            <pre><code>{
+  "passphrase": "your-secret-passphrase",
+  "broker": "oanda",
+  "asset_class": "FX",
+  "action": "buy",
+  "ticker": "USDJPY",
+  "quantity": 1000
+}</code></pre>
+
+            <table class="payload-table">
+              <thead><tr><th>Field</th><th>Description</th><th>Example</th></tr></thead>
+              <tbody>
+                <tr><td><code>passphrase</code><br/><span class="req">required</span></td><td>Must match WEBHOOK_PASSPHRASE in .env</td><td>"my-secret"</td></tr>
+                <tr><td><code>broker</code><br/><span class="req">required</span></td><td>Target broker</td><td>"oanda" / "moomoo"</td></tr>
+                <tr><td><code>asset_class</code><br/><span class="req">required</span></td><td>Asset class</td><td>"FX" / "COMMODITY" / "US" / "INDEX"</td></tr>
+                <tr><td><code>action</code><br/><span class="req">required</span></td><td>Order direction</td><td>"buy" / "sell"</td></tr>
+                <tr><td><code>ticker</code><br/><span class="req">required</span></td><td>Symbol (TradingView notation)</td><td>"USDJPY" / "XAUUSD"</td></tr>
+                <tr><td><code>quantity</code><br/><span class="req">required</span></td><td>Order size (positive number)</td><td>1000 / 0.1</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">4. Ticker to OANDA instrument mapping</h3>
+            <table class="option-table">
+              <thead><tr><th>asset_class</th><th>ticker</th><th>OANDA instrument</th></tr></thead>
+              <tbody>
+                <tr><td>FX</td><td>USDJPY</td><td>USD_JPY</td></tr>
+                <tr><td>COMMODITY</td><td>XAUUSD</td><td>XAU_USD</td></tr>
+                <tr><td>INDEX</td><td>NAS100</td><td>NAS100_USD</td></tr>
+                <tr><td>US</td><td>AAPL</td><td>AAPL_USD</td></tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">5. Verify connectivity</h3>
+            <pre><code># Health check
+curl http://localhost:8080/health
+# → {"status":"ok"}
+
+# Test order (use PRACTICE / SIMULATE environment)
+curl -X POST http://localhost:8080/webhook \
+  -H "Content-Type: application/json" \
+  -d '{"passphrase":"your-secret","broker":"oanda","asset_class":"FX","action":"buy","ticker":"USDJPY","quantity":1000}'</code></pre>
+          </section>
+
         </div>
       </div>
-    </div>
+    </div><!-- /lang-en -->
+
   </div>
 
   <footer>


### PR DESCRIPTION
## Summary

issue #14 対応。ドキュメントページを全面的に拡充しました。

## 追加内容

### コマンドリファレンス（5コマンド → 全グループ）
- **data**: fetch / update / list
- **strategy**: create / save / list / show
- **backtest**: run / wft / list / report / compare / chart / diagnose / monte-carlo / portfolio / batch
- **optimize**: run / apply / walk-forward / sensitivity / history / portfolio / cross-symbol
- **pine**: generate / preview / import（Pine Script 生成）
- **dashboard** / **license**（activate / status / deactivate）

### 新規ガイドセクション
- **エンドツーエンド戦略開発ワークフロー** — データ取得→戦略作成→バックテスト→最適化→ウォークフォワード→Pine Script 生成の6ステップ
- **TradingView への Pine Script 反映手順** — エディタへの貼り付けとアラート設定方法
- **TradingView と alpha-strike の連携ガイド** — .env 設定、Webhook URL、ペイロード仕様、instrument マッピング、疎通確認コマンド

日英両言語版を並列更新しています。

Closes #14