### PR TITLE
feat: チュートリアルページへのリンクをヘッダに追加

### DIFF
--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -126,7 +126,7 @@ window.COPY = {
     usecases: {
       label: '活用シーン',
       title: '多様なエンジニアリング領域に\n対応する時系列シミュレーション',
-      subtitle: 'AlphaForge の統計エンジンは、金融以外の分野でも活用できる汎用的な基盤です。',
+      subtitle: 'AlphaForge の統計エンジンは、IoTセンサーの監視や需要予測などさまざまな分野で活用できる汎用的な基盤です。',
       items: [
         {
           icon: '⚙️',
@@ -375,7 +375,7 @@ window.COPY = {
     usecases: {
       label: 'Use Cases',
       title: 'Versatile Time-Series Simulation\nfor Modern Engineering',
-      subtitle: 'The AlphaForge statistical engine is a general-purpose foundation applicable far beyond a single domain.',
+      subtitle: 'The AlphaForge statistical engine is a general-purpose foundation applicable to IoT sensor monitoring, demand forecasting, and many other domains.',
       items: [
         {
           icon: '⚙️',

--- a/site-header.jsx
+++ b/site-header.jsx
@@ -6,6 +6,7 @@ const HEADER_COPY = {
     pricing: '料金',
     install: 'インストール',
     docs: 'ドキュメント',
+    tutorial: 'チュートリアル',
     roadmap: 'ロードマップ',
     faq: 'FAQ',
     follow: 'フォロー',
@@ -16,6 +17,7 @@ const HEADER_COPY = {
     pricing: 'Pricing',
     install: 'Install',
     docs: 'Docs',
+    tutorial: 'Tutorial',
     roadmap: 'Roadmap',
     faq: 'FAQ',
     follow: 'Follow',
@@ -28,6 +30,7 @@ const HEADER_LINKS = [
   { key: 'pricing', href: '/#pricing' },
   { key: 'install', href: '/install.html' },
   { key: 'docs', href: '/docs.html' },
+  { key: 'tutorial', href: '/tutorial-telemetry.html' },
   { key: 'roadmap', href: '/#roadmap' },
   { key: 'faq', href: '/#faq' },
 ];


### PR DESCRIPTION
## Summary

- ヘッダーナビゲーションに「チュートリアル / Tutorial」リンクを追加（`/tutorial-telemetry.html` へ）
- `products.usecases.subtitle` を「IoTセンサーの監視や需要予測など」と具体的なユースケースを記載した文言に更新（JA/EN）

## Test plan

- [ ] ヘッダーに「チュートリアル」リンクが表示されることを確認
- [ ] リンクが `tutorial-telemetry.html` へ遷移することを確認
- [ ] ホームページの活用事例セクションの説明文が更新されていることを確認