### PR TITLE
feat: 決済プロバイダーを LemonSqueezy から Polar に移行

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -299,7 +299,7 @@ forge dashboard --port 8501 --no-open</code></pre>
           <section class="cmd-section" id="ja-license" style="margin-top:2rem;">
             <div class="section-category">ライセンス</div>
             <h2 class="section-heading">forge license</h2>
-            <p>LemonSqueezy のライセンスキーを認証します。認証情報は <code>~/.forge/license.json</code> にキャッシュされます。</p>
+            <p>Polar のライセンスキーを認証します。認証情報は <code>~/.forge/license.json</code> にキャッシュされます。</p>
 
             <table class="option-table">
               <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
@@ -573,7 +573,7 @@ forge dashboard --port 8501 --no-open</code></pre>
           <section class="cmd-section" id="en-license" style="margin-top:2rem;">
             <div class="section-category">License</div>
             <h2 class="section-heading">forge license</h2>
-            <p>Activate and manage your LemonSqueezy license. Activation data is cached in <code>~/.forge/license.json</code>.</p>
+            <p>Activate and manage your Polar license. Activation data is cached in <code>~/.forge/license.json</code>.</p>
 
             <table class="option-table">
               <thead><tr><th>Command</th><th>Description</th></tr></thead>

--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -42,7 +42,7 @@ window.COPY = {
             '将来バージョンのアップデート込み',
             '1台のマシンでアクティベート',
           ],
-          url: 'https://alforge-labs.lemonsqueezy.com',
+          url: 'https://polar.sh/alforge-labs',
         },
         {
           name: 'Annual',
@@ -59,7 +59,7 @@ window.COPY = {
             '常に最新バージョン',
             '1台のマシンでアクティベート',
           ],
-          url: 'https://alforge-labs.lemonsqueezy.com',
+          url: 'https://polar.sh/alforge-labs',
         },
         {
           name: 'Monthly',
@@ -76,7 +76,7 @@ window.COPY = {
             '常に最新バージョン',
             '1台のマシンでアクティベート',
           ],
-          url: 'https://alforge-labs.lemonsqueezy.com',
+          url: 'https://polar.sh/alforge-labs',
         },
       ],
       buyNow: '今すぐ購入',
@@ -291,7 +291,7 @@ window.COPY = {
             'Future version updates included',
             'Activate on 1 machine',
           ],
-          url: 'https://alforge-labs.lemonsqueezy.com',
+          url: 'https://polar.sh/alforge-labs',
         },
         {
           name: 'Annual',
@@ -308,7 +308,7 @@ window.COPY = {
             'Always latest version',
             'Activate on 1 machine',
           ],
-          url: 'https://alforge-labs.lemonsqueezy.com',
+          url: 'https://polar.sh/alforge-labs',
         },
         {
           name: 'Monthly',
@@ -325,7 +325,7 @@ window.COPY = {
             'Always latest version',
             'Activate on 1 machine',
           ],
-          url: 'https://alforge-labs.lemonsqueezy.com',
+          url: 'https://polar.sh/alforge-labs',
         },
       ],
       buyNow: 'Get Access',

--- a/privacy.html
+++ b/privacy.html
@@ -35,10 +35,10 @@
 
       <h2 class="section-heading">1. 収集する情報</h2>
       <h3 class="sub-heading">1.1 購入時に収集する情報</h3>
-      <p>LemonSqueezy を通じたライセンス購入時に、氏名または会社名、メールアドレス、決済情報、国・地域情報が収集されます。決済情報は LemonSqueezy が処理し、当社は保持しません。</p>
+      <p>Polar を通じたライセンス購入時に、氏名または会社名、メールアドレス、決済情報、国・地域情報が収集されます。決済情報は Polar が処理し、当社は保持しません。</p>
 
       <h3 class="sub-heading">1.2 ライセンス認証時に収集する情報</h3>
-      <p><code>forge license activate</code> 実行時に、ライセンスキー、インスタンス名、アクティベーション日時が LemonSqueezy の License API に送信されます。</p>
+      <p><code>forge license activate</code> 実行時に、ライセンスキー、インスタンス名、アクティベーション日時が Polar の License API に送信されます。</p>
 
       <h3 class="sub-heading">1.3 収集しない情報</h3>
       <div class="callout">
@@ -55,11 +55,11 @@
       </ul>
 
       <h2 class="section-heading">3. 第三者への情報提供</h2>
-      <p>当社は、決済処理・ライセンス管理のために LemonSqueezy と必要な情報を共有する場合、および法令上の要請がある場合を除き、個人情報を第三者に提供しません。マーケティング目的でのデータ販売・共有は行いません。</p>
+      <p>当社は、決済処理・ライセンス管理のために Polar と必要な情報を共有する場合、および法令上の要請がある場合を除き、個人情報を第三者に提供しません。マーケティング目的でのデータ販売・共有は行いません。</p>
 
       <h2 class="section-heading">4. データの保存期間</h2>
       <ul>
-        <li>購入情報・ライセンス情報: LemonSqueezy のデータ保持ポリシーに準拠</li>
+        <li>購入情報・ライセンス情報: Polar のデータ保持ポリシーに準拠</li>
         <li>サポートメール: 対応完了後2年間</li>
         <li>ローカル認証キャッシュ: ユーザーが削除するまで、または <code>forge license deactivate</code> 実行まで保持</li>
       </ul>
@@ -81,10 +81,10 @@
 
       <h2 class="section-heading">1. Information We Collect</h2>
       <h3 class="sub-heading">1.1 Purchase Information</h3>
-      <p>When you purchase a license through LemonSqueezy, information such as your name or company name, email address, payment details, and country or region may be collected. Payment details are processed by LemonSqueezy and are not stored by Alforge Labs.</p>
+      <p>When you purchase a license through Polar, information such as your name or company name, email address, payment details, and country or region may be collected. Payment details are processed by Polar and are not stored by Alforge Labs.</p>
 
       <h3 class="sub-heading">1.2 License Activation Information</h3>
-      <p>When you run <code>forge license activate</code>, the license key, instance name, and activation timestamp are sent to the LemonSqueezy License API.</p>
+      <p>When you run <code>forge license activate</code>, the license key, instance name, and activation timestamp are sent to the Polar License API.</p>
 
       <h3 class="sub-heading">1.3 Information We Do Not Collect</h3>
       <div class="callout">
@@ -101,11 +101,11 @@
       </ul>
 
       <h2 class="section-heading">3. Third-Party Sharing</h2>
-      <p>We do not share personal information with third parties except when necessary for payment processing and license management through LemonSqueezy, or when required by law. We do not sell or share data for marketing purposes.</p>
+      <p>We do not share personal information with third parties except when necessary for payment processing and license management through Polar, or when required by law. We do not sell or share data for marketing purposes.</p>
 
       <h2 class="section-heading">4. Data Retention</h2>
       <ul>
-        <li>Purchase and license information: retained according to LemonSqueezy's data retention policy</li>
+        <li>Purchase and license information: retained according to Polar's data retention policy</li>
         <li>Support email: retained for two years after the support request is resolved</li>
         <li>Local authentication cache: retained until the user removes it or runs <code>forge license deactivate</code></li>
       </ul>


### PR DESCRIPTION
## Summary

- `homepage-copy.jsx`: 購入URL を `https://alforge-labs.lemonsqueezy.com` → `https://polar.sh/alforge-labs` に変更（6箇所）
- `privacy.html`: 「LemonSqueezy」→「Polar」に変更（JA/EN 各4箇所、計8箇所）
- `docs.html`: `forge license` セクションの説明文を Polar に変更（JA/EN 各1箇所）

## Test plan

- [ ] 料金ページの購入ボタンリンクが `polar.sh/alforge-labs` を向いていることを確認
- [ ] プライバシーポリシー（JA/EN）に「LemonSqueezy」が残っていないことを確認
- [ ] ドキュメントの `forge license` セクションに「LemonSqueezy」が残っていないことを確認