### PR TITLE
feat: tutorial-telemetry.html を日英バイリンガル対応に更新

### DIFF
--- a/tutorial-telemetry.html
+++ b/tutorial-telemetry.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Tutorial: Simulating Server Telemetry and Anomaly Detection — Alforge Labs</title>
-  <meta name="description" content="A step-by-step tutorial showing how to use the AlphaForge CLI to ingest server telemetry data and run a local simulation to detect resource spikes." />
-  <meta property="og:title" content="Tutorial: Simulating Server Telemetry and Anomaly Detection" />
-  <meta property="og:description" content="Ingest CPU, memory, and network latency logs into AlphaForge and run a local anomaly-detection simulation — no external services required." />
+  <title>チュートリアル: サーバーテレメトリのシミュレーションと異常検知 — Alforge Labs</title>
+  <meta name="description" content="AlphaForge CLI を使ってサーバーテレメトリデータを取り込み、リソーススパイクをローカルでシミュレーション検知するステップバイステップのチュートリアル。" />
+  <meta property="og:title" content="チュートリアル: サーバーテレメトリのシミュレーションと異常検知" />
+  <meta property="og:description" content="CPU・メモリ・ネットワークレイテンシーのログを AlphaForge に取り込み、外部サービス不要でローカル異常検知シミュレーションを実行します。" />
   <meta property="og:type" content="article" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -88,85 +88,89 @@
   <script>
     (function() {
       var t = localStorage.getItem('al_theme') || 'dark';
+      var l = localStorage.getItem('al_lang') || 'ja';
       document.documentElement.setAttribute('data-theme', t);
+      document.documentElement.setAttribute('lang', l);
       document.addEventListener('DOMContentLoaded', function() {
         document.body.setAttribute('data-theme', t);
-        document.body.setAttribute('data-lang', 'en');
+        document.body.setAttribute('data-lang', l);
       });
     })();
   </script>
 </head>
-<body data-theme="dark" data-lang="en">
+<body data-theme="dark" data-lang="ja">
   <div id="site-header"></div>
 
   <div class="page-wrap" style="max-width: 1060px;">
 
-    <div class="page-label">Tutorial</div>
-    <h1 class="page-title">Simulating Server Telemetry<br>and Anomaly Detection</h1>
-    <p class="page-subtitle">
-      A practical walkthrough for DevOps and Data Engineering teams. Ingest raw system-resource
-      logs into AlphaForge, define a spike-detection descriptor, and run a fully local simulation
-      — no external services or network connectivity required.
-    </p>
+    <!-- ══════════════════════════════════════════════════════════ JA ══ -->
+    <div class="lang-content lang-ja">
 
-    <div class="doc-layout" style="margin-top: 2.5rem;">
+      <div class="page-label">チュートリアル</div>
+      <h1 class="page-title">サーバーテレメトリの<br>シミュレーションと異常検知</h1>
+      <p class="page-subtitle">
+        DevOps・データエンジニアリングチーム向けの実践ガイドです。システムリソースログを AlphaForge
+        に取り込み、スパイク検知ディスクリプターを定義して、外部サービス不要の完全ローカルシミュレーションを実行します。
+      </p>
 
-      <!-- ── Sidebar nav ── -->
-      <nav class="cmd-nav">
-        <ul class="cmd-nav-list">
-          <li class="nav-group">Overview</li>
-          <li><a href="#prerequisites">Prerequisites</a></li>
-          <li><a href="#architecture">Architecture</a></li>
-          <li class="nav-group">Walkthrough</li>
-          <li><a href="#step-ingest">Step 1 — Ingest</a></li>
-          <li><a href="#step-descriptor">Step 2 — Descriptor</a></li>
-          <li><a href="#step-dry-run">Step 3 — Dry Run</a></li>
-          <li><a href="#step-simulate">Step 4 — Simulate</a></li>
-          <li><a href="#step-inspect">Step 5 — Inspect</a></li>
-          <li class="nav-group">Reference</li>
-          <li><a href="#cli-reference">CLI Options</a></li>
-          <li><a href="#schema-reference">Schema Reference</a></li>
-          <li><a href="#troubleshooting">Troubleshooting</a></li>
-        </ul>
-      </nav>
+      <div class="doc-layout" style="margin-top: 2.5rem;">
 
-      <!-- ── Main content ── -->
-      <div>
+        <!-- ── サイドナビ ── -->
+        <nav class="cmd-nav">
+          <ul class="cmd-nav-list">
+            <li class="nav-group">概要</li>
+            <li><a href="#ja-prerequisites">前提条件</a></li>
+            <li><a href="#ja-architecture">アーキテクチャ</a></li>
+            <li class="nav-group">ウォークスルー</li>
+            <li><a href="#ja-step-ingest">Step 1 — 取り込み</a></li>
+            <li><a href="#ja-step-descriptor">Step 2 — ディスクリプター</a></li>
+            <li><a href="#ja-step-dry-run">Step 3 — ドライラン</a></li>
+            <li><a href="#ja-step-simulate">Step 4 — シミュレーション</a></li>
+            <li><a href="#ja-step-inspect">Step 5 — 結果確認</a></li>
+            <li class="nav-group">リファレンス</li>
+            <li><a href="#ja-cli-reference">CLIオプション</a></li>
+            <li><a href="#ja-schema-reference">スキーマリファレンス</a></li>
+            <li><a href="#ja-troubleshooting">トラブルシューティング</a></li>
+          </ul>
+        </nav>
 
-        <!-- Prerequisites -->
-        <section class="cmd-section" id="prerequisites">
-          <div class="section-category">Overview</div>
-          <h2 class="section-heading">Prerequisites</h2>
-          <p>Before starting, confirm the following are in place:</p>
+        <!-- ── メインコンテンツ ── -->
+        <div>
 
-          <table class="option-table" style="margin-top: 1rem;">
-            <thead><tr><th>Requirement</th><th>Notes</th></tr></thead>
-            <tbody>
-              <tr><td><code>forge</code> CLI ≥ 0.9.0</td><td>Run <code>forge --version</code> to verify. See <a href="/install.html">Install</a> for setup.</td></tr>
-              <tr><td>Python 3.10+ <em>or</em> Docker</td><td>The simulation engine runs in a local process; no cloud dependency.</td></tr>
-              <tr><td>Telemetry JSONL file</td><td>One JSON object per line. Fields: <code>ts</code>, <code>host</code>, and one or more numeric series. See <a href="#step-ingest">Step 1</a> for the schema.</td></tr>
-              <tr><td>≥ 500 MB free disk</td><td>Simulation output and intermediate state are written to <code>./output/</code> by default.</td></tr>
-            </tbody>
-          </table>
+          <!-- 前提条件 -->
+          <section class="cmd-section" id="ja-prerequisites">
+            <div class="section-category">概要</div>
+            <h2 class="section-heading">前提条件</h2>
+            <p>開始前に以下が揃っていることを確認してください。</p>
 
-          <div class="callout">
-            All processing in this tutorial runs <strong>locally on your workstation</strong>. No telemetry data
-            leaves the host. AlphaForge does not phone home during simulation execution.
-          </div>
-        </section>
+            <table class="option-table" style="margin-top: 1rem;">
+              <thead><tr><th>要件</th><th>備考</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge</code> CLI ≥ 0.9.0</td><td><code>forge --version</code> で確認。セットアップは <a href="/install.html">インストール</a> ページを参照。</td></tr>
+                <tr><td>Python 3.10+ <em>または</em> Docker</td><td>シミュレーションエンジンはローカルプロセスで動作します。クラウド依存はありません。</td></tr>
+                <tr><td>テレメトリ JSONL ファイル</td><td>1行1JSONオブジェクト。フィールド: <code>ts</code>、<code>host</code>、数値シリーズ1件以上。スキーマは <a href="#ja-step-ingest">Step 1</a> を参照。</td></tr>
+                <tr><td>空きディスク ≥ 500 MB</td><td>シミュレーション出力と中間状態はデフォルトで <code>./output/</code> に書き込まれます。</td></tr>
+              </tbody>
+            </table>
 
-        <hr class="section-divider" />
+            <div class="callout">
+              このチュートリアルのすべての処理は<strong>ワークステーション上でローカル実行</strong>されます。テレメトリデータは
+              ホスト外に送信されません。AlphaForge はシミュレーション実行中に外部通信を行いません。
+            </div>
+          </section>
 
-        <!-- Architecture -->
-        <section class="cmd-section" id="architecture">
-          <div class="section-category">Overview</div>
-          <h2 class="section-heading">Architecture</h2>
-          <p>
-            AlphaForge operates as a <strong>three-stage pipeline</strong>: ingestion, descriptor evaluation,
-            and result emission. Each stage is independently configurable and testable.
-          </p>
+          <hr class="section-divider" />
 
-          <pre><code>┌─────────────────────────────────────────────────────────────────┐
+          <!-- アーキテクチャ -->
+          <section class="cmd-section" id="ja-architecture">
+            <div class="section-category">概要</div>
+            <h2 class="section-heading">アーキテクチャ</h2>
+            <p>
+              AlphaForge は<strong>3ステージパイプライン</strong>として動作します: 取り込み、ディスクリプター評価、
+              結果出力。各ステージは独立して設定・テスト可能です。
+            </p>
+
+            <pre><code>┌─────────────────────────────────────────────────────────────────┐
 │                     AlphaForge Pipeline                         │
 │                                                                 │
 │  ┌──────────────┐   ┌──────────────────┐   ┌────────────────┐  │
@@ -180,42 +184,41 @@
 │    (normalised store)   (per-run state)        anomalies.jsonl  │
 └─────────────────────────────────────────────────────────────────┘</code></pre>
 
-          <p style="margin-top: 1rem; font-size: 0.9rem; color: var(--text2);">
-            The <strong>descriptor</strong> (<code>.yaml</code>) defines which series to watch, the
-            baseline computation method, and the threshold conditions that constitute an anomaly. The
-            descriptor does not contain execution logic; AlphaForge interprets it at simulation time.
-          </p>
-        </section>
+            <p style="margin-top: 1rem; font-size: 0.9rem; color: var(--text2);">
+              <strong>ディスクリプター</strong>（<code>.yaml</code>）は、監視するシリーズ、ローリングベースラインの計算方法、
+              および異常イベントを構成するしきい値条件を定義します。ディスクリプターには実行ロジックは含まれません。
+              AlphaForge がシミュレーション時にこれを解釈します。
+            </p>
+          </section>
 
-        <hr class="section-divider" />
+          <hr class="section-divider" />
 
-        <!-- Step 1: Ingest -->
-        <section class="cmd-section" id="step-ingest">
-          <div class="section-category">Step 1 of 5</div>
-          <h2 class="section-heading">Ingest Telemetry Data</h2>
-          <p>
-            Use <code>forge ingest</code> to load your raw JSONL log file into AlphaForge's normalised
-            time-series store. The command validates the timestamp field, casts numeric columns, and
-            partitions the data by host identifier.
-          </p>
+          <!-- Step 1: 取り込み -->
+          <section class="cmd-section" id="ja-step-ingest">
+            <div class="section-category">Step 1 of 5</div>
+            <h2 class="section-heading">テレメトリデータの取り込み</h2>
+            <p>
+              <code>forge ingest</code> を使って、生のJSONLログファイルを AlphaForge の正規化時系列ストアに読み込みます。
+              このコマンドはタイムスタンプフィールドを検証し、数値カラムをキャストし、ホスト識別子でデータをパーティション分割します。
+            </p>
 
-          <h3 class="sub-heading">Sample input file — <code>telemetry.jsonl</code></h3>
-          <pre><code>{"ts":"2026-01-15T08:00:00Z","host":"web-01","cpu_pct":12.4,"mem_pct":45.1,"net_latency_ms":5.2}
+            <h3 class="sub-heading">サンプル入力ファイル — <code>telemetry.jsonl</code></h3>
+            <pre><code>{"ts":"2026-01-15T08:00:00Z","host":"web-01","cpu_pct":12.4,"mem_pct":45.1,"net_latency_ms":5.2}
 {"ts":"2026-01-15T08:01:00Z","host":"web-01","cpu_pct":89.7,"mem_pct":71.3,"net_latency_ms":420.8}
 {"ts":"2026-01-15T08:02:00Z","host":"web-01","cpu_pct":91.2,"mem_pct":73.0,"net_latency_ms":510.3}
 {"ts":"2026-01-15T08:03:00Z","host":"web-01","cpu_pct":14.1,"mem_pct":47.8,"net_latency_ms":6.1}
 {"ts":"2026-01-15T08:00:00Z","host":"db-01", "cpu_pct": 8.3,"mem_pct":82.5,"net_latency_ms":2.9}
 {"ts":"2026-01-15T08:01:00Z","host":"db-01", "cpu_pct": 9.1,"mem_pct":83.2,"net_latency_ms":3.4}</code></pre>
 
-          <h3 class="sub-heading">Command</h3>
-          <pre><code>forge ingest telemetry.jsonl \
+            <h3 class="sub-heading">コマンド</h3>
+            <pre><code>forge ingest telemetry.jsonl \
   --format jsonl \
   --timestamp-field ts \
   --partition-field host \
   --series cpu_pct mem_pct net_latency_ms</code></pre>
 
-          <h3 class="sub-heading">Expected output</h3>
-          <pre><code>✔  Parsed     6 records across 2 partitions (web-01, db-01)
+            <h3 class="sub-heading">期待される出力</h3>
+            <pre><code>✔  Parsed     6 records across 2 partitions (web-01, db-01)
 ✔  Validated  timestamp field: ts  →  UTC ISO-8601
 ✔  Cast       cpu_pct       float64
 ✔  Cast       mem_pct       float64
@@ -224,45 +227,45 @@
 ✔  Stored     ./data/series/db-01.parquet   (2 rows)
    Ingest complete in 0.18 s</code></pre>
 
-          <div class="callout">
-            Supported input formats: <code>--format jsonl</code> (default), <code>csv</code>, <code>parquet</code>.
-            For CSV files, use <code>--delimiter ","</code> or <code>";"</code> as needed.
-            Parquet inputs skip the casting step entirely.
-          </div>
+            <div class="callout">
+              サポートされる入力フォーマット: <code>--format jsonl</code>（デフォルト）、<code>csv</code>、<code>parquet</code>。
+              CSVファイルは <code>--delimiter ","</code> または <code>";"</code> を必要に応じて使用してください。
+              Parquet入力はキャストステップをスキップします。
+            </div>
 
-          <h3 class="sub-heading">Verify the loaded series</h3>
-          <pre><code>forge data list
+            <h3 class="sub-heading">読み込まれたシリーズの確認</h3>
+            <pre><code>forge data list
 
 # Output:
 # PARTITION   ROWS   FROM                  TO                    SERIES
 # web-01      4      2026-01-15T08:00:00Z  2026-01-15T08:03:00Z  cpu_pct, mem_pct, net_latency_ms
 # db-01       2      2026-01-15T08:00:00Z  2026-01-15T08:01:00Z  cpu_pct, mem_pct, net_latency_ms</code></pre>
-        </section>
+          </section>
 
-        <hr class="section-divider" />
+          <hr class="section-divider" />
 
-        <!-- Step 2: Descriptor -->
-        <section class="cmd-section" id="step-descriptor">
-          <div class="section-category">Step 2 of 5</div>
-          <h2 class="section-heading">Write the Descriptor</h2>
-          <p>
-            A <strong>descriptor</strong> is a declarative YAML file that tells AlphaForge which series to
-            monitor, how to compute a rolling baseline, and what threshold conditions trigger an anomaly event.
-            No scripting or compiled code is required.
-          </p>
+          <!-- Step 2: ディスクリプター -->
+          <section class="cmd-section" id="ja-step-descriptor">
+            <div class="section-category">Step 2 of 5</div>
+            <h2 class="section-heading">ディスクリプターの作成</h2>
+            <p>
+              <strong>ディスクリプター</strong>は、AlphaForge に監視するシリーズ、ローリングベースラインの計算方法、
+              および異常イベントを発生させるしきい値条件を指示する宣言型YAMLファイルです。
+              スクリプトやコンパイル済みコードは不要です。
+            </p>
 
-          <h3 class="sub-heading">Create the descriptor file</h3>
-          <pre><code>forge strategy create \
+            <h3 class="sub-heading">ディスクリプターファイルの作成</h3>
+            <pre><code>forge strategy create \
   --template anomaly_detector \
   --id resource_spike_detector \
   --out descriptors/resource_spike_detector.yaml</code></pre>
 
-          <p style="margin-top: 0.8rem;">
-            Open the generated file and configure it as follows. Every field is documented inline.
-          </p>
+            <p style="margin-top: 0.8rem;">
+              生成されたファイルを開き、以下のように設定してください。各フィールドはインラインでドキュメント化されています。
+            </p>
 
-          <h3 class="sub-heading"><code>descriptors/resource_spike_detector.yaml</code></h3>
-          <pre><code># AlphaForge Descriptor — Server Resource Spike Detector
+            <h3 class="sub-heading"><code>descriptors/resource_spike_detector.yaml</code></h3>
+            <pre><code># AlphaForge Descriptor — Server Resource Spike Detector
 # Version schema: https://alforge-labs.github.io/schema/descriptor/v1
 id: resource_spike_detector
 version: "1.0.0"
@@ -316,37 +319,37 @@ output:
   include_context_window: true   # Append pre/post-event observations to each record
   context_window: 5m             # Lookback/lookahead duration</code></pre>
 
-          <h3 class="sub-heading">Register the descriptor</h3>
-          <pre><code>forge strategy save descriptors/resource_spike_detector.yaml
+            <h3 class="sub-heading">ディスクリプターの登録</h3>
+            <pre><code>forge strategy save descriptors/resource_spike_detector.yaml
 
 # Output:
 # ✔  Registered  resource_spike_detector  (v1.0.0)</code></pre>
 
-          <div class="callout">
-            Baseline options at a glance:
-            <br><code>rolling_mean</code> — arithmetic mean of the window; sensitive to isolated spikes.
-            <br><code>rolling_median</code> — robust to outliers; slower to reflect sustained shifts.
-            <br><code>rolling_percentile</code> — use for long-tail distributions (e.g. latency).
-          </div>
-        </section>
+            <div class="callout">
+              ベースラインオプションの概要:
+              <br><code>rolling_mean</code> — ウィンドウの算術平均。孤立したスパイクに敏感。
+              <br><code>rolling_median</code> — 外れ値に頑健。持続的な変化への反応は遅い。
+              <br><code>rolling_percentile</code> — 長尾分布（レイテンシーなど）に使用。
+            </div>
+          </section>
 
-        <hr class="section-divider" />
+          <hr class="section-divider" />
 
-        <!-- Step 3: Dry Run -->
-        <section class="cmd-section" id="step-dry-run">
-          <div class="section-category">Step 3 of 5</div>
-          <h2 class="section-heading">Validate with a Dry Run</h2>
-          <p>
-            Before executing a full simulation, use <code>--dry-run</code> to verify descriptor syntax,
-            confirm series resolution, and preview threshold parameters — without writing any output files.
-          </p>
+          <!-- Step 3: ドライラン -->
+          <section class="cmd-section" id="ja-step-dry-run">
+            <div class="section-category">Step 3 of 5</div>
+            <h2 class="section-heading">ドライランによる検証</h2>
+            <p>
+              完全なシミュレーションを実行する前に、<code>--dry-run</code> を使ってディスクリプターの構文を検証し、
+              シリーズの解決を確認し、しきい値パラメーターをプレビューします。出力ファイルは書き込まれません。
+            </p>
 
-          <pre><code>forge run \
+            <pre><code>forge run \
   --strategy resource_spike_detector \
   --dry-run</code></pre>
 
-          <h3 class="sub-heading">Expected dry-run output</h3>
-          <pre><code>AlphaForge  v0.9.4   dry-run mode
+            <h3 class="sub-heading">期待されるドライラン出力</h3>
+            <pre><code>AlphaForge  v0.9.4   dry-run mode
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Descriptor      resource_spike_detector  v1.0.0
 Partitions      web-01, db-01
@@ -363,26 +366,25 @@ Estimated time  &lt; 1s
 ✔  Descriptor is valid. No output written (dry-run).
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</code></pre>
 
-          <div class="callout warn">
-            If you see <code>ERROR: series 'cpu_pct' not found in partition 'db-01'</code>, the ingest
-            step did not include that series for that partition. Re-run <code>forge ingest</code> with all
-            required series listed under <code>--series</code>.
-          </div>
-        </section>
+            <div class="callout warn">
+              <code>ERROR: series 'cpu_pct' not found in partition 'db-01'</code> が表示された場合、
+              取り込みステップでそのパーティションにそのシリーズが含まれていません。
+              必要なシリーズをすべて <code>--series</code> に指定して <code>forge ingest</code> を再実行してください。
+            </div>
+          </section>
 
-        <hr class="section-divider" />
+          <hr class="section-divider" />
 
-        <!-- Step 4: Simulate -->
-        <section class="cmd-section" id="step-simulate">
-          <div class="section-category">Step 4 of 5</div>
-          <h2 class="section-heading">Run the Simulation</h2>
-          <p>
-            Execute the full simulation across the ingested time range. AlphaForge iterates over each
-            partition, computes rolling baselines, evaluates thresholds at every observation, and emits
-            anomaly events to the configured output path.
-          </p>
+          <!-- Step 4: シミュレーション -->
+          <section class="cmd-section" id="ja-step-simulate">
+            <div class="section-category">Step 4 of 5</div>
+            <h2 class="section-heading">シミュレーションの実行</h2>
+            <p>
+              取り込まれた時間範囲全体でシミュレーションを実行します。AlphaForge は各パーティションを反復処理し、
+              ローリングベースラインを計算し、各観測でしきい値を評価して、設定された出力パスに異常イベントを書き出します。
+            </p>
 
-          <pre><code>forge run \
+            <pre><code>forge run \
   --strategy resource_spike_detector \
   --data ./data/series/ \
   --from 2026-01-15T00:00:00Z \
@@ -390,8 +392,8 @@ Estimated time  &lt; 1s
   --output ./output/ \
   --workers 4</code></pre>
 
-          <h3 class="sub-heading">Progress output</h3>
-          <pre><code>AlphaForge  v0.9.4
+            <h3 class="sub-heading">進捗出力</h3>
+            <pre><code>AlphaForge  v0.9.4
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Run ID          2026-01-15-001
 Descriptor      resource_spike_detector  v1.0.0
@@ -411,34 +413,33 @@ Output          ./output/anomalies.jsonl
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Simulation complete in 0.31 s</code></pre>
 
-          <div class="callout">
-            <code>--workers</code> controls the number of parallel partition processors. For large datasets
-            (millions of rows), set this to the number of available CPU cores.
-            The default is <code>1</code> (sequential) to minimise memory pressure.
-          </div>
-        </section>
+            <div class="callout">
+              <code>--workers</code> は並列パーティションプロセッサーの数を制御します。大規模データセット（数百万行）の場合は、
+              利用可能なCPUコア数に設定してください。デフォルトは <code>1</code>（順次処理）でメモリ使用量を最小化します。
+            </div>
+          </section>
 
-        <hr class="section-divider" />
+          <hr class="section-divider" />
 
-        <!-- Step 5: Inspect -->
-        <section class="cmd-section" id="step-inspect">
-          <div class="section-category">Step 5 of 5</div>
-          <h2 class="section-heading">Inspect Results</h2>
-          <p>
-            Use <code>forge dashboard</code> to view a summary of detected anomalies, or read the raw
-            JSONL output directly for downstream pipeline integration.
-          </p>
+          <!-- Step 5: 結果確認 -->
+          <section class="cmd-section" id="ja-step-inspect">
+            <div class="section-category">Step 5 of 5</div>
+            <h2 class="section-heading">結果の確認</h2>
+            <p>
+              <code>forge dashboard</code> を使って検出された異常のサマリーを表示するか、
+              ダウンストリームパイプライン統合のために生のJSONL出力を直接読み取ります。
+            </p>
 
-          <h3 class="sub-heading">Open the dashboard</h3>
-          <pre><code>forge dashboard --run-id 2026-01-15-001</code></pre>
+            <h3 class="sub-heading">ダッシュボードを開く</h3>
+            <pre><code>forge dashboard --run-id 2026-01-15-001</code></pre>
 
-          <p style="margin-top: 0.8rem;">
-            The dashboard renders in your default browser at <code>http://127.0.0.1:7890</code>.
-            It is a local-only HTTP server; no data is transmitted externally.
-          </p>
+            <p style="margin-top: 0.8rem;">
+              ダッシュボードはデフォルトブラウザの <code>http://127.0.0.1:7890</code> でレンダリングされます。
+              ローカルのみのHTTPサーバーです。データは外部に送信されません。
+            </p>
 
-          <h3 class="sub-heading">Raw JSONL output — <code>./output/anomalies.jsonl</code></h3>
-          <pre><code>{
+            <h3 class="sub-heading">生のJSONL出力 — <code>./output/anomalies.jsonl</code></h3>
+            <pre><code>{
   "run_id": "2026-01-15-001",
   "descriptor": "resource_spike_detector",
   "partition": "web-01",
@@ -479,207 +480,204 @@ Simulation complete in 0.31 s</code></pre>
   ]
 }</code></pre>
 
-          <h3 class="sub-heading">Pipe output into downstream tools</h3>
-          <pre><code># Count events per series
+            <h3 class="sub-heading">ダウンストリームツールへのパイプ</h3>
+            <pre><code># シリーズごとのイベント数を集計
 jq -r '.series' ./output/anomalies.jsonl | sort | uniq -c
 
-# Filter to a single host
+# 特定ホストのみ抽出
 jq 'select(.partition == "web-01")' ./output/anomalies.jsonl
 
-# Extract timestamps and sigma values for alerting pipelines
+# アラートパイプライン向けにタイムスタンプとシグマ値を抽出
 jq '{series, ts_start, sigma_observed}' ./output/anomalies.jsonl</code></pre>
-        </section>
+          </section>
 
-        <hr class="section-divider" />
+          <hr class="section-divider" />
 
-        <!-- CLI Reference -->
-        <section class="cmd-section" id="cli-reference">
-          <div class="section-category">Reference</div>
-          <h2 class="section-heading">CLI Options — <code>forge run</code></h2>
+          <!-- CLIリファレンス -->
+          <section class="cmd-section" id="ja-cli-reference">
+            <div class="section-category">リファレンス</div>
+            <h2 class="section-heading">CLIオプション — <code>forge run</code></h2>
 
-          <table class="option-table">
-            <thead>
-              <tr><th>Option</th><th>Type</th><th>Default</th><th>Description</th></tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><code>--strategy &lt;ID&gt;</code></td>
-                <td>string</td>
-                <td>—</td>
-                <td>Registered descriptor ID, or path to a <code>.yaml</code> file.</td>
-              </tr>
-              <tr>
-                <td><code>--data &lt;PATH&gt;</code></td>
-                <td>path</td>
-                <td><code>./data/series/</code></td>
-                <td>Directory of per-partition Parquet files, or a single JSONL file.</td>
-              </tr>
-              <tr>
-                <td><code>--from &lt;ISO8601&gt;</code></td>
-                <td>datetime</td>
-                <td>earliest record</td>
-                <td>Simulation start boundary (inclusive). UTC assumed if no timezone suffix.</td>
-              </tr>
-              <tr>
-                <td><code>--to &lt;ISO8601&gt;</code></td>
-                <td>datetime</td>
-                <td>latest record</td>
-                <td>Simulation end boundary (inclusive).</td>
-              </tr>
-              <tr>
-                <td><code>--output &lt;PATH&gt;</code></td>
-                <td>path</td>
-                <td><code>./output/</code></td>
-                <td>Directory for run state, anomaly JSONL, and dashboard assets.</td>
-              </tr>
-              <tr>
-                <td><code>--workers &lt;N&gt;</code></td>
-                <td>int</td>
-                <td><code>1</code></td>
-                <td>Parallel partition processors. Recommend: number of CPU cores.</td>
-              </tr>
-              <tr>
-                <td><code>--dry-run</code></td>
-                <td>flag</td>
-                <td>off</td>
-                <td>Validate descriptor and resolve series without executing the simulation.</td>
-              </tr>
-              <tr>
-                <td><code>--log-level &lt;LEVEL&gt;</code></td>
-                <td>enum</td>
-                <td><code>info</code></td>
-                <td>Verbosity: <code>debug</code> | <code>info</code> | <code>warn</code> | <code>error</code>.</td>
-              </tr>
-            </tbody>
-          </table>
+            <table class="option-table">
+              <thead>
+                <tr><th>オプション</th><th>型</th><th>デフォルト</th><th>説明</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>--strategy &lt;ID&gt;</code></td>
+                  <td>string</td>
+                  <td>—</td>
+                  <td>登録済みディスクリプターID、または <code>.yaml</code> ファイルへのパス。</td>
+                </tr>
+                <tr>
+                  <td><code>--data &lt;PATH&gt;</code></td>
+                  <td>path</td>
+                  <td><code>./data/series/</code></td>
+                  <td>パーティション別Parquetファイルのディレクトリ、または単一のJSONLファイル。</td>
+                </tr>
+                <tr>
+                  <td><code>--from &lt;ISO8601&gt;</code></td>
+                  <td>datetime</td>
+                  <td>最古レコード</td>
+                  <td>シミュレーション開始境界（inclusive）。タイムゾーンサフィックスがない場合はUTCとみなされます。</td>
+                </tr>
+                <tr>
+                  <td><code>--to &lt;ISO8601&gt;</code></td>
+                  <td>datetime</td>
+                  <td>最新レコード</td>
+                  <td>シミュレーション終了境界（inclusive）。</td>
+                </tr>
+                <tr>
+                  <td><code>--output &lt;PATH&gt;</code></td>
+                  <td>path</td>
+                  <td><code>./output/</code></td>
+                  <td>実行状態、異常JSONL、ダッシュボードアセットの出力ディレクトリ。</td>
+                </tr>
+                <tr>
+                  <td><code>--workers &lt;N&gt;</code></td>
+                  <td>int</td>
+                  <td><code>1</code></td>
+                  <td>並列パーティションプロセッサー数。推奨: CPUコア数。</td>
+                </tr>
+                <tr>
+                  <td><code>--dry-run</code></td>
+                  <td>flag</td>
+                  <td>off</td>
+                  <td>シミュレーションを実行せずにディスクリプターを検証してシリーズを解決します。</td>
+                </tr>
+                <tr>
+                  <td><code>--log-level &lt;LEVEL&gt;</code></td>
+                  <td>enum</td>
+                  <td><code>info</code></td>
+                  <td>詳細度: <code>debug</code> | <code>info</code> | <code>warn</code> | <code>error</code>。</td>
+                </tr>
+              </tbody>
+            </table>
 
-          <h3 class="sub-heading">CLI Options — <code>forge ingest</code></h3>
-          <table class="option-table">
-            <thead>
-              <tr><th>Option</th><th>Type</th><th>Default</th><th>Description</th></tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><code>--format &lt;FMT&gt;</code></td>
-                <td>enum</td>
-                <td><code>jsonl</code></td>
-                <td>Input format: <code>jsonl</code> | <code>csv</code> | <code>parquet</code>.</td>
-              </tr>
-              <tr>
-                <td><code>--timestamp-field &lt;F&gt;</code></td>
-                <td>string</td>
-                <td><code>ts</code></td>
-                <td>Name of the timestamp column. Must be ISO-8601 or Unix epoch (ms).</td>
-              </tr>
-              <tr>
-                <td><code>--partition-field &lt;F&gt;</code></td>
-                <td>string</td>
-                <td>—</td>
-                <td>Column to split data into per-host partitions. Omit for single-host datasets.</td>
-              </tr>
-              <tr>
-                <td><code>--series &lt;S…&gt;</code></td>
-                <td>list</td>
-                <td>all numeric</td>
-                <td>Whitelist of numeric columns to ingest. Unspecified columns are ignored.</td>
-              </tr>
-              <tr>
-                <td><code>--delimiter &lt;C&gt;</code></td>
-                <td>char</td>
-                <td><code>,</code></td>
-                <td>Column delimiter for CSV input only.</td>
-              </tr>
-              <tr>
-                <td><code>--out &lt;PATH&gt;</code></td>
-                <td>path</td>
-                <td><code>./data/series/</code></td>
-                <td>Output directory for normalised Parquet partitions.</td>
-              </tr>
-            </tbody>
-          </table>
-        </section>
+            <h3 class="sub-heading">CLIオプション — <code>forge ingest</code></h3>
+            <table class="option-table">
+              <thead>
+                <tr><th>オプション</th><th>型</th><th>デフォルト</th><th>説明</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>--format &lt;FMT&gt;</code></td>
+                  <td>enum</td>
+                  <td><code>jsonl</code></td>
+                  <td>入力フォーマット: <code>jsonl</code> | <code>csv</code> | <code>parquet</code>。</td>
+                </tr>
+                <tr>
+                  <td><code>--timestamp-field &lt;F&gt;</code></td>
+                  <td>string</td>
+                  <td><code>ts</code></td>
+                  <td>タイムスタンプカラムの名前。ISO-8601またはUnixエポック（ms）を指定。</td>
+                </tr>
+                <tr>
+                  <td><code>--partition-field &lt;F&gt;</code></td>
+                  <td>string</td>
+                  <td>—</td>
+                  <td>データをホスト別パーティションに分割するカラム。単一ホストデータセットの場合は省略可。</td>
+                </tr>
+                <tr>
+                  <td><code>--series &lt;S…&gt;</code></td>
+                  <td>list</td>
+                  <td>全数値カラム</td>
+                  <td>取り込む数値カラムのホワイトリスト。未指定のカラムは無視されます。</td>
+                </tr>
+                <tr>
+                  <td><code>--delimiter &lt;C&gt;</code></td>
+                  <td>char</td>
+                  <td><code>,</code></td>
+                  <td>CSV入力のみのカラム区切り文字。</td>
+                </tr>
+                <tr>
+                  <td><code>--out &lt;PATH&gt;</code></td>
+                  <td>path</td>
+                  <td><code>./data/series/</code></td>
+                  <td>正規化Parquetパーティションの出力ディレクトリ。</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
 
-        <hr class="section-divider" />
+          <hr class="section-divider" />
 
-        <!-- Schema Reference -->
-        <section class="cmd-section" id="schema-reference">
-          <div class="section-category">Reference</div>
-          <h2 class="section-heading">Descriptor Schema Reference</h2>
-          <p>
-            The descriptor YAML follows a versioned schema. All fields below are supported as of
-            AlphaForge <code>v0.9.x</code>.
-          </p>
+          <!-- スキーマリファレンス -->
+          <section class="cmd-section" id="ja-schema-reference">
+            <div class="section-category">リファレンス</div>
+            <h2 class="section-heading">ディスクリプタースキーマリファレンス</h2>
+            <p>
+              ディスクリプターYAMLはバージョン管理されたスキーマに従います。以下のすべてのフィールドは
+              AlphaForge <code>v0.9.x</code> 時点でサポートされています。
+            </p>
 
-          <table class="option-table">
-            <thead>
-              <tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr>
-            </thead>
-            <tbody>
-              <tr><td><code>id</code></td><td>string</td><td>Yes</td><td>Unique descriptor identifier. Alphanumeric and underscores only.</td></tr>
-              <tr><td><code>version</code></td><td>semver</td><td>Yes</td><td>Descriptor version string (e.g. <code>"1.0.0"</code>).</td></tr>
-              <tr><td><code>description</code></td><td>string</td><td>No</td><td>Human-readable summary. Appears in <code>forge strategy list</code> output.</td></tr>
-              <tr><td><code>input.partition_field</code></td><td>string</td><td>No</td><td>Column used to split observations into named partitions.</td></tr>
-              <tr><td><code>input.timestamp_field</code></td><td>string</td><td>Yes</td><td>Column containing observation timestamps.</td></tr>
-              <tr><td><code>series[].name</code></td><td>string</td><td>Yes</td><td>Column name in the ingested dataset.</td></tr>
-              <tr><td><code>series[].window</code></td><td>duration</td><td>Yes</td><td>Rolling window for baseline computation. Format: <code>Ns</code>, <code>Nm</code>, <code>Nh</code>.</td></tr>
-              <tr><td><code>series[].baseline</code></td><td>enum</td><td>Yes</td><td><code>rolling_mean</code> | <code>rolling_median</code> | <code>rolling_percentile</code>.</td></tr>
-              <tr><td><code>series[].percentile</code></td><td>float</td><td>Conditional</td><td>Required when <code>baseline: rolling_percentile</code>. Range: 0–100.</td></tr>
-              <tr><td><code>thresholds.&lt;series&gt;.sigma</code></td><td>float</td><td>Yes</td><td>Standard-deviation multiplier above baseline to trigger an event.</td></tr>
-              <tr><td><code>thresholds.&lt;series&gt;.min_duration</code></td><td>duration</td><td>Yes</td><td>Minimum continuous exceedance duration before an event is emitted.</td></tr>
-              <tr><td><code>output.format</code></td><td>enum</td><td>No</td><td>Result format: <code>jsonl</code> (default) | <code>csv</code> | <code>parquet</code>.</td></tr>
-              <tr><td><code>output.path</code></td><td>path</td><td>No</td><td>Output file path. Overrides <code>--output</code> CLI flag if set.</td></tr>
-              <tr><td><code>output.include_context_window</code></td><td>bool</td><td>No</td><td>Append surrounding observations to each anomaly record.</td></tr>
-              <tr><td><code>output.context_window</code></td><td>duration</td><td>No</td><td>Lookback and lookahead range for context records. Default: <code>5m</code>.</td></tr>
-            </tbody>
-          </table>
-        </section>
+            <table class="option-table">
+              <thead>
+                <tr><th>フィールド</th><th>型</th><th>必須</th><th>説明</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>id</code></td><td>string</td><td>Yes</td><td>一意のディスクリプター識別子。英数字とアンダースコアのみ。</td></tr>
+                <tr><td><code>version</code></td><td>semver</td><td>Yes</td><td>ディスクリプターバージョン文字列（例: <code>"1.0.0"</code>）。</td></tr>
+                <tr><td><code>description</code></td><td>string</td><td>No</td><td>人間が読めるサマリー。<code>forge strategy list</code> の出力に表示されます。</td></tr>
+                <tr><td><code>input.partition_field</code></td><td>string</td><td>No</td><td>観測値を名前付きパーティションに分割するカラム。</td></tr>
+                <tr><td><code>input.timestamp_field</code></td><td>string</td><td>Yes</td><td>観測タイムスタンプを含むカラム。</td></tr>
+                <tr><td><code>series[].name</code></td><td>string</td><td>Yes</td><td>取り込まれたデータセットのカラム名。</td></tr>
+                <tr><td><code>series[].window</code></td><td>duration</td><td>Yes</td><td>ベースライン計算のローリングウィンドウ。フォーマット: <code>Ns</code>, <code>Nm</code>, <code>Nh</code>。</td></tr>
+                <tr><td><code>series[].baseline</code></td><td>enum</td><td>Yes</td><td><code>rolling_mean</code> | <code>rolling_median</code> | <code>rolling_percentile</code>。</td></tr>
+                <tr><td><code>series[].percentile</code></td><td>float</td><td>条件付き</td><td><code>baseline: rolling_percentile</code> の場合に必須。範囲: 0–100。</td></tr>
+                <tr><td><code>thresholds.&lt;series&gt;.sigma</code></td><td>float</td><td>Yes</td><td>イベントを発生させるベースライン上の標準偏差乗数。</td></tr>
+                <tr><td><code>thresholds.&lt;series&gt;.min_duration</code></td><td>duration</td><td>Yes</td><td>イベントが出力されるまでの最小連続超過時間。</td></tr>
+                <tr><td><code>output.format</code></td><td>enum</td><td>No</td><td>結果フォーマット: <code>jsonl</code>（デフォルト）| <code>csv</code> | <code>parquet</code>。</td></tr>
+                <tr><td><code>output.path</code></td><td>path</td><td>No</td><td>出力ファイルパス。設定されている場合は <code>--output</code> CLIフラグを上書きします。</td></tr>
+                <tr><td><code>output.include_context_window</code></td><td>bool</td><td>No</td><td>各異常レコードに前後の観測値を付加します。</td></tr>
+                <tr><td><code>output.context_window</code></td><td>duration</td><td>No</td><td>コンテキストレコードのルックバック・ルックアヘッド範囲。デフォルト: <code>5m</code>。</td></tr>
+              </tbody>
+            </table>
+          </section>
 
-        <hr class="section-divider" />
+          <hr class="section-divider" />
 
-        <!-- Troubleshooting -->
-        <section class="cmd-section" id="troubleshooting">
-          <div class="section-category">Reference</div>
-          <h2 class="section-heading">Troubleshooting</h2>
+          <!-- トラブルシューティング -->
+          <section class="cmd-section" id="ja-troubleshooting">
+            <div class="section-category">リファレンス</div>
+            <h2 class="section-heading">トラブルシューティング</h2>
 
-          <ul class="step-list">
-            <li>
-              <div>
-                <strong>No anomaly events emitted despite visible spikes in source data</strong>
-                <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                  The most common cause is a <code>min_duration</code> that exceeds the actual spike duration
-                  in the data. Reduce <code>min_duration</code> (e.g. from <code>5m</code> to <code>30s</code>)
-                  and re-run. Also verify the rolling window is not wider than the total observation range,
-                  which leaves too few rows to compute a meaningful baseline.
-                </p>
-                <pre><code># Inspect the rolling baseline for a specific series and partition
+            <ul class="step-list">
+              <li>
+                <div>
+                  <strong>ソースデータに明確なスパイクがあるにもかかわらず異常イベントが出力されない</strong>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
+                    最も一般的な原因は、<code>min_duration</code> がデータ内の実際のスパイク持続時間を超えていることです。
+                    <code>min_duration</code> を短くして（例: <code>5m</code> → <code>30s</code>）再実行してください。
+                    また、ローリングウィンドウが観測範囲全体より広い場合は、意味のあるベースライン計算に十分な行数が残りません。
+                  </p>
+                  <pre><code># 特定シリーズとパーティションのローリングベースラインを確認
 forge debug baseline \
   --strategy resource_spike_detector \
   --series cpu_pct \
   --partition web-01 \
   --output ./debug/</code></pre>
-              </div>
-            </li>
-            <li>
-              <div>
-                <strong>Ingest fails with <code>ParseError: invalid timestamp</code></strong>
-                <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                  AlphaForge expects ISO-8601 UTC timestamps (e.g. <code>2026-01-15T08:00:00Z</code>) or
-                  Unix epoch in milliseconds. If your source uses a different format, convert it before
-                  ingesting:
-                </p>
-                <pre><code># Convert epoch-seconds to ISO-8601 using jq
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong><code>ParseError: invalid timestamp</code> で取り込みが失敗する</strong>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
+                    AlphaForge はISO-8601 UTCタイムスタンプ（例: <code>2026-01-15T08:00:00Z</code>）または
+                    Unixエポック（ミリ秒）を期待します。ソースが異なるフォーマットを使用している場合は、取り込む前に変換してください。
+                  </p>
+                  <pre><code># jq を使ってエポック秒をISO-8601に変換
 jq 'del(.ts) | .ts = (.epoch_s | todate)' raw.jsonl &gt; telemetry.jsonl</code></pre>
-              </div>
-            </li>
-            <li>
-              <div>
-                <strong>High memory consumption with large JSONL files</strong>
-                <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                  Convert your input to Parquet before ingesting. Parquet is columnar and
-                  supports predicate pushdown, which substantially reduces the memory footprint
-                  for wide schemas:
-                </p>
-                <pre><code># Convert JSONL to Parquet using DuckDB (no install required via uv)
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>大きなJSONLファイルでメモリ消費が多い</strong>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
+                    取り込む前にParquetに変換してください。Parquetはカラム型でプレディケートプッシュダウンをサポートしており、
+                    広いスキーマのメモリフットプリントを大幅に削減します。
+                  </p>
+                  <pre><code># DuckDB を使ってJSONLをParquetに変換（uv経由でインストール不要）
 uvx duckdb -c "
   COPY (SELECT * FROM read_json_auto('telemetry.jsonl'))
   TO 'telemetry.parquet' (FORMAT PARQUET);
@@ -689,46 +687,665 @@ forge ingest telemetry.parquet \
   --format parquet \
   --partition-field host \
   --series cpu_pct mem_pct net_latency_ms</code></pre>
-              </div>
-            </li>
-            <li>
-              <div>
-                <strong>Simulation is slow on large datasets</strong>
-                <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                  Increase <code>--workers</code> to match available CPU cores. Each partition is processed
-                  independently, so parallelism scales linearly up to the partition count:
-                </p>
-                <pre><code>forge run \
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>大規模データセットでシミュレーションが遅い</strong>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
+                    <code>--workers</code> を利用可能なCPUコア数に合わせて増やしてください。各パーティションは独立して処理されるため、
+                    並列性はパーティション数まで線形にスケールします。
+                  </p>
+                  <pre><code>forge run \
+  --strategy resource_spike_detector \
+  --workers $(nproc) \    # Linux
+  --output ./output/
+
+# macOS の場合
+forge run --strategy resource_spike_detector --workers $(sysctl -n hw.logicalcpu)</code></pre>
+                </div>
+              </li>
+            </ul>
+
+            <div class="callout">
+              <code>forge run --log-level debug</code> を実行して行ごとの評価トレースを出力します。
+              ファイルにリダイレクト（<code>2&gt; debug.log</code>）することで、ターミナルを汚さずに
+              完全な評価タイムラインを確認できます。
+            </div>
+          </section>
+
+        </div><!-- /メインコンテンツ -->
+      </div><!-- /doc-layout -->
+    </div><!-- /lang-ja -->
+
+    <!-- ══════════════════════════════════════════════════════════ EN ══ -->
+    <div class="lang-content lang-en">
+
+      <div class="page-label">Tutorial</div>
+      <h1 class="page-title">Simulating Server Telemetry<br>and Anomaly Detection</h1>
+      <p class="page-subtitle">
+        A practical walkthrough for DevOps and Data Engineering teams. Ingest raw system-resource
+        logs into AlphaForge, define a spike-detection descriptor, and run a fully local simulation
+        — no external services or network connectivity required.
+      </p>
+
+      <div class="doc-layout" style="margin-top: 2.5rem;">
+
+        <!-- ── Sidebar nav ── -->
+        <nav class="cmd-nav">
+          <ul class="cmd-nav-list">
+            <li class="nav-group">Overview</li>
+            <li><a href="#prerequisites">Prerequisites</a></li>
+            <li><a href="#architecture">Architecture</a></li>
+            <li class="nav-group">Walkthrough</li>
+            <li><a href="#step-ingest">Step 1 — Ingest</a></li>
+            <li><a href="#step-descriptor">Step 2 — Descriptor</a></li>
+            <li><a href="#step-dry-run">Step 3 — Dry Run</a></li>
+            <li><a href="#step-simulate">Step 4 — Simulate</a></li>
+            <li><a href="#step-inspect">Step 5 — Inspect</a></li>
+            <li class="nav-group">Reference</li>
+            <li><a href="#cli-reference">CLI Options</a></li>
+            <li><a href="#schema-reference">Schema Reference</a></li>
+            <li><a href="#troubleshooting">Troubleshooting</a></li>
+          </ul>
+        </nav>
+
+        <!-- ── Main content ── -->
+        <div>
+
+          <!-- Prerequisites -->
+          <section class="cmd-section" id="prerequisites">
+            <div class="section-category">Overview</div>
+            <h2 class="section-heading">Prerequisites</h2>
+            <p>Before starting, confirm the following are in place:</p>
+
+            <table class="option-table" style="margin-top: 1rem;">
+              <thead><tr><th>Requirement</th><th>Notes</th></tr></thead>
+              <tbody>
+                <tr><td><code>forge</code> CLI ≥ 0.9.0</td><td>Run <code>forge --version</code> to verify. See <a href="/install.html">Install</a> for setup.</td></tr>
+                <tr><td>Python 3.10+ <em>or</em> Docker</td><td>The simulation engine runs in a local process; no cloud dependency.</td></tr>
+                <tr><td>Telemetry JSONL file</td><td>One JSON object per line. Fields: <code>ts</code>, <code>host</code>, and one or more numeric series. See <a href="#step-ingest">Step 1</a> for the schema.</td></tr>
+                <tr><td>≥ 500 MB free disk</td><td>Simulation output and intermediate state are written to <code>./output/</code> by default.</td></tr>
+              </tbody>
+            </table>
+
+            <div class="callout">
+              All processing in this tutorial runs <strong>locally on your workstation</strong>. No telemetry data
+              leaves the host. AlphaForge does not phone home during simulation execution.
+            </div>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- Architecture -->
+          <section class="cmd-section" id="architecture">
+            <div class="section-category">Overview</div>
+            <h2 class="section-heading">Architecture</h2>
+            <p>
+              AlphaForge operates as a <strong>three-stage pipeline</strong>: ingestion, descriptor evaluation,
+              and result emission. Each stage is independently configurable and testable.
+            </p>
+
+            <pre><code>┌─────────────────────────────────────────────────────────────────┐
+│                     AlphaForge Pipeline                         │
+│                                                                 │
+│  ┌──────────────┐   ┌──────────────────┐   ┌────────────────┐  │
+│  │  forge ingest│──▶│  forge run       │──▶│  forge         │  │
+│  │              │   │  (descriptor     │   │  dashboard     │  │
+│  │ JSONL / CSV  │   │   evaluation)    │   │  (result view) │  │
+│  │ Parquet      │   │                  │   │                │  │
+│  └──────────────┘   └──────────────────┘   └────────────────┘  │
+│         │                    │                      │           │
+│    ./data/series/       ./output/runs/         ./output/        │
+│    (normalised store)   (per-run state)        anomalies.jsonl  │
+└─────────────────────────────────────────────────────────────────┘</code></pre>
+
+            <p style="margin-top: 1rem; font-size: 0.9rem; color: var(--text2);">
+              The <strong>descriptor</strong> (<code>.yaml</code>) defines which series to watch, the
+              baseline computation method, and the threshold conditions that constitute an anomaly. The
+              descriptor does not contain execution logic; AlphaForge interprets it at simulation time.
+            </p>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- Step 1: Ingest -->
+          <section class="cmd-section" id="step-ingest">
+            <div class="section-category">Step 1 of 5</div>
+            <h2 class="section-heading">Ingest Telemetry Data</h2>
+            <p>
+              Use <code>forge ingest</code> to load your raw JSONL log file into AlphaForge's normalised
+              time-series store. The command validates the timestamp field, casts numeric columns, and
+              partitions the data by host identifier.
+            </p>
+
+            <h3 class="sub-heading">Sample input file — <code>telemetry.jsonl</code></h3>
+            <pre><code>{"ts":"2026-01-15T08:00:00Z","host":"web-01","cpu_pct":12.4,"mem_pct":45.1,"net_latency_ms":5.2}
+{"ts":"2026-01-15T08:01:00Z","host":"web-01","cpu_pct":89.7,"mem_pct":71.3,"net_latency_ms":420.8}
+{"ts":"2026-01-15T08:02:00Z","host":"web-01","cpu_pct":91.2,"mem_pct":73.0,"net_latency_ms":510.3}
+{"ts":"2026-01-15T08:03:00Z","host":"web-01","cpu_pct":14.1,"mem_pct":47.8,"net_latency_ms":6.1}
+{"ts":"2026-01-15T08:00:00Z","host":"db-01", "cpu_pct": 8.3,"mem_pct":82.5,"net_latency_ms":2.9}
+{"ts":"2026-01-15T08:01:00Z","host":"db-01", "cpu_pct": 9.1,"mem_pct":83.2,"net_latency_ms":3.4}</code></pre>
+
+            <h3 class="sub-heading">Command</h3>
+            <pre><code>forge ingest telemetry.jsonl \
+  --format jsonl \
+  --timestamp-field ts \
+  --partition-field host \
+  --series cpu_pct mem_pct net_latency_ms</code></pre>
+
+            <h3 class="sub-heading">Expected output</h3>
+            <pre><code>✔  Parsed     6 records across 2 partitions (web-01, db-01)
+✔  Validated  timestamp field: ts  →  UTC ISO-8601
+✔  Cast       cpu_pct       float64
+✔  Cast       mem_pct       float64
+✔  Cast       net_latency_ms float64
+✔  Stored     ./data/series/web-01.parquet  (4 rows)
+✔  Stored     ./data/series/db-01.parquet   (2 rows)
+   Ingest complete in 0.18 s</code></pre>
+
+            <div class="callout">
+              Supported input formats: <code>--format jsonl</code> (default), <code>csv</code>, <code>parquet</code>.
+              For CSV files, use <code>--delimiter ","</code> or <code>";"</code> as needed.
+              Parquet inputs skip the casting step entirely.
+            </div>
+
+            <h3 class="sub-heading">Verify the loaded series</h3>
+            <pre><code>forge data list
+
+# Output:
+# PARTITION   ROWS   FROM                  TO                    SERIES
+# web-01      4      2026-01-15T08:00:00Z  2026-01-15T08:03:00Z  cpu_pct, mem_pct, net_latency_ms
+# db-01       2      2026-01-15T08:00:00Z  2026-01-15T08:01:00Z  cpu_pct, mem_pct, net_latency_ms</code></pre>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- Step 2: Descriptor -->
+          <section class="cmd-section" id="step-descriptor">
+            <div class="section-category">Step 2 of 5</div>
+            <h2 class="section-heading">Write the Descriptor</h2>
+            <p>
+              A <strong>descriptor</strong> is a declarative YAML file that tells AlphaForge which series to
+              monitor, how to compute a rolling baseline, and what threshold conditions trigger an anomaly event.
+              No scripting or compiled code is required.
+            </p>
+
+            <h3 class="sub-heading">Create the descriptor file</h3>
+            <pre><code>forge strategy create \
+  --template anomaly_detector \
+  --id resource_spike_detector \
+  --out descriptors/resource_spike_detector.yaml</code></pre>
+
+            <p style="margin-top: 0.8rem;">
+              Open the generated file and configure it as follows. Every field is documented inline.
+            </p>
+
+            <h3 class="sub-heading"><code>descriptors/resource_spike_detector.yaml</code></h3>
+            <pre><code># AlphaForge Descriptor — Server Resource Spike Detector
+# Version schema: https://alforge-labs.github.io/schema/descriptor/v1
+id: resource_spike_detector
+version: "1.0.0"
+description: >
+  Detects sustained CPU, memory, and network-latency spikes in per-host
+  server telemetry. Emits a structured anomaly event whenever a series
+  exceeds its rolling baseline by the configured sigma multiplier for at
+  least the specified minimum duration.
+
+# ── Input ────────────────────────────────────────────────────────────────
+input:
+  partition_field: host          # Group observations by this field
+  timestamp_field: ts
+
+# ── Series Definitions ───────────────────────────────────────────────────
+series:
+  - name: cpu_pct
+    unit: percent                # Informational; not used in computation
+    window: 10m                  # Rolling window for baseline computation
+    baseline: rolling_mean       # Options: rolling_mean | rolling_median | rolling_percentile
+
+  - name: mem_pct
+    unit: percent
+    window: 10m
+    baseline: rolling_mean
+
+  - name: net_latency_ms
+    unit: milliseconds
+    window: 5m
+    baseline: rolling_percentile
+    percentile: 95               # Required when baseline: rolling_percentile
+
+# ── Anomaly Thresholds ───────────────────────────────────────────────────
+thresholds:
+  cpu_pct:
+    sigma: 3.0                   # Standard deviations above baseline
+    min_duration: 2m             # Must persist this long to emit an event
+
+  mem_pct:
+    sigma: 2.5
+    min_duration: 5m
+
+  net_latency_ms:
+    sigma: 4.0
+    min_duration: 30s
+
+# ── Output ───────────────────────────────────────────────────────────────
+output:
+  format: jsonl                  # Options: jsonl | csv | parquet
+  path: ./output/anomalies.jsonl
+  include_context_window: true   # Append pre/post-event observations to each record
+  context_window: 5m             # Lookback/lookahead duration</code></pre>
+
+            <h3 class="sub-heading">Register the descriptor</h3>
+            <pre><code>forge strategy save descriptors/resource_spike_detector.yaml
+
+# Output:
+# ✔  Registered  resource_spike_detector  (v1.0.0)</code></pre>
+
+            <div class="callout">
+              Baseline options at a glance:
+              <br><code>rolling_mean</code> — arithmetic mean of the window; sensitive to isolated spikes.
+              <br><code>rolling_median</code> — robust to outliers; slower to reflect sustained shifts.
+              <br><code>rolling_percentile</code> — use for long-tail distributions (e.g. latency).
+            </div>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- Step 3: Dry Run -->
+          <section class="cmd-section" id="step-dry-run">
+            <div class="section-category">Step 3 of 5</div>
+            <h2 class="section-heading">Validate with a Dry Run</h2>
+            <p>
+              Before executing a full simulation, use <code>--dry-run</code> to verify descriptor syntax,
+              confirm series resolution, and preview threshold parameters — without writing any output files.
+            </p>
+
+            <pre><code>forge run \
+  --strategy resource_spike_detector \
+  --dry-run</code></pre>
+
+            <h3 class="sub-heading">Expected dry-run output</h3>
+            <pre><code>AlphaForge  v0.9.4   dry-run mode
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Descriptor      resource_spike_detector  v1.0.0
+Partitions      web-01, db-01
+Series          cpu_pct, mem_pct, net_latency_ms
+
+Thresholds
+  cpu_pct        sigma=3.0   min_duration=120s
+  mem_pct        sigma=2.5   min_duration=300s
+  net_latency_ms sigma=4.0   min_duration=30s
+
+Estimated rows  6
+Estimated time  &lt; 1s
+
+✔  Descriptor is valid. No output written (dry-run).
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</code></pre>
+
+            <div class="callout warn">
+              If you see <code>ERROR: series 'cpu_pct' not found in partition 'db-01'</code>, the ingest
+              step did not include that series for that partition. Re-run <code>forge ingest</code> with all
+              required series listed under <code>--series</code>.
+            </div>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- Step 4: Simulate -->
+          <section class="cmd-section" id="step-simulate">
+            <div class="section-category">Step 4 of 5</div>
+            <h2 class="section-heading">Run the Simulation</h2>
+            <p>
+              Execute the full simulation across the ingested time range. AlphaForge iterates over each
+              partition, computes rolling baselines, evaluates thresholds at every observation, and emits
+              anomaly events to the configured output path.
+            </p>
+
+            <pre><code>forge run \
+  --strategy resource_spike_detector \
+  --data ./data/series/ \
+  --from 2026-01-15T00:00:00Z \
+  --to   2026-01-15T23:59:59Z \
+  --output ./output/ \
+  --workers 4</code></pre>
+
+            <h3 class="sub-heading">Progress output</h3>
+            <pre><code>AlphaForge  v0.9.4
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Run ID          2026-01-15-001
+Descriptor      resource_spike_detector  v1.0.0
+Range           2026-01-15T00:00:00Z → 2026-01-15T23:59:59Z
+Partitions      2  (web-01, db-01)
+Workers         4
+
+  [web-01]  ████████████████████  100%   4 rows   0.04s
+  [db-01]   ████████████████████  100%   2 rows   0.02s
+
+Anomaly events  2
+  cpu_pct        1 event  (web-01)
+  net_latency_ms 1 event  (web-01)
+  mem_pct        0 events
+
+Output          ./output/anomalies.jsonl
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Simulation complete in 0.31 s</code></pre>
+
+            <div class="callout">
+              <code>--workers</code> controls the number of parallel partition processors. For large datasets
+              (millions of rows), set this to the number of available CPU cores.
+              The default is <code>1</code> (sequential) to minimise memory pressure.
+            </div>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- Step 5: Inspect -->
+          <section class="cmd-section" id="step-inspect">
+            <div class="section-category">Step 5 of 5</div>
+            <h2 class="section-heading">Inspect Results</h2>
+            <p>
+              Use <code>forge dashboard</code> to view a summary of detected anomalies, or read the raw
+              JSONL output directly for downstream pipeline integration.
+            </p>
+
+            <h3 class="sub-heading">Open the dashboard</h3>
+            <pre><code>forge dashboard --run-id 2026-01-15-001</code></pre>
+
+            <p style="margin-top: 0.8rem;">
+              The dashboard renders in your default browser at <code>http://127.0.0.1:7890</code>.
+              It is a local-only HTTP server; no data is transmitted externally.
+            </p>
+
+            <h3 class="sub-heading">Raw JSONL output — <code>./output/anomalies.jsonl</code></h3>
+            <pre><code>{
+  "run_id": "2026-01-15-001",
+  "descriptor": "resource_spike_detector",
+  "partition": "web-01",
+  "series": "cpu_pct",
+  "event": "spike_detected",
+  "ts_start": "2026-01-15T08:01:00Z",
+  "ts_end":   "2026-01-15T08:02:00Z",
+  "duration_s": 120,
+  "peak_value": 91.2,
+  "baseline_at_event": 14.2,
+  "sigma_observed": 5.8,
+  "threshold_sigma": 3.0,
+  "context_window": [
+    {"ts":"2026-01-15T08:00:00Z","cpu_pct":12.4},
+    {"ts":"2026-01-15T08:01:00Z","cpu_pct":89.7},
+    {"ts":"2026-01-15T08:02:00Z","cpu_pct":91.2},
+    {"ts":"2026-01-15T08:03:00Z","cpu_pct":14.1}
+  ]
+}
+{
+  "run_id": "2026-01-15-001",
+  "descriptor": "resource_spike_detector",
+  "partition": "web-01",
+  "series": "net_latency_ms",
+  "event": "spike_detected",
+  "ts_start": "2026-01-15T08:01:00Z",
+  "ts_end":   "2026-01-15T08:02:00Z",
+  "duration_s": 60,
+  "peak_value": 510.3,
+  "baseline_at_event": 5.2,
+  "sigma_observed": 6.1,
+  "threshold_sigma": 4.0,
+  "context_window": [
+    {"ts":"2026-01-15T08:00:00Z","net_latency_ms":5.2},
+    {"ts":"2026-01-15T08:01:00Z","net_latency_ms":420.8},
+    {"ts":"2026-01-15T08:02:00Z","net_latency_ms":510.3},
+    {"ts":"2026-01-15T08:03:00Z","net_latency_ms":6.1}
+  ]
+}</code></pre>
+
+            <h3 class="sub-heading">Pipe output into downstream tools</h3>
+            <pre><code># Count events per series
+jq -r '.series' ./output/anomalies.jsonl | sort | uniq -c
+
+# Filter to a single host
+jq 'select(.partition == "web-01")' ./output/anomalies.jsonl
+
+# Extract timestamps and sigma values for alerting pipelines
+jq '{series, ts_start, sigma_observed}' ./output/anomalies.jsonl</code></pre>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- CLI Reference -->
+          <section class="cmd-section" id="cli-reference">
+            <div class="section-category">Reference</div>
+            <h2 class="section-heading">CLI Options — <code>forge run</code></h2>
+
+            <table class="option-table">
+              <thead>
+                <tr><th>Option</th><th>Type</th><th>Default</th><th>Description</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>--strategy &lt;ID&gt;</code></td>
+                  <td>string</td>
+                  <td>—</td>
+                  <td>Registered descriptor ID, or path to a <code>.yaml</code> file.</td>
+                </tr>
+                <tr>
+                  <td><code>--data &lt;PATH&gt;</code></td>
+                  <td>path</td>
+                  <td><code>./data/series/</code></td>
+                  <td>Directory of per-partition Parquet files, or a single JSONL file.</td>
+                </tr>
+                <tr>
+                  <td><code>--from &lt;ISO8601&gt;</code></td>
+                  <td>datetime</td>
+                  <td>earliest record</td>
+                  <td>Simulation start boundary (inclusive). UTC assumed if no timezone suffix.</td>
+                </tr>
+                <tr>
+                  <td><code>--to &lt;ISO8601&gt;</code></td>
+                  <td>datetime</td>
+                  <td>latest record</td>
+                  <td>Simulation end boundary (inclusive).</td>
+                </tr>
+                <tr>
+                  <td><code>--output &lt;PATH&gt;</code></td>
+                  <td>path</td>
+                  <td><code>./output/</code></td>
+                  <td>Directory for run state, anomaly JSONL, and dashboard assets.</td>
+                </tr>
+                <tr>
+                  <td><code>--workers &lt;N&gt;</code></td>
+                  <td>int</td>
+                  <td><code>1</code></td>
+                  <td>Parallel partition processors. Recommend: number of CPU cores.</td>
+                </tr>
+                <tr>
+                  <td><code>--dry-run</code></td>
+                  <td>flag</td>
+                  <td>off</td>
+                  <td>Validate descriptor and resolve series without executing the simulation.</td>
+                </tr>
+                <tr>
+                  <td><code>--log-level &lt;LEVEL&gt;</code></td>
+                  <td>enum</td>
+                  <td><code>info</code></td>
+                  <td>Verbosity: <code>debug</code> | <code>info</code> | <code>warn</code> | <code>error</code>.</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3 class="sub-heading">CLI Options — <code>forge ingest</code></h3>
+            <table class="option-table">
+              <thead>
+                <tr><th>Option</th><th>Type</th><th>Default</th><th>Description</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>--format &lt;FMT&gt;</code></td>
+                  <td>enum</td>
+                  <td><code>jsonl</code></td>
+                  <td>Input format: <code>jsonl</code> | <code>csv</code> | <code>parquet</code>.</td>
+                </tr>
+                <tr>
+                  <td><code>--timestamp-field &lt;F&gt;</code></td>
+                  <td>string</td>
+                  <td><code>ts</code></td>
+                  <td>Name of the timestamp column. Must be ISO-8601 or Unix epoch (ms).</td>
+                </tr>
+                <tr>
+                  <td><code>--partition-field &lt;F&gt;</code></td>
+                  <td>string</td>
+                  <td>—</td>
+                  <td>Column to split data into per-host partitions. Omit for single-host datasets.</td>
+                </tr>
+                <tr>
+                  <td><code>--series &lt;S…&gt;</code></td>
+                  <td>list</td>
+                  <td>all numeric</td>
+                  <td>Whitelist of numeric columns to ingest. Unspecified columns are ignored.</td>
+                </tr>
+                <tr>
+                  <td><code>--delimiter &lt;C&gt;</code></td>
+                  <td>char</td>
+                  <td><code>,</code></td>
+                  <td>Column delimiter for CSV input only.</td>
+                </tr>
+                <tr>
+                  <td><code>--out &lt;PATH&gt;</code></td>
+                  <td>path</td>
+                  <td><code>./data/series/</code></td>
+                  <td>Output directory for normalised Parquet partitions.</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- Schema Reference -->
+          <section class="cmd-section" id="schema-reference">
+            <div class="section-category">Reference</div>
+            <h2 class="section-heading">Descriptor Schema Reference</h2>
+            <p>
+              The descriptor YAML follows a versioned schema. All fields below are supported as of
+              AlphaForge <code>v0.9.x</code>.
+            </p>
+
+            <table class="option-table">
+              <thead>
+                <tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><code>id</code></td><td>string</td><td>Yes</td><td>Unique descriptor identifier. Alphanumeric and underscores only.</td></tr>
+                <tr><td><code>version</code></td><td>semver</td><td>Yes</td><td>Descriptor version string (e.g. <code>"1.0.0"</code>).</td></tr>
+                <tr><td><code>description</code></td><td>string</td><td>No</td><td>Human-readable summary. Appears in <code>forge strategy list</code> output.</td></tr>
+                <tr><td><code>input.partition_field</code></td><td>string</td><td>No</td><td>Column used to split observations into named partitions.</td></tr>
+                <tr><td><code>input.timestamp_field</code></td><td>string</td><td>Yes</td><td>Column containing observation timestamps.</td></tr>
+                <tr><td><code>series[].name</code></td><td>string</td><td>Yes</td><td>Column name in the ingested dataset.</td></tr>
+                <tr><td><code>series[].window</code></td><td>duration</td><td>Yes</td><td>Rolling window for baseline computation. Format: <code>Ns</code>, <code>Nm</code>, <code>Nh</code>.</td></tr>
+                <tr><td><code>series[].baseline</code></td><td>enum</td><td>Yes</td><td><code>rolling_mean</code> | <code>rolling_median</code> | <code>rolling_percentile</code>.</td></tr>
+                <tr><td><code>series[].percentile</code></td><td>float</td><td>Conditional</td><td>Required when <code>baseline: rolling_percentile</code>. Range: 0–100.</td></tr>
+                <tr><td><code>thresholds.&lt;series&gt;.sigma</code></td><td>float</td><td>Yes</td><td>Standard-deviation multiplier above baseline to trigger an event.</td></tr>
+                <tr><td><code>thresholds.&lt;series&gt;.min_duration</code></td><td>duration</td><td>Yes</td><td>Minimum continuous exceedance duration before an event is emitted.</td></tr>
+                <tr><td><code>output.format</code></td><td>enum</td><td>No</td><td>Result format: <code>jsonl</code> (default) | <code>csv</code> | <code>parquet</code>.</td></tr>
+                <tr><td><code>output.path</code></td><td>path</td><td>No</td><td>Output file path. Overrides <code>--output</code> CLI flag if set.</td></tr>
+                <tr><td><code>output.include_context_window</code></td><td>bool</td><td>No</td><td>Append surrounding observations to each anomaly record.</td></tr>
+                <tr><td><code>output.context_window</code></td><td>duration</td><td>No</td><td>Lookback and lookahead range for context records. Default: <code>5m</code>.</td></tr>
+              </tbody>
+            </table>
+          </section>
+
+          <hr class="section-divider" />
+
+          <!-- Troubleshooting -->
+          <section class="cmd-section" id="troubleshooting">
+            <div class="section-category">Reference</div>
+            <h2 class="section-heading">Troubleshooting</h2>
+
+            <ul class="step-list">
+              <li>
+                <div>
+                  <strong>No anomaly events emitted despite visible spikes in source data</strong>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
+                    The most common cause is a <code>min_duration</code> that exceeds the actual spike duration
+                    in the data. Reduce <code>min_duration</code> (e.g. from <code>5m</code> to <code>30s</code>)
+                    and re-run. Also verify the rolling window is not wider than the total observation range,
+                    which leaves too few rows to compute a meaningful baseline.
+                  </p>
+                  <pre><code># Inspect the rolling baseline for a specific series and partition
+forge debug baseline \
+  --strategy resource_spike_detector \
+  --series cpu_pct \
+  --partition web-01 \
+  --output ./debug/</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>Ingest fails with <code>ParseError: invalid timestamp</code></strong>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
+                    AlphaForge expects ISO-8601 UTC timestamps (e.g. <code>2026-01-15T08:00:00Z</code>) or
+                    Unix epoch in milliseconds. If your source uses a different format, convert it before
+                    ingesting:
+                  </p>
+                  <pre><code># Convert epoch-seconds to ISO-8601 using jq
+jq 'del(.ts) | .ts = (.epoch_s | todate)' raw.jsonl &gt; telemetry.jsonl</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>High memory consumption with large JSONL files</strong>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
+                    Convert your input to Parquet before ingesting. Parquet is columnar and
+                    supports predicate pushdown, which substantially reduces the memory footprint
+                    for wide schemas:
+                  </p>
+                  <pre><code># Convert JSONL to Parquet using DuckDB (no install required via uv)
+uvx duckdb -c "
+  COPY (SELECT * FROM read_json_auto('telemetry.jsonl'))
+  TO 'telemetry.parquet' (FORMAT PARQUET);
+"
+
+forge ingest telemetry.parquet \
+  --format parquet \
+  --partition-field host \
+  --series cpu_pct mem_pct net_latency_ms</code></pre>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <strong>Simulation is slow on large datasets</strong>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
+                    Increase <code>--workers</code> to match available CPU cores. Each partition is processed
+                    independently, so parallelism scales linearly up to the partition count:
+                  </p>
+                  <pre><code>forge run \
   --strategy resource_spike_detector \
   --workers $(nproc) \    # Linux
   --output ./output/
 
 # macOS equivalent
 forge run --strategy resource_spike_detector --workers $(sysctl -n hw.logicalcpu)</code></pre>
-              </div>
-            </li>
-          </ul>
+                </div>
+              </li>
+            </ul>
 
-          <div class="callout">
-            Run <code>forge run --log-level debug</code> to emit per-row evaluation traces.
-            Redirect to a file (<code>2&gt; debug.log</code>) to inspect the full evaluation
-            timeline without cluttering your terminal.
-          </div>
-        </section>
+            <div class="callout">
+              Run <code>forge run --log-level debug</code> to emit per-row evaluation traces.
+              Redirect to a file (<code>2&gt; debug.log</code>) to inspect the full evaluation
+              timeline without cluttering your terminal.
+            </div>
+          </section>
 
-      </div><!-- /main content -->
-    </div><!-- /doc-layout -->
+        </div><!-- /main content -->
+      </div><!-- /doc-layout -->
+    </div><!-- /lang-en -->
+
   </div><!-- /page-wrap -->
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="footer-links">
-      <a href="/">Home</a>
-      <a href="install.html">Install</a>
-      <a href="docs.html">Docs</a>
-      <a href="terms.html">Terms</a>
-      <a href="privacy.html">Privacy</a>
-    </div>
+    <div class="lang-content lang-ja"><div class="footer-links"><a href="/">ホーム</a><a href="install.html">インストール</a><a href="docs.html">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a></div></div>
+    <div class="lang-content lang-en"><div class="footer-links"><a href="/">Home</a><a href="install.html">Install</a><a href="docs.html">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a></div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
@@ -736,7 +1353,7 @@ forge run --strategy resource_spike_detector --workers $(sysctl -n hw.logicalcpu
   <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
   <script type="text/babel" src="site-header.jsx"></script>
   <script type="text/babel">
-    renderStandaloneHeader({ active: 'docs' });
+    renderStandaloneHeader({ active: 'tutorial' });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- `tutorial-telemetry.html` を `lang-content lang-ja` / `lang-content lang-en` パターンでバイリンガル化
- 日本語版コンテンツを全セクション追加（前提条件・アーキテクチャ・Step 1〜5・CLIリファレンス・スキーマ・トラブルシューティング）
- コードブロック・YAML・JSONLサンプル・ASCIIアートは共通（両言語で同一）
- 初期化スクリプトを `al_lang` localStorage 対応に変更（他ページと統一）
- フッターリンクをバイリンガル化
- `renderStandaloneHeader({ active: 'tutorial' })` に修正（前 PR で追加したヘッダーリンクと対応）

## Test plan

- [ ] ヘッダーの言語切替で JA/EN が正しく切り替わることを確認
- [ ] 日本語版の全セクションが表示されることを確認
- [ ] サイドナビのリンクがスクロール先セクションに正しくジャンプすることを確認
- [ ] ヘッダーナビの「チュートリアル」が active スタイルで表示されることを確認