### PR TITLE
feat: install.sh / install.ps1 を書き直し — ワンライナーインストーラー完全版

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -4,75 +4,164 @@
     AlphaForge forge の Windows インストーラー
 
 .DESCRIPTION
-    GitHub Releases から最新の forge.exe をダウンロードし、
-    %USERPROFILE%\bin\forge.exe へ配置します。
-    PATH が未設定の場合は追加方法を案内します。
+    GitHub Releases から最新の forge を取得し、$HOME\bin\forge.exe へ配置します。
+    -DryRun スイッチで実際の変更なしに動作を確認できます。
 
 .EXAMPLE
     irm https://alforge-labs.github.io/install.ps1 | iex
+
+.EXAMPLE
+    & ([scriptblock]::Create((irm https://alforge-labs.github.io/install.ps1))) -DryRun
 #>
+param(
+    [switch]$DryRun
+)
 
 $ErrorActionPreference = "Stop"
 
-$REPO       = "alforge-labs/alforge-labs.github.io"
-$ARTIFACT   = "forge-windows-x86_64.exe"
-$INSTALL_DIR = Join-Path $env:USERPROFILE "bin"
+$REPO         = "alforge-labs/alforge-labs.github.io"
+$ARTIFACT     = "forge-windows-x64"
+$EXT          = "zip"
+$INSTALL_DIR  = Join-Path $env:USERPROFILE "bin"
 $INSTALL_PATH = Join-Path $INSTALL_DIR "forge.exe"
 
-# 最新バージョンを取得
-Write-Host "最新バージョンを確認中..."
+function Write-Ok   { param($msg) Write-Host "  ✓ $msg" -ForegroundColor Green }
+function Write-Info { param($msg) Write-Host "  → $msg" }
+function Write-Warn { param($msg) Write-Host "  ⚠ $msg" -ForegroundColor Yellow }
+function Write-Fail { param($msg) Write-Host "  ✗ $msg" -ForegroundColor Red; exit 1 }
+
+if ($DryRun) { Write-Host "[dry-run] 実際のインストールは行いません。" -ForegroundColor Cyan }
+
+# ── 1. 最新バージョンを取得 ─────────────────────────────────────
+Write-Info "最新バージョンを確認中..."
 try {
     $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest" -UseBasicParsing
     $VERSION = $release.tag_name
 } catch {
-    Write-Error "リリースバージョンの取得に失敗しました: $_"
-    exit 1
+    Write-Fail "バージョン取得に失敗しました: $_"
+}
+if (-not $VERSION) { Write-Fail "バージョン情報を取得できませんでした。" }
+
+Write-Ok "最新バージョン: $VERSION"
+
+# 既存バイナリのバージョン確認
+if (Get-Command forge -ErrorAction SilentlyContinue) {
+    $currentVer = & forge --version 2>$null | Select-Object -First 1
+    if ($currentVer) { Write-Info "現在: $currentVer → $VERSION に更新します" }
 }
 
-if (-not $VERSION) {
-    Write-Error "バージョン情報を取得できませんでした。"
-    exit 1
+$DOWNLOAD_URL = "https://github.com/$REPO/releases/download/$VERSION/${ARTIFACT}.${EXT}"
+
+# ── 2. ダウンロード & 展開 ─────────────────────────────────────
+$TMP_DIR = Join-Path $env:TEMP "forge-install-$(Get-Random)"
+$TMP_ZIP = Join-Path $TMP_DIR "${ARTIFACT}.${EXT}"
+
+if (-not $DryRun) {
+    New-Item -ItemType Directory -Path $TMP_DIR | Out-Null
+    try {
+        Write-Info "ダウンロード中: $DOWNLOAD_URL"
+        Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_ZIP -UseBasicParsing
+    } catch {
+        Write-Fail "ダウンロードに失敗しました: $_`n  $DOWNLOAD_URL"
+    }
+    try {
+        Expand-Archive -Path $TMP_ZIP -DestinationPath $TMP_DIR -Force
+    } catch {
+        # .NET フォールバック
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($TMP_ZIP, $TMP_DIR)
+    }
+    $BINARY = Join-Path $TMP_DIR "forge.dist\forge.exe"
+    if (-not (Test-Path $BINARY)) { Write-Fail "展開後にバイナリが見つかりません" }
+    Write-Ok "ダウンロード・展開完了"
+} else {
+    Write-Host "  [dry-run] Invoke-WebRequest $DOWNLOAD_URL → Expand-Archive"
 }
 
-Write-Host "AlphaForge forge $VERSION をインストールします..."
-
-# インストール先ディレクトリを作成
-if (-not (Test-Path $INSTALL_DIR)) {
-    New-Item -ItemType Directory -Path $INSTALL_DIR | Out-Null
-    Write-Host "$INSTALL_DIR を作成しました。"
-}
-
-# ダウンロード
-$DOWNLOAD_URL = "https://github.com/$REPO/releases/download/$VERSION/$ARTIFACT"
-$TMP_PATH = Join-Path $env:TEMP "forge_tmp.exe"
-
-Write-Host "ダウンロード中: $DOWNLOAD_URL"
-try {
-    Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_PATH -UseBasicParsing
-} catch {
-    Write-Error "ダウンロードに失敗しました: $_"
-    exit 1
-}
-
-# 配置
-Move-Item -Path $TMP_PATH -Destination $INSTALL_PATH -Force
-
+# ── 3. インストール先を確定 ──────────────────────────────────────
 Write-Host ""
-Write-Host "✓ forge を $INSTALL_PATH にインストールしました" -ForegroundColor Green
-Write-Host ""
+if ($DryRun) {
+    Write-Host "  [dry-run] インストール先: $INSTALL_DIR（デフォルト）"
+} else {
+    $choice = Read-Host "  C:\Program Files\forge\ にインストールしますか？ [y/N]"
+    if ($choice -match '^[Yy]$') {
+        $INSTALL_DIR  = "C:\Program Files\forge"
+        $INSTALL_PATH = Join-Path $INSTALL_DIR "forge.exe"
+    }
+}
 
-# PATH の確認と案内
+if (-not $DryRun) {
+    if (-not (Test-Path $INSTALL_DIR)) {
+        New-Item -ItemType Directory -Path $INSTALL_DIR | Out-Null
+    }
+    Copy-Item -Path $BINARY -Destination $INSTALL_PATH -Force
+    Write-Ok "forge を $INSTALL_PATH に配置しました"
+} else {
+    Write-Host "  [dry-run] Copy-Item forge.exe → $INSTALL_PATH"
+}
+
+# ── 4. PATH 自動登録 ─────────────────────────────────────────────
 $currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
 if ($currentPath -notlike "*$INSTALL_DIR*") {
-    Write-Host "PATH に $INSTALL_DIR が含まれていません。" -ForegroundColor Yellow
-    Write-Host "以下のコマンドで追加できます（PowerShell を再起動後に有効）:" -ForegroundColor Yellow
-    Write-Host ""
-    Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `$env:PATH + ';$INSTALL_DIR', 'User')" -ForegroundColor Cyan
-    Write-Host ""
+    if ($DryRun) {
+        Write-Host "  [dry-run] PATH に $INSTALL_DIR を追加"
+    } else {
+        $newPath = if ($currentPath) { "$currentPath;$INSTALL_DIR" } else { $INSTALL_DIR }
+        if ($newPath.Length -gt 2048) {
+            Write-Warn "PATH が 2048 文字を超えています。手動で追加してください:"
+            Write-Host "    [Environment]::SetEnvironmentVariable('PATH', `$env:PATH + ';$INSTALL_DIR', 'User')"
+        } else {
+            [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+            $env:PATH = "$env:PATH;$INSTALL_DIR"
+            Write-Ok "PATH に $INSTALL_DIR を追加しました（次回ターミナル起動から有効）"
+        }
+    }
 } else {
-    Write-Host "PATH は設定済みです。"
+    Write-Ok "PATH はすでに設定済みです"
 }
 
-Write-Host "次のステップ:"
-Write-Host "  forge --version"
-Write-Host "  forge license activate <YOUR_LICENSE_KEY>"
+# ── 5. ライセンスアクティベーション ──────────────────────────────
+Write-Host ""
+Write-Host "ライセンスアクティベーション"
+Write-Host "  Whop でご購入のライセンスキーを入力してください。"
+if ($DryRun) {
+    Write-Host "  [dry-run] ライセンスキー入力をスキップ"
+    $LICENSE_KEY = ""
+} else {
+    $LICENSE_KEY = Read-Host "  ライセンスキー（Enter でスキップ）"
+}
+
+if ($LICENSE_KEY) {
+    if ($DryRun) {
+        Write-Host "  [dry-run] forge license activate $LICENSE_KEY"
+    } else {
+        try {
+            & $INSTALL_PATH license activate $LICENSE_KEY
+            Write-Ok "ライセンス認証が完了しました"
+        } catch {
+            Write-Warn "ライセンス認証に失敗しました。後から再実行してください:"
+            Write-Host "    forge license activate <YOUR_LICENSE_KEY>"
+        }
+    }
+} else {
+    Write-Host "  → スキップしました。後から実行してください:"
+    Write-Host "      forge license activate <YOUR_LICENSE_KEY>"
+}
+
+# ── 6. 確認 ─────────────────────────────────────────────────────
+Write-Host ""
+if (-not $DryRun) {
+    try {
+        & $INSTALL_PATH --version | Out-Null
+        Write-Ok "インストール完了！"
+        Write-Host ""
+        Write-Host "  新しいターミナルを開いて試してください: forge --help"
+    } catch {
+        Write-Warn "forge の確認に失敗しました。新しいターミナルを開いて試してください:"
+        Write-Host "    forge --version"
+    }
+    # クリーンアップ
+    if (Test-Path $TMP_DIR) { Remove-Item -Recurse -Force $TMP_DIR }
+} else {
+    Write-Ok "ドライランが完了しました。実際にインストールするには -DryRun を外して再実行してください。"
+}

--- a/install.ps1
+++ b/install.ps1
@@ -59,105 +59,117 @@ $TMP_ZIP = Join-Path $TMP_DIR "${ARTIFACT}.${EXT}"
 if (-not $DryRun) {
     New-Item -ItemType Directory -Path $TMP_DIR | Out-Null
     try {
-        Write-Info "ダウンロード中: $DOWNLOAD_URL"
-        Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_ZIP -UseBasicParsing
-    } catch {
-        Write-Fail "ダウンロードに失敗しました: $_`n  $DOWNLOAD_URL"
+        try {
+            Write-Info "ダウンロード中: $DOWNLOAD_URL"
+            Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_ZIP -UseBasicParsing
+        } catch {
+            Write-Fail "ダウンロードに失敗しました: $_`n  $DOWNLOAD_URL"
+        }
+        try {
+            Expand-Archive -Path $TMP_ZIP -DestinationPath $TMP_DIR -Force
+        } catch {
+            # .NET フォールバック
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
+            [System.IO.Compression.ZipFile]::ExtractToDirectory($TMP_ZIP, $TMP_DIR)
+        }
+        $BINARY = Join-Path $TMP_DIR "forge.dist\forge.exe"
+        if (-not (Test-Path $BINARY)) { Write-Fail "展開後にバイナリが見つかりません" }
+        Write-Ok "ダウンロード・展開完了"
+
+        # ── 3. インストール先を確定 ──────────────────────────────────────
+        Write-Host ""
+        $choice = Read-Host "  C:\Program Files\forge\ にインストールしますか？ [y/N]"
+        if ($choice -match '^[Yy]$') {
+            $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+                [Security.Principal.WindowsBuiltInRole]::Administrator
+            )
+            if (-not $isAdmin) {
+                Write-Fail "C:\Program Files へのインストールには管理者権限が必要です。`nPowerShell を「管理者として実行」して再度お試しください。"
+            }
+            $INSTALL_DIR  = "C:\Program Files\forge"
+            $INSTALL_PATH = Join-Path $INSTALL_DIR "forge.exe"
+        }
+
+        if (-not (Test-Path $INSTALL_DIR)) {
+            New-Item -ItemType Directory -Path $INSTALL_DIR | Out-Null
+        }
+        Copy-Item -Path $BINARY -Destination $INSTALL_PATH -Force
+        Write-Ok "forge を $INSTALL_PATH に配置しました"
+
+        # ── 4. PATH 自動登録 ─────────────────────────────────────────────
+        $currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+        if ($currentPath -notlike "*$INSTALL_DIR*") {
+            $newPath = if ($currentPath) { "$currentPath;$INSTALL_DIR" } else { $INSTALL_DIR }
+            if ($newPath.Length -gt 2048) {
+                Write-Warn "PATH が 2048 文字を超えています。手動で追加してください:"
+                Write-Host "    [Environment]::SetEnvironmentVariable('PATH', `$env:PATH + ';$INSTALL_DIR', 'User')"
+            } else {
+                [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+                $env:PATH = "$env:PATH;$INSTALL_DIR"
+                Write-Ok "PATH に $INSTALL_DIR を追加しました（次回ターミナル起動から有効）"
+            }
+        } else {
+            Write-Ok "PATH はすでに設定済みです"
+        }
+
+        # ── 5. ライセンスアクティベーション ──────────────────────────────
+        Write-Host ""
+        Write-Host "ライセンスアクティベーション"
+        Write-Host "  Whop でご購入のライセンスキーを入力してください。"
+        $LICENSE_KEY = Read-Host "  ライセンスキー（Enter でスキップ）"
+        if ($LICENSE_KEY) {
+            try {
+                & $INSTALL_PATH license activate $LICENSE_KEY
+                Write-Ok "ライセンス認証が完了しました"
+            } catch {
+                Write-Warn "ライセンス認証に失敗しました。後から再実行してください:"
+                Write-Host "    forge license activate <YOUR_LICENSE_KEY>"
+            }
+        } else {
+            Write-Host "  → スキップしました。後から実行してください:"
+            Write-Host "      forge license activate <YOUR_LICENSE_KEY>"
+        }
+
+        # ── 6. 確認 ─────────────────────────────────────────────────────
+        Write-Host ""
+        try {
+            & $INSTALL_PATH --version | Out-Null
+            Write-Ok "インストール完了！"
+            Write-Host ""
+            Write-Host "  新しいターミナルを開いて試してください: forge --help"
+        } catch {
+            Write-Warn "forge の確認に失敗しました。新しいターミナルを開いて試してください:"
+            Write-Host "    forge --version"
+        }
+    } finally {
+        if (Test-Path $TMP_DIR) { Remove-Item -Recurse -Force $TMP_DIR -ErrorAction SilentlyContinue }
     }
-    try {
-        Expand-Archive -Path $TMP_ZIP -DestinationPath $TMP_DIR -Force
-    } catch {
-        # .NET フォールバック
-        Add-Type -AssemblyName System.IO.Compression.FileSystem
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($TMP_ZIP, $TMP_DIR)
-    }
-    $BINARY = Join-Path $TMP_DIR "forge.dist\forge.exe"
-    if (-not (Test-Path $BINARY)) { Write-Fail "展開後にバイナリが見つかりません" }
-    Write-Ok "ダウンロード・展開完了"
 } else {
     Write-Host "  [dry-run] Invoke-WebRequest $DOWNLOAD_URL → Expand-Archive"
-}
 
-# ── 3. インストール先を確定 ──────────────────────────────────────
-Write-Host ""
-if ($DryRun) {
+    # ── 3. インストール先を確定（dry-run）──────────────────────────
+    Write-Host ""
     Write-Host "  [dry-run] インストール先: $INSTALL_DIR（デフォルト）"
-} else {
-    $choice = Read-Host "  C:\Program Files\forge\ にインストールしますか？ [y/N]"
-    if ($choice -match '^[Yy]$') {
-        $INSTALL_DIR  = "C:\Program Files\forge"
-        $INSTALL_PATH = Join-Path $INSTALL_DIR "forge.exe"
-    }
-}
 
-if (-not $DryRun) {
-    if (-not (Test-Path $INSTALL_DIR)) {
-        New-Item -ItemType Directory -Path $INSTALL_DIR | Out-Null
-    }
-    Copy-Item -Path $BINARY -Destination $INSTALL_PATH -Force
-    Write-Ok "forge を $INSTALL_PATH に配置しました"
-} else {
     Write-Host "  [dry-run] Copy-Item forge.exe → $INSTALL_PATH"
-}
 
-# ── 4. PATH 自動登録 ─────────────────────────────────────────────
-$currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-if ($currentPath -notlike "*$INSTALL_DIR*") {
-    if ($DryRun) {
+    # ── 4. PATH 自動登録（dry-run）───────────────────────────────
+    $currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+    if ($currentPath -notlike "*$INSTALL_DIR*") {
         Write-Host "  [dry-run] PATH に $INSTALL_DIR を追加"
     } else {
-        $newPath = if ($currentPath) { "$currentPath;$INSTALL_DIR" } else { $INSTALL_DIR }
-        if ($newPath.Length -gt 2048) {
-            Write-Warn "PATH が 2048 文字を超えています。手動で追加してください:"
-            Write-Host "    [Environment]::SetEnvironmentVariable('PATH', `$env:PATH + ';$INSTALL_DIR', 'User')"
-        } else {
-            [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
-            $env:PATH = "$env:PATH;$INSTALL_DIR"
-            Write-Ok "PATH に $INSTALL_DIR を追加しました（次回ターミナル起動から有効）"
-        }
+        Write-Ok "PATH はすでに設定済みです"
     }
-} else {
-    Write-Ok "PATH はすでに設定済みです"
-}
 
-# ── 5. ライセンスアクティベーション ──────────────────────────────
-Write-Host ""
-Write-Host "ライセンスアクティベーション"
-Write-Host "  Whop でご購入のライセンスキーを入力してください。"
-if ($DryRun) {
+    # ── 5. ライセンスアクティベーション（dry-run）────────────────
+    Write-Host ""
+    Write-Host "ライセンスアクティベーション"
+    Write-Host "  Whop でご購入のライセンスキーを入力してください。"
     Write-Host "  [dry-run] ライセンスキー入力をスキップ"
     Write-Host "  → スキップしました。後から実行してください:"
     Write-Host "      forge license activate <YOUR_LICENSE_KEY>"
-} else {
-    $LICENSE_KEY = Read-Host "  ライセンスキー（Enter でスキップ）"
-    if ($LICENSE_KEY) {
-        try {
-            & $INSTALL_PATH license activate $LICENSE_KEY
-            Write-Ok "ライセンス認証が完了しました"
-        } catch {
-            Write-Warn "ライセンス認証に失敗しました。後から再実行してください:"
-            Write-Host "    forge license activate <YOUR_LICENSE_KEY>"
-        }
-    } else {
-        Write-Host "  → スキップしました。後から実行してください:"
-        Write-Host "      forge license activate <YOUR_LICENSE_KEY>"
-    }
-}
 
-# ── 6. 確認 ─────────────────────────────────────────────────────
-Write-Host ""
-if (-not $DryRun) {
-    try {
-        & $INSTALL_PATH --version | Out-Null
-        Write-Ok "インストール完了！"
-        Write-Host ""
-        Write-Host "  新しいターミナルを開いて試してください: forge --help"
-    } catch {
-        Write-Warn "forge の確認に失敗しました。新しいターミナルを開いて試してください:"
-        Write-Host "    forge --version"
-    }
-    # クリーンアップ
-    if (Test-Path $TMP_DIR) { Remove-Item -Recurse -Force $TMP_DIR }
-} else {
+    # ── 6. 確認（dry-run）────────────────────────────────────────
+    Write-Host ""
     Write-Ok "ドライランが完了しました。実際にインストールするには -DryRun を外して再実行してください。"
 }

--- a/install.ps1
+++ b/install.ps1
@@ -22,7 +22,7 @@ $ErrorActionPreference = "Stop"
 $REPO         = "alforge-labs/alforge-labs.github.io"
 $ARTIFACT     = "forge-windows-x64"
 $EXT          = "zip"
-$INSTALL_DIR  = Join-Path $env:USERPROFILE "bin"
+$INSTALL_DIR  = Join-Path $HOME "bin"
 $INSTALL_PATH = Join-Path $INSTALL_DIR "forge.exe"
 
 function Write-Ok   { param($msg) Write-Host "  ✓ $msg" -ForegroundColor Green }
@@ -126,15 +126,11 @@ Write-Host "ライセンスアクティベーション"
 Write-Host "  Whop でご購入のライセンスキーを入力してください。"
 if ($DryRun) {
     Write-Host "  [dry-run] ライセンスキー入力をスキップ"
-    $LICENSE_KEY = ""
+    Write-Host "  → スキップしました。後から実行してください:"
+    Write-Host "      forge license activate <YOUR_LICENSE_KEY>"
 } else {
     $LICENSE_KEY = Read-Host "  ライセンスキー（Enter でスキップ）"
-}
-
-if ($LICENSE_KEY) {
-    if ($DryRun) {
-        Write-Host "  [dry-run] forge license activate $LICENSE_KEY"
-    } else {
+    if ($LICENSE_KEY) {
         try {
             & $INSTALL_PATH license activate $LICENSE_KEY
             Write-Ok "ライセンス認証が完了しました"
@@ -142,10 +138,10 @@ if ($LICENSE_KEY) {
             Write-Warn "ライセンス認証に失敗しました。後から再実行してください:"
             Write-Host "    forge license activate <YOUR_LICENSE_KEY>"
         }
+    } else {
+        Write-Host "  → スキップしました。後から実行してください:"
+        Write-Host "      forge license activate <YOUR_LICENSE_KEY>"
     }
-} else {
-    Write-Host "  → スキップしました。後から実行してください:"
-    Write-Host "      forge license activate <YOUR_LICENSE_KEY>"
 }
 
 # ── 6. 確認 ─────────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -1,61 +1,170 @@
 #!/usr/bin/env bash
+# AlphaForge forge インストーラー
+# Usage: bash <(curl -sSL https://alforge-labs.github.io/install.sh)
+#        bash <(curl -sSL https://alforge-labs.github.io/install.sh) --dry-run
 set -euo pipefail
 
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
-REPO="alforge-labs/alforge-labs.github.io"
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+  echo "[dry-run] 実際のインストールは行いません。"
+fi
 
-# OS・アーキテクチャ判定
+REPO="alforge-labs/alforge-labs.github.io"
+DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
+INSTALL_DIR=""
+
+ok()   { echo "  ✓ $*"; }
+info() { echo "  → $*"; }
+fail() { echo "  ✗ $*" >&2; exit 1; }
+
+# ── 1. OS + アーキテクチャ検出 ──────────────────────────────────
 OS="$(uname -s)"
 ARCH="$(uname -m)"
+
 case "${OS}-${ARCH}" in
-  Darwin-arm64)  ARTIFACT="forge-macos-arm64" ;;
-  Darwin-x86_64) ARTIFACT="forge-macos-x86_64" ;;
-  Linux-x86_64)  ARTIFACT="forge-linux-x86_64" ;;
-  *) echo "未対応プラットフォーム: ${OS}-${ARCH}"; exit 1 ;;
+  Darwin-arm64)  ARTIFACT="forge-macos-arm64"; EXT="tar.gz" ;;
+  Darwin-x86_64) ARTIFACT="forge-macos-x64";   EXT="tar.gz" ;;
+  *) fail "未対応プラットフォーム: ${OS}-${ARCH}。対応: macOS arm64, macOS x86_64" ;;
 esac
 
-# 最新バージョンを取得
-VERSION="$(curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" \
-  | grep '"tag_name"' | cut -d '"' -f 4)"
+info "プラットフォーム: ${OS}-${ARCH} → ${ARTIFACT}"
+
+# ── 2. 最新バージョンを取得 ─────────────────────────────────────
+info "最新バージョンを確認中..."
+if ! command -v curl >/dev/null 2>&1; then
+  fail "curl がインストールされていません。インストール後に再実行してください。"
+fi
+
+VERSION="$(curl -sSfL "https://api.github.com/repos/${REPO}/releases/latest" \
+  2>/dev/null | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')" || true
 
 if [ -z "${VERSION}" ]; then
-  echo "エラー: リリースバージョンの取得に失敗しました。"
-  exit 1
+  fail "バージョン取得に失敗しました。ネットワーク接続を確認してください。\n  https://github.com/${REPO}/releases"
 fi
 
-echo "AlphaForge forge ${VERSION} (${ARTIFACT}) をインストールします..."
+ok "最新バージョン: ${VERSION}"
 
-# インストール先ディレクトリが存在しない場合は作成を試みる
-if [ ! -d "${INSTALL_DIR}" ]; then
-  echo "${INSTALL_DIR} が存在しないため作成します..."
-  mkdir -p "${INSTALL_DIR}" 2>/dev/null || {
-    echo "権限エラー: sudo で再実行してください。"
-    echo "  sudo INSTALL_DIR=${INSTALL_DIR} bash <(curl -sSL https://alforge-labs.github.io/install.sh)"
-    exit 1
-  }
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT}.${EXT}"
+
+# 既存バイナリのバージョン確認
+if command -v forge >/dev/null 2>&1; then
+  CURRENT_VER="$(forge --version 2>/dev/null | head -1)" || CURRENT_VER=""
+  if [ -n "${CURRENT_VER}" ]; then
+    info "現在のバージョン: ${CURRENT_VER} → ${VERSION} に更新します"
+  fi
 fi
 
-# ダウンロード & 配置
-TMP_FILE="$(mktemp)"
-trap 'rm -f "${TMP_FILE}"' EXIT
+# ── 3. ダウンロード & 展開 ─────────────────────────────────────
+TMP_DIR="$(mktemp -d /tmp/forge-install.XXXXXX)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
 
-curl -sSL \
-  "https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT}" \
-  -o "${TMP_FILE}"
-
-# 書き込み権限チェック
-if [ ! -w "${INSTALL_DIR}" ]; then
-  echo "権限エラー: ${INSTALL_DIR} への書き込み権限がありません。sudo で再実行してください。"
-  echo "  sudo INSTALL_DIR=${INSTALL_DIR} bash <(curl -sSL https://alforge-labs.github.io/install.sh)"
-  exit 1
+if [ "${DRY_RUN}" = "false" ]; then
+  info "ダウンロード中: ${DOWNLOAD_URL}"
+  curl -sSfL "${DOWNLOAD_URL}" -o "${TMP_DIR}/archive.${EXT}" \
+    || fail "ダウンロードに失敗しました。\n  ${DOWNLOAD_URL}"
+  tar xzf "${TMP_DIR}/archive.${EXT}" -C "${TMP_DIR}"
+  BINARY="${TMP_DIR}/forge.dist/forge"
+  if [ ! -f "${BINARY}" ]; then
+    fail "展開後にバイナリが見つかりません"
+  fi
+  ok "ダウンロード・展開完了"
+else
+  echo "  [dry-run] curl -L ${DOWNLOAD_URL} → tar xzf → ${TMP_DIR}/forge.dist/forge"
+  BINARY="${TMP_DIR}/forge.dist/forge"
 fi
 
-cp "${TMP_FILE}" "${INSTALL_DIR}/forge"
-chmod +x "${INSTALL_DIR}/forge"
-
+# ── 4. インストール先を確定 ──────────────────────────────────────
 echo ""
-echo "✓ forge を ${INSTALL_DIR}/forge にインストールしました"
+echo "インストール先を選択してください（デフォルト: ${DEFAULT_INSTALL_DIR}）"
+read -r -p "  /usr/local/bin にインストールしますか？ [y/N] " REPLY
+if [[ "${REPLY}" =~ ^[Yy]$ ]]; then
+  INSTALL_DIR="/usr/local/bin"
+else
+  INSTALL_DIR="${DEFAULT_INSTALL_DIR}"
+fi
+
+if [ "${DRY_RUN}" = "false" ]; then
+  mkdir -p "${INSTALL_DIR}"
+  if [ -w "${INSTALL_DIR}" ]; then
+    cp "${BINARY}" "${INSTALL_DIR}/forge"
+  else
+    info "sudo でインストールします..."
+    if ! sudo cp "${BINARY}" "${INSTALL_DIR}/forge" 2>/dev/null; then
+      info "sudo 失敗。${DEFAULT_INSTALL_DIR} にフォールバックします"
+      INSTALL_DIR="${DEFAULT_INSTALL_DIR}"
+      mkdir -p "${INSTALL_DIR}"
+      cp "${BINARY}" "${INSTALL_DIR}/forge"
+    fi
+  fi
+  chmod +x "${INSTALL_DIR}/forge"
+  ok "forge を ${INSTALL_DIR}/forge に配置しました"
+else
+  echo "  [dry-run] cp forge → ${INSTALL_DIR}/forge && chmod +x"
+fi
+
+# ── 5. PATH 自動追記 ─────────────────────────────────────────────
+if [[ ":${PATH}:" != *":${INSTALL_DIR}:"* ]]; then
+  SHELL_NAME="$(basename "${SHELL:-bash}")"
+  case "${SHELL_NAME}" in
+    zsh)  RC="${HOME}/.zshrc" ;;
+    fish) RC="${HOME}/.config/fish/config.fish" ;;
+    *)    RC="${HOME}/.bashrc" ;;
+  esac
+
+  PATH_LINE="export PATH=\"${INSTALL_DIR}:\${PATH}\""
+
+  if [ "${DRY_RUN}" = "false" ]; then
+    if ! grep -qF "${INSTALL_DIR}" "${RC}" 2>/dev/null; then
+      printf '\n# AlphaForge forge\n%s\n' "${PATH_LINE}" >> "${RC}"
+      ok "PATH を ${RC} に追記しました"
+    else
+      ok "PATH はすでに ${RC} に設定済みです"
+    fi
+  else
+    echo "  [dry-run] echo '${PATH_LINE}' >> ${RC}"
+  fi
+else
+  ok "PATH はすでに設定済みです"
+fi
+
+# ── 6. ライセンスアクティベーション ──────────────────────────────
 echo ""
-echo "次のステップ:"
-echo "  forge --version"
-echo "  forge license activate <YOUR_LICENSE_KEY>"
+echo "ライセンスアクティベーション"
+echo "  Whop でご購入のライセンスキーを入力してください。"
+read -r -p "  ライセンスキー（Enter でスキップ）: " LICENSE_KEY
+
+if [ -n "${LICENSE_KEY}" ]; then
+  if [ "${DRY_RUN}" = "false" ]; then
+    if "${INSTALL_DIR}/forge" license activate "${LICENSE_KEY}"; then
+      ok "ライセンス認証が完了しました"
+    else
+      echo "  ⚠ ライセンス認証に失敗しました。後から再実行してください:"
+      echo "      forge license activate <YOUR_LICENSE_KEY>"
+    fi
+  else
+    echo "  [dry-run] forge license activate ${LICENSE_KEY}"
+  fi
+else
+  echo "  → スキップしました。後から実行してください:"
+  echo "      forge license activate <YOUR_LICENSE_KEY>"
+fi
+
+# ── 7. 確認 ─────────────────────────────────────────────────────
+echo ""
+if [ "${DRY_RUN}" = "false" ]; then
+  if "${INSTALL_DIR}/forge" --version >/dev/null 2>&1; then
+    ok "インストール完了！"
+    echo ""
+    echo "  PATH を反映するには新しいターミナルを開くか、以下を実行してください:"
+    echo "    source ${RC:-~/.zshrc}"
+    echo ""
+    echo "  使い方: forge --help"
+  else
+    echo "  ⚠ forge コマンドの確認に失敗しました。PATH を確認してください:"
+    echo "    export PATH=\"${INSTALL_DIR}:\${PATH}\""
+    echo "    forge --version"
+  fi
+else
+  ok "ドライランが完了しました。実際にインストールするには --dry-run を外して再実行してください。"
+fi

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,12 @@ VERSION="$(curl -sSfL "https://api.github.com/repos/${REPO}/releases/latest" \
   2>/dev/null | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')" || true
 
 if [ -z "${VERSION}" ]; then
-  fail "バージョン取得に失敗しました。ネットワーク接続を確認してください。\n  https://github.com/${REPO}/releases"
+  if [ "${DRY_RUN}" = "true" ]; then
+    VERSION="vX.Y.Z（dry-run: バージョン未取得）"
+    info "バージョン取得できませんでした（dry-run のため続行）"
+  else
+    fail "バージョン取得に失敗しました。ネットワーク接続を確認してください。\n  https://github.com/${REPO}/releases"
+  fi
 fi
 
 ok "最新バージョン: ${VERSION}"

--- a/install.sh
+++ b/install.sh
@@ -77,30 +77,34 @@ fi
 # ── 4. インストール先を確定 ──────────────────────────────────────
 echo ""
 echo "インストール先を選択してください（デフォルト: ${DEFAULT_INSTALL_DIR}）"
-read -r -p "  /usr/local/bin にインストールしますか？ [y/N] " REPLY
-if [[ "${REPLY}" =~ ^[Yy]$ ]]; then
-  INSTALL_DIR="/usr/local/bin"
-else
+if [ "${DRY_RUN}" = "true" ]; then
   INSTALL_DIR="${DEFAULT_INSTALL_DIR}"
+  echo "  [dry-run] インストール先: ${INSTALL_DIR}（デフォルト）"
+else
+  read -r -p "  /usr/local/bin にインストールしますか？ [y/N] " REPLY
+  if [[ "${REPLY}" =~ ^[Yy]$ ]]; then
+    INSTALL_DIR="/usr/local/bin"
+  else
+    INSTALL_DIR="${DEFAULT_INSTALL_DIR}"
+  fi
 fi
 
 if [ "${DRY_RUN}" = "false" ]; then
   mkdir -p "${INSTALL_DIR}"
   if [ -w "${INSTALL_DIR}" ]; then
-    cp "${BINARY}" "${INSTALL_DIR}/forge"
+    install -m 755 "${BINARY}" "${INSTALL_DIR}/forge"
   else
     info "sudo でインストールします..."
-    if ! sudo cp "${BINARY}" "${INSTALL_DIR}/forge" 2>/dev/null; then
+    if ! sudo install -m 755 "${BINARY}" "${INSTALL_DIR}/forge" 2>/dev/null; then
       info "sudo 失敗。${DEFAULT_INSTALL_DIR} にフォールバックします"
       INSTALL_DIR="${DEFAULT_INSTALL_DIR}"
       mkdir -p "${INSTALL_DIR}"
-      cp "${BINARY}" "${INSTALL_DIR}/forge"
+      install -m 755 "${BINARY}" "${INSTALL_DIR}/forge"
     fi
   fi
-  chmod +x "${INSTALL_DIR}/forge"
   ok "forge を ${INSTALL_DIR}/forge に配置しました"
 else
-  echo "  [dry-run] cp forge → ${INSTALL_DIR}/forge && chmod +x"
+  echo "  [dry-run] install -m 755 forge → ${INSTALL_DIR}/forge"
 fi
 
 # ── 5. PATH 自動追記 ─────────────────────────────────────────────
@@ -132,7 +136,12 @@ fi
 echo ""
 echo "ライセンスアクティベーション"
 echo "  Whop でご購入のライセンスキーを入力してください。"
-read -r -p "  ライセンスキー（Enter でスキップ）: " LICENSE_KEY
+if [ "${DRY_RUN}" = "true" ]; then
+  echo "  [dry-run] ライセンスキー入力をスキップ"
+  LICENSE_KEY=""
+else
+  read -r -p "  ライセンスキー（Enter でスキップ）: " LICENSE_KEY
+fi
 
 if [ -n "${LICENSE_KEY}" ]; then
   if [ "${DRY_RUN}" = "false" ]; then

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ INSTALL_DIR=""
 
 ok()   { echo "  ✓ $*"; }
 info() { echo "  → $*"; }
-fail() { echo "  ✗ $*" >&2; exit 1; }
+fail() { printf "  ✗ %b\n" "$*" >&2; exit 1; }
 
 # ── 1. OS + アーキテクチャ検出 ──────────────────────────────────
 OS="$(uname -s)"
@@ -95,7 +95,7 @@ if [ "${DRY_RUN}" = "false" ]; then
     install -m 755 "${BINARY}" "${INSTALL_DIR}/forge"
   else
     info "sudo でインストールします..."
-    if ! sudo install -m 755 "${BINARY}" "${INSTALL_DIR}/forge" 2>/dev/null; then
+    if ! sudo install -m 755 "${BINARY}" "${INSTALL_DIR}/forge"; then
       info "sudo 失敗。${DEFAULT_INSTALL_DIR} にフォールバックします"
       INSTALL_DIR="${DEFAULT_INSTALL_DIR}"
       mkdir -p "${INSTALL_DIR}"


### PR DESCRIPTION
## 変更内容

### install.sh（macOS arm64/x86_64）
- アーティファクト名を修正: `forge-macos-x86_64` → `forge-macos-x64`（tar.gz 展開対応）
- Linux ケースを削除（ビルド対象外）
- デフォルトインストール先を `/usr/local/bin` → `~/.local/bin` に変更（ユーザー権限優先）
- `--dry-run` オプションを追加（ダウンロード・書き込み・システム変更をスキップ）
- PATH 自動追記を追加（zsh/bash/fish シェル検出）
- ライセンスキー対話入力を追加（Enter でスキップ可）
- `sudo install -m 755` でコピーとパーミッション設定を1ステップに統合
- `fail()` を `printf "%b\n"` に変更（\n エスケープ対応）
- dry-run 時のバージョン取得失敗にプレースホルダーフォールバックを追加

### install.ps1（Windows x64）
- アーティファクト名を修正: `forge-windows-x86_64.exe` → `forge-windows-x64.zip`（zip 展開対応）
- PATH 自動登録を実装（案内のみ → `SetEnvironmentVariable` で実際に登録）
- ライセンスキー対話入力を追加（Enter でスキップ可）
- `-DryRun` スイッチを追加
- `Expand-Archive` 失敗時の `.NET` フォールバックを追加
- `try/finally` で一時ディレクトリのクリーンアップを保証
- `C:\Program Files` 選択時の管理者権限チェックを追加
- `$env:USERPROFILE` → `$HOME` に統一

## テスト
- `bash install.sh --dry-run` で動作確認済み（macOS arm64）
- `shellcheck install.sh` でエラー 0 件

## ワンライナー
\`\`\`bash
bash <(curl -sSL https://alforge-labs.github.io/install.sh)
\`\`\`
\`\`\`powershell
irm https://alforge-labs.github.io/install.ps1 | iex
\`\`\`