### PR TITLE
feat: 購入ボタンを販売開始前の案内表示に変更

### DIFF
--- a/homepage-components.jsx
+++ b/homepage-components.jsx
@@ -277,12 +277,12 @@ function Pricing({ t }) {
                 ))}
               </ul>
               <a
-                href={plan.url}
-                target="_blank" rel="noopener"
+                href="#roadmap"
                 className={plan.featured ? 'btn-primary' : 'btn-secondary'}
-                style={{ justifyContent: 'center', marginTop: 'auto' }}
+                style={{ justifyContent: 'center', marginTop: 'auto', flexDirection: 'column', gap: '2px' }}
               >
-                {c.buyNow}
+                <s>{c.buyNow}</s>
+                <span style={{ fontSize: '0.85em', fontWeight: 400 }}>{c.comingSummer}</span>
               </a>
             </div>
           ))}

--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -89,6 +89,7 @@ window.COPY = {
         },
       ],
       buyNow: '今すぐ購入',
+      comingSummer: '今夏販売開始予定',
       note: '購入後にライセンスキーが発行されます。インストール後に forge license activate <KEY> で有効化してください。',
     },
     products: {
@@ -320,6 +321,7 @@ window.COPY = {
         },
       ],
       buyNow: 'Buy Now',
+      comingSummer: 'Coming This Summer',
       note: 'A license key is issued after purchase. Activate with: forge license activate <KEY>',
     },
     products: {


### PR DESCRIPTION
## Summary
- Pricing セクションの3つの「今すぐ購入」ボタンを販売未開始の案内に変更
  - 「今すぐ購入」に取り消し線を表示
  - 「今夏販売開始予定」 / "Coming This Summer" を追記
  - クリックするとページ内の「ロードマップ」セクション (`#roadmap`) へスクロール

## Test plan
- [ ] Pricing セクションの3ボタンに取り消し線付きテキストが表示される
- [ ] 「今夏販売開始予定」の文字が表示される
- [ ] クリックでロードマップセクションへスクロールする