### PR TITLE
fix: インストーラースクリプトのリポジトリURLをパブリックリポジトリに修正

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -14,7 +14,7 @@
 
 $ErrorActionPreference = "Stop"
 
-$REPO       = "ysakae/alpha-forge"
+$REPO       = "alforge-labs/alforge-labs.github.io"
 $ARTIFACT   = "forge-windows-x86_64.exe"
 $INSTALL_DIR = Join-Path $env:USERPROFILE "bin"
 $INSTALL_PATH = Join-Path $INSTALL_DIR "forge.exe"

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
-REPO="ysakae/alpha-forge"
+REPO="alforge-labs/alforge-labs.github.io"
 
 # OS・アーキテクチャ判定
 OS="$(uname -s)"


### PR DESCRIPTION
## Summary
- `install.sh` / `install.ps1` の `REPO` 変数が `ysakae/alpha-forge`（プライベート）になっていたのを `alforge-labs/alforge-labs.github.io`（パブリック）に修正

## Test plan
- [ ] スクリプト内の `REPO` 変数が `alforge-labs/alforge-labs.github.io` になっていることを確認
- [ ] GitHub Releases API (`api.github.com/repos/alforge-labs/alforge-labs.github.io/releases/latest`) が公開後に正常レスポンスを返すことを確認