### PR TITLE
fix: ダウンロードURLをalforge-labs/alforge-labs.github.ioに修正

### DIFF
--- a/install.html
+++ b/install.html
@@ -64,7 +64,7 @@
       <div id="tab-ja-manual" class="platform-content">
         <ol>
           <li>
-            <a href="https://github.com/ysakae/alpha-forge/releases/latest" target="_blank" rel="noopener">GitHub Releases</a>
+            <a href="https://github.com/alforge-labs/alforge-labs.github.io/releases/latest" target="_blank" rel="noopener">GitHub Releases</a>
             から使用するプラットフォームのバイナリをダウンロードします。
           </li>
           <li>macOS / Linux: 実行権限を付与して PATH の通ったディレクトリに配置します。<pre><code>chmod +x forge-macos-arm64
@@ -137,7 +137,7 @@ rm -rf ~/.forge</code></pre>
 
       <div id="tab-en-manual" class="platform-content">
         <ol>
-          <li>Download the binary for your platform from <a href="https://github.com/ysakae/alpha-forge/releases/latest" target="_blank" rel="noopener">GitHub Releases</a>.</li>
+          <li>Download the binary for your platform from <a href="https://github.com/alforge-labs/alforge-labs.github.io/releases/latest" target="_blank" rel="noopener">GitHub Releases</a>.</li>
           <li>macOS / Linux: make it executable and move it to a directory on your PATH.<pre><code>chmod +x forge-macos-arm64
 sudo mv forge-macos-arm64 /usr/local/bin/forge</code></pre></li>
           <li>Windows: place the binary in any folder and add that folder to PATH.</li>


### PR DESCRIPTION
## Summary

- 手動インストール手順のダウンロードリンクを修正
  - 旧: `https://github.com/ysakae/alpha-forge/releases/latest`（プライベートリポジトリのため非公開）
  - 新: `https://github.com/alforge-labs/alforge-labs.github.io/releases/latest`（公開リポジトリ）

## 関連PR
- alpha-forge: インストーラースクリプト + CI/CD ワークフロー修正
- alpha-strike: CI/CD ワークフロー修正

## 事前設定が必要なシークレット（重要）
alpha-forge・alpha-strike の GitHub リポジトリ設定に以下のシークレットを追加してください:

| シークレット名 | 値 |
|---|---|
| `RELEASE_REPO_TOKEN` | `alforge-labs/alforge-labs.github.io` への `contents: write` 権限を持つ PAT |