### PR TITLE
feat: docs.html を「カタログ + 主要 6 コマンド」に再構成 (#65)

### DIFF
--- a/docs/superpowers/plans/2026-04-30-alforge-labs-issue-65-docs-html-slim.md
+++ b/docs/superpowers/plans/2026-04-30-alforge-labs-issue-65-docs-html-slim.md
@@ -1,0 +1,917 @@
+# docs.html 簡素化と「カタログ + 主要 6 コマンド」再構成 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `templates/docs.html.j2`（現状 1012 行）を「ヒーロー + 主要 6 コマンドカードグリッド + 全グループカタログ表 + cli-reference 誘導」のページに再構成し、`{ja,en}/docs.html` を再生成する。
+
+**Architecture:** Jinja2 テンプレート (`templates/docs.html.j2`) を `Write` で完全置換 → `uv run python build.py` で `ja/docs.html` と `en/docs.html` を再生成 → 2 コミット → PR 作成。新規 CSS（カードグリッド用）はテンプレ内 `<style>` ブロックに局所追加、`page.css` は無変更。MkDocs `cli-reference/` への各サブコマンドアンカー (`#forge-{group}-{sub}`) リンクが正常に機能するか実装フェーズで検証する。
+
+**Tech Stack:** Jinja2, Python 3 (build.py with PyYAML), 静的 HTML/CSS, GitHub Pages, gh CLI, MkDocs Material（既存ビルド済み）
+
+**作業ブランチ:** `feat/docs-issue-65-docs-html-slim`（spec コミット `6329bf8` で作成済み）
+
+**Spec:** `docs/superpowers/specs/2026-04-30-alforge-labs-issue-65-docs-html-slim-design.md`
+
+---
+
+## File Structure
+
+| ファイル | 責務 | 変更タイプ |
+|---|---|---|
+| `templates/docs.html.j2` | Jinja2 テンプレート（正本） | **完全書き直し（Write）** |
+| `ja/docs.html` | build.py 出力 | 再生成（コミット） |
+| `en/docs.html` | build.py 出力 | 再生成（コミット） |
+| `seo.yaml` | SEO メタデータ | 変更なし |
+| `page.css` | グローバルスタイル | 変更なし |
+| `build.py` | ビルドスクリプト | 変更なし |
+| `mkdocs_src/`, `{ja,en}/docs/` | MkDocs 関連 | **一切変更なし** |
+
+---
+
+## Task 1: `templates/docs.html.j2` を新構造で完全書き直し
+
+**Files:**
+- Modify: `templates/docs.html.j2`（既存 1012 行を完全置換、推定 ~310 行へ）
+
+- [ ] **Step 1: 既存テンプレートの上下保持部分を確認**
+
+```bash
+sed -n '1,25p' templates/docs.html.j2  # head: meta タグ群（保持）
+sed -n '108,122p' templates/docs.html.j2  # theme スクリプト + body 開始（保持）
+sed -n '998,1012p' templates/docs.html.j2  # footer + React/Babel scripts（保持）
+```
+
+期待: meta タグ・JSON-LD・hreflang（line 1-25）、theme 初期化スクリプト（line 108-119）、body 開始 + site-header div（line 121-122）、footer（line 998-1002）、React/Babel scripts（line 1004-1010）が確認できる。これらは新テンプレートでも保持する。
+
+- [ ] **Step 2: `templates/docs.html.j2` を Write で完全置換**
+
+ファイル全文を以下の内容で上書きする:
+
+```html
+<!DOCTYPE html>
+<html lang="{{ lang }}">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{{ title }}</title>
+  <meta name="description" content="{{ description }}" />
+  <meta name="keywords" content="{{ keywords }}" />
+  <link rel="canonical" href="{{ canonical_url }}" />
+  <link rel="alternate" hreflang="ja" href="{{ hreflang_ja }}" />
+  <link rel="alternate" hreflang="en" href="{{ hreflang_en }}" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <meta property="og:url" content="{{ canonical_url }}" />
+  <meta property="og:image" content="{{ og_image }}" />
+  <meta property="og:locale" content="{{ og_locale }}" />
+  <meta property="og:site_name" content="Alforge Labs" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:site" content="{{ twitter_site }}" />
+  <meta name="twitter:title" content="{{ og_title }}" />
+  <meta name="twitter:description" content="{{ og_description }}" />
+  <meta name="twitter:image" content="{{ og_image }}" />
+  <script type="application/ld+json">{{ json_ld }}</script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../page.css" />
+  <style>
+    /* ── CARD GRID ── */
+    .cmd-card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1rem;
+      margin: 1.5rem 0 2.5rem;
+    }
+    .cmd-card {
+      display: block;
+      padding: 1.25rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      text-decoration: none;
+      transition: border-color 0.15s, transform 0.15s;
+    }
+    .cmd-card:hover {
+      border-color: var(--accent);
+      transform: translateY(-2px);
+      text-decoration: none;
+    }
+    .cmd-card-name {
+      font-family: var(--mono);
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--accent);
+      margin-bottom: 0.4rem;
+    }
+    .cmd-card-desc { font-size: 0.85rem; color: var(--text2); margin-bottom: 0.75rem; }
+    .cmd-card-usage {
+      background: var(--bg2);
+      padding: 0.5rem 0.75rem;
+      border-radius: 4px;
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      color: var(--text);
+      margin: 0 0 0.75rem;
+      overflow-x: auto;
+    }
+    .cmd-card-options { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 0.75rem; }
+    .cmd-card-option {
+      font-family: var(--mono); font-size: 0.72rem;
+      padding: 0.2rem 0.5rem;
+      background: var(--accent-bg); color: var(--accent);
+      border-radius: 4px;
+    }
+    .cmd-card-link {
+      font-size: 0.78rem;
+      color: var(--text3);
+      font-family: var(--mono);
+    }
+    .cmd-card:hover .cmd-card-link { color: var(--accent); }
+  </style>
+  <script>
+    (function() {
+      var t = localStorage.getItem('al_theme') || 'dark';
+      var l = localStorage.getItem('al_lang') || '{{ lang }}';
+      document.documentElement.setAttribute('data-theme', t);
+      document.documentElement.setAttribute('lang', l);
+      document.addEventListener('DOMContentLoaded', function() {
+        document.body.setAttribute('data-theme', t);
+        document.body.setAttribute('data-lang', l);
+      });
+    })();
+  </script>
+</head>
+<body data-theme="dark" data-lang="{{ lang }}">
+  <div id="site-header"></div>
+
+  <div class="page-wrap">
+
+    <!-- ==================== 日本語版 ==================== -->
+    <div class="lang-content lang-ja">
+      <div class="page-label">Documentation</div>
+      <h1 class="page-title">forge コマンドの早見表</h1>
+      <p class="page-subtitle">主要 6 コマンドのカードと全コマンドカタログ。詳細パラメータと出力例は公式ドキュメントへ。</p>
+
+      <div class="callout" style="margin-bottom: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          全 76 サブコマンドの詳細パラメータ、出力例、エラーコードは
+          <strong>公式ドキュメント</strong>を参照してください。
+        </p>
+        <a href="/ja/docs/cli-reference/" class="btn-primary">
+          CLI リファレンスを開く →
+        </a>
+      </div>
+
+      <h2 class="section-heading">主要コマンド</h2>
+      <div class="cmd-card-grid">
+        <a class="cmd-card" href="/ja/docs/cli-reference/backtest/#forge-backtest-run">
+          <div class="cmd-card-name">forge backtest run</div>
+          <div class="cmd-card-desc">単一銘柄に戦略を適用してバックテストを実行する。</div>
+          <pre class="cmd-card-usage"><code>forge backtest run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--strategy</span>
+            <span class="cmd-card-option">--start</span>
+            <span class="cmd-card-option">--json</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/optimize/#forge-optimize-run">
+          <div class="cmd-card-name">forge optimize run</div>
+          <div class="cmd-card-desc">Optuna によるパラメータ最適化（TPE）。多目的最適化にも対応。</div>
+          <pre class="cmd-card-usage"><code>forge optimize run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--metric</span>
+            <span class="cmd-card-option">--trials</span>
+            <span class="cmd-card-option">--apply</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/optimize/#forge-optimize-walk-forward">
+          <div class="cmd-card-name">forge optimize walk-forward</div>
+          <div class="cmd-card-desc">時系列をウィンドウ分割し IS 最適化 → OOS 評価で過学習耐性を測定。</div>
+          <pre class="cmd-card-usage"><code>forge optimize walk-forward SYMBOL --strategy ID --windows N</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--windows</span>
+            <span class="cmd-card-option">--metric</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/data/#forge-data-fetch">
+          <div class="cmd-card-name">forge data fetch</div>
+          <div class="cmd-card-desc">OHLCV をプロバイダーから取得し Parquet で保存。</div>
+          <pre class="cmd-card-usage"><code>forge data fetch SYMBOL --period 5y --interval 1d</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--period</span>
+            <span class="cmd-card-option">--interval</span>
+            <span class="cmd-card-option">--watchlist</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/strategy/#forge-strategy-save">
+          <div class="cmd-card-name">forge strategy save</div>
+          <div class="cmd-card-desc">戦略 JSON をレジストリに登録（任意で Journal に記録）。</div>
+          <pre class="cmd-card-usage"><code>forge strategy save FILE_PATH</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--force</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/journal/#forge-journal-show">
+          <div class="cmd-card-name">forge journal show</div>
+          <div class="cmd-card-desc">戦略の全履歴（スナップショット・Runs・タグ・ライブサマリ）を表示。</div>
+          <pre class="cmd-card-usage"><code>forge journal show STRATEGY_ID</code></pre>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+      </div>
+
+      <h2 class="section-heading">全コマンドカタログ</h2>
+      <table class="cmd-table">
+        <thead>
+          <tr><th>グループ</th><th>説明</th><th>サブコマンド数</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/backtest/"><code>forge backtest</code></a></td>
+            <td>バックテスト実行・スキャン・カスタム実験</td>
+            <td>11</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/optimize/"><code>forge optimize</code></a></td>
+            <td>パラメータ最適化（grid / bayes / wfa）</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td>
+            <td>戦略 JSON の保存・検証・適用</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/data/"><code>forge data</code></a></td>
+            <td>ヒストリカルデータ取得・更新</td>
+            <td>4</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/journal/"><code>forge journal</code></a></td>
+            <td>取引ジャーナル・トレード分析</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/live/"><code>forge live</code></a></td>
+            <td>ライブトレーディング・ブローカー連携</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/other/">その他コマンド</a></td>
+            <td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> 他</td>
+            <td>10 グループ</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout" style="margin-top: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          各グループの完全なサブコマンドリスト、オプション一覧、戻り値、サンプル出力は
+          ドキュメントの CLI リファレンスを参照してください。
+        </p>
+        <a href="/ja/docs/cli-reference/" class="btn-primary">
+          CLI リファレンスを開く →
+        </a>
+      </div>
+
+      <div class="callout" style="margin-top: 1rem;">
+        <p>サポートが必要な場合は <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a> までお問い合わせください。</p>
+      </div>
+    </div>
+
+    <!-- ==================== English ==================== -->
+    <div class="lang-content lang-en">
+      <div class="page-label">Documentation</div>
+      <h1 class="page-title">forge Command Quick Reference</h1>
+      <p class="page-subtitle">Cards for the six core commands plus a full command catalog. Detailed parameters and output examples live in the official docs.</p>
+
+      <div class="callout" style="margin-bottom: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          For detailed parameters, output examples, and error codes for all 76 subcommands,
+          see the <strong>official documentation</strong>.
+        </p>
+        <a href="/en/docs/cli-reference/" class="btn-primary">
+          Open CLI Reference →
+        </a>
+      </div>
+
+      <h2 class="section-heading">Top Commands</h2>
+      <div class="cmd-card-grid">
+        <a class="cmd-card" href="/en/docs/cli-reference/backtest/#forge-backtest-run">
+          <div class="cmd-card-name">forge backtest run</div>
+          <div class="cmd-card-desc">Run a backtest applying a strategy to a single symbol.</div>
+          <pre class="cmd-card-usage"><code>forge backtest run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--strategy</span>
+            <span class="cmd-card-option">--start</span>
+            <span class="cmd-card-option">--json</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/optimize/#forge-optimize-run">
+          <div class="cmd-card-name">forge optimize run</div>
+          <div class="cmd-card-desc">Parameter optimization with Optuna (TPE). Multi-objective also supported.</div>
+          <pre class="cmd-card-usage"><code>forge optimize run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--metric</span>
+            <span class="cmd-card-option">--trials</span>
+            <span class="cmd-card-option">--apply</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/optimize/#forge-optimize-walk-forward">
+          <div class="cmd-card-name">forge optimize walk-forward</div>
+          <div class="cmd-card-desc">Split time series into windows; IS optimization → OOS evaluation for overfitting resistance.</div>
+          <pre class="cmd-card-usage"><code>forge optimize walk-forward SYMBOL --strategy ID --windows N</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--windows</span>
+            <span class="cmd-card-option">--metric</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/data/#forge-data-fetch">
+          <div class="cmd-card-name">forge data fetch</div>
+          <div class="cmd-card-desc">Fetch OHLCV from a provider and store as Parquet.</div>
+          <pre class="cmd-card-usage"><code>forge data fetch SYMBOL --period 5y --interval 1d</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--period</span>
+            <span class="cmd-card-option">--interval</span>
+            <span class="cmd-card-option">--watchlist</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/strategy/#forge-strategy-save">
+          <div class="cmd-card-name">forge strategy save</div>
+          <div class="cmd-card-desc">Register a strategy JSON to the registry (optionally recorded in the Journal).</div>
+          <pre class="cmd-card-usage"><code>forge strategy save FILE_PATH</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--force</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/journal/#forge-journal-show">
+          <div class="cmd-card-name">forge journal show</div>
+          <div class="cmd-card-desc">Show the full history of a strategy (snapshots, runs, tags, live summary).</div>
+          <pre class="cmd-card-usage"><code>forge journal show STRATEGY_ID</code></pre>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+      </div>
+
+      <h2 class="section-heading">All Command Groups</h2>
+      <table class="cmd-table">
+        <thead>
+          <tr><th>Group</th><th>Description</th><th>Subcommands</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="/en/docs/cli-reference/backtest/"><code>forge backtest</code></a></td>
+            <td>Backtest execution, scanning, custom experiments</td>
+            <td>11</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/optimize/"><code>forge optimize</code></a></td>
+            <td>Parameter optimization (grid / bayes / wfa)</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td>
+            <td>Strategy JSON save / validate / apply</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/data/"><code>forge data</code></a></td>
+            <td>Historical data fetch / update</td>
+            <td>4</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/journal/"><code>forge journal</code></a></td>
+            <td>Trading journal and trade analysis</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/live/"><code>forge live</code></a></td>
+            <td>Live trading and broker integration</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/other/">Other commands</a></td>
+            <td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> and more</td>
+            <td>10 groups</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout" style="margin-top: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          For complete subcommand listings, options, return values, and sample output for each group,
+          see the CLI Reference in the official docs.
+        </p>
+        <a href="/en/docs/cli-reference/" class="btn-primary">
+          Open CLI Reference →
+        </a>
+      </div>
+
+      <div class="callout" style="margin-top: 1rem;">
+        <p>If you need help, contact <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a>.</p>
+      </div>
+    </div>
+
+  </div>
+
+  <footer>
+    <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
+    <div class="lang-content lang-ja"><div class="footer-links"><a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="docs.html">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a></div></div>
+    <div class="lang-content lang-en"><div class="footer-links"><a href="index.html">Home</a><a href="install.html">Install</a><a href="docs.html">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a></div></div>
+  </footer>
+
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <script type="text/babel" src="../site-header.jsx"></script>
+  <script type="text/babel">
+    renderStandaloneHeader({ active: 'docs' });
+  </script>
+</body>
+</html>
+```
+
+Write ツールで `templates/docs.html.j2` の全内容を上記で置換する。**注意**: 既存ファイルなので Write 前に Read で 1 回読んでから Write すること（Claude Code の Write tool 仕様上、既存ファイルへの上書きは Read 必須）。
+
+- [ ] **Step 3: テンプレ全体の構造検証**
+
+```bash
+wc -l templates/docs.html.j2
+```
+期待: 約 290〜320 行（1012 行から大幅圧縮）
+
+```bash
+grep -c '<h1 class="page-title">' templates/docs.html.j2
+```
+期待: `2`（ja + en の各ヒーロー）
+
+```bash
+grep -c 'cmd-card-grid' templates/docs.html.j2
+```
+期待: `2`（ja + en で各 1 グリッド）+ CSS 定義 1 = `3`。CSS のみカウントする場合は別 grep。
+
+```bash
+grep -c '<a class="cmd-card"' templates/docs.html.j2
+```
+期待: `12`（ja + en で 6 カードずつ）
+
+```bash
+grep -c 'btn-primary' templates/docs.html.j2
+```
+期待: `4`（上下 callout × ja/en）
+
+```bash
+grep -c '/ja/docs/cli-reference/' templates/docs.html.j2
+```
+期待: `15`（ja セクションのリンク総数: 上 callout 1 + 6 カード + 7 表行 + 下 callout 1 = 15）
+
+```bash
+grep -c '/en/docs/cli-reference/' templates/docs.html.j2
+```
+期待: `15`（en セクション同等）
+
+```bash
+grep -c 'forge コマンドの早見表' templates/docs.html.j2
+```
+期待: `1`
+
+```bash
+grep -c 'forge Command Quick Reference' templates/docs.html.j2
+```
+期待: `1`
+
+```bash
+grep -c 'cmd-nav-list\|doc-layout\|option-table\|payload-table\|step-list' templates/docs.html.j2
+```
+期待: `0`（削除セクション関連の class が完全に消えている）
+
+```bash
+grep -c 'エンドツーエンド\|TradingView\|alpha-strike' templates/docs.html.j2
+```
+期待: `0`（ガイド 3 セクションが完全削除）
+
+- [ ] **Step 4: Jinja2 変数とヘッダー/フッターの保持を検証**
+
+```bash
+grep -c '{{ lang }}' templates/docs.html.j2
+```
+期待: `4`（html lang, theme スクリプト 2 箇所、body data-lang）
+
+```bash
+grep -c '{{ canonical_url }}\|{{ hreflang_ja }}\|{{ hreflang_en }}\|{{ json_ld }}' templates/docs.html.j2
+```
+期待: `4`（各 1 件、SEO 維持）
+
+```bash
+grep -c "renderStandaloneHeader({ active: 'docs' })" templates/docs.html.j2
+```
+期待: `1`
+
+```bash
+grep -c 'site-header.jsx' templates/docs.html.j2
+```
+期待: `1`
+
+- [ ] **Step 5: テンプレをステージング & コミット**
+
+```bash
+git add templates/docs.html.j2
+git status
+git commit -m "feat: docs.html を「カタログ + 主要 6 コマンド」に再構成
+
+- 1012 行から約 300 行へ大幅簡素化
+- ヒーロー + 主要 6 コマンドのカードグリッド + 全 7 グループのカタログ表 +
+  上下 2 箇所の cli-reference 誘導 callout に再構成
+- 削除: 左サイドバー、forge {data,strategy,backtest,optimize,pine,dashboard,license}
+  セクション、ワークフロー / TradingView / alpha-strike 連携の 3 ガイドセクション
+- 詳細は /{ja,en}/docs/cli-reference/ へリンク（MkDocs を正本に）
+
+Refs #65"
+```
+
+期待: コミット成功、`templates/docs.html.j2` が 1 ファイル変更として記録される。
+
+```bash
+git log --oneline -3
+```
+期待: 最新コミットが上記メッセージで記録されている。
+
+---
+
+## Task 2: build.py を実行してビルド成果物を再生成 → コミット 2
+
+**Files:**
+- Generate: `ja/docs.html`
+- Generate: `en/docs.html`
+
+- [ ] **Step 1: build.py を実行**
+
+```bash
+uv run python build.py
+```
+期待出力（順不同）:
+```
+  ✓ ja/index.html
+  ✓ ja/install.html
+  ✓ ja/docs.html
+  ✓ ja/tutorial-strategy.html
+  ✓ ja/privacy.html
+  ✓ ja/terms.html
+  ✓ en/index.html
+  ✓ en/install.html
+  ✓ en/docs.html
+  ✓ en/tutorial-strategy.html
+  ✓ en/privacy.html
+  ✓ en/terms.html
+  ✓ robots.txt
+  ✓ sitemap.xml
+Build complete.
+```
+
+- [ ] **Step 2: 副作用チェック（docs.html 以外が変わっていないこと）**
+
+```bash
+git diff --stat ja/ en/ robots.txt sitemap.xml
+```
+期待: `ja/docs.html` と `en/docs.html` のみが変更ファイルに含まれる。他のページ（index.html, install.html, tutorial-strategy.html, privacy.html, terms.html）と robots.txt / sitemap.xml に差分が無い。
+
+- [ ] **Step 3: ja/docs.html の構造確認**
+
+```bash
+grep -c '<a class="cmd-card"' ja/docs.html
+```
+期待: `12`（ja + en の各カードが SPA 構造で 1 ファイルに同梱）
+
+```bash
+grep -c 'btn-primary' ja/docs.html
+```
+期待: `4`（上下 callout × ja/en 合算）
+
+```bash
+grep -c '/ja/docs/cli-reference/' ja/docs.html
+```
+期待: `15`（ja セクション内のリンク総数）
+
+```bash
+grep -c '/en/docs/cli-reference/' ja/docs.html
+```
+期待: `15`（同一ファイル内の en セクションのリンク）
+
+```bash
+grep -c 'forge コマンドの早見表' ja/docs.html
+```
+期待: `1`
+
+```bash
+grep -c 'forge Command Quick Reference' ja/docs.html
+```
+期待: `1`（同一ファイル内に en コンテンツも含まれる SPA 構造）
+
+```bash
+grep -c 'cmd-nav-list\|エンドツーエンド\|TradingView\|alpha-strike' ja/docs.html
+```
+期待: `0`（削除セクション関連の文字列が完全に消えている）
+
+```bash
+grep -c '"@context"' ja/docs.html
+```
+期待: `1`（JSON-LD 維持）
+
+```bash
+grep -c 'hreflang=' ja/docs.html
+```
+期待: `3`（ja, en, x-default）
+
+```bash
+grep -c '<title>ドキュメント — Alforge Labs</title>' ja/docs.html
+```
+期待: `1`（seo.yaml の docs.ja.title）
+
+- [ ] **Step 4: en/docs.html の構造確認**
+
+```bash
+grep -c '<a class="cmd-card"' en/docs.html
+```
+期待: `12`
+
+```bash
+grep -c 'btn-primary' en/docs.html
+```
+期待: `4`
+
+```bash
+grep -c 'forge Command Quick Reference' en/docs.html
+```
+期待: `1`
+
+```bash
+grep -c '<title>Documentation — Alforge Labs</title>' en/docs.html
+```
+期待: `1`（seo.yaml の docs.en.title）
+
+```bash
+grep -c '"@context"' en/docs.html
+```
+期待: `1`
+
+- [ ] **Step 5: ローカルブラウザ確認はスキップ**
+
+`open` は subagent では実行できないため、Step 5 は省略。Step 3 と Step 4 の grep 検証で構造確認は十分。controller / ユーザー側で目視確認する。
+
+- [ ] **Step 6: ビルド成果物をステージング & コミット**
+
+```bash
+git add ja/docs.html en/docs.html
+git status
+git commit -m "chore: docs.html の build.py 出力を再生成
+
+templates/docs.html.j2 の再構成に伴うビルド成果物の更新。
+
+Refs #65"
+```
+
+期待: コミット成功、`ja/docs.html` と `en/docs.html` の 2 ファイルが変更として記録される。
+
+```bash
+git log --oneline -5
+```
+期待: 直近 3 コミット（spec / テンプレ書き直し / ビルド成果物）が確認できる。
+
+---
+
+## Task 3: MkDocs アンカー存在検証
+
+**Files:**
+- 変更なし（検証のみ）
+
+カードの href が指す MkDocs ビルド済みアンカー (`#forge-{group}-{sub}`) が実在することを確認する。
+
+- [ ] **Step 1: 各サブコマンドアンカーの存在確認**
+
+```bash
+grep -c 'id="forge-backtest-run"' ja/docs/cli-reference/backtest/index.html
+```
+期待: `1`
+
+```bash
+grep -c 'id="forge-optimize-run"' ja/docs/cli-reference/optimize/index.html
+```
+期待: `1`
+
+```bash
+grep -c 'id="forge-optimize-walk-forward"' ja/docs/cli-reference/optimize/index.html
+```
+期待: `1`
+
+```bash
+grep -c 'id="forge-data-fetch"' ja/docs/cli-reference/data/index.html
+```
+期待: `1`
+
+```bash
+grep -c 'id="forge-strategy-save"' ja/docs/cli-reference/strategy/index.html
+```
+期待: `1`
+
+```bash
+grep -c 'id="forge-journal-show"' ja/docs/cli-reference/journal/index.html
+```
+期待: `1`
+
+- [ ] **Step 2: 英語版アンカーの存在確認**
+
+```bash
+grep -c 'id="forge-backtest-run"' en/docs/cli-reference/backtest/index.html
+```
+期待: `1`
+
+```bash
+grep -c 'id="forge-optimize-run"' en/docs/cli-reference/optimize/index.html
+```
+期待: `1`
+
+```bash
+grep -c 'id="forge-optimize-walk-forward"' en/docs/cli-reference/optimize/index.html
+```
+期待: `1`
+
+```bash
+grep -c 'id="forge-data-fetch"' en/docs/cli-reference/data/index.html
+```
+期待: `1`
+
+```bash
+grep -c 'id="forge-strategy-save"' en/docs/cli-reference/strategy/index.html
+```
+期待: `1`
+
+```bash
+grep -c 'id="forge-journal-show"' en/docs/cli-reference/journal/index.html
+```
+期待: `1`
+
+- [ ] **Step 3: グループページの存在確認**
+
+```bash
+ls ja/docs/cli-reference/{backtest,optimize,strategy,data,journal,live,other}/index.html 2>/dev/null | wc -l
+```
+期待: `7`
+
+```bash
+ls en/docs/cli-reference/{backtest,optimize,strategy,data,journal,live,other}/index.html 2>/dev/null | wc -l
+```
+期待: `7`
+
+すべて `1` または `7` が返ることを確認すること。もし `0` が返るアンカーがあれば、MkDocs ビルドのアンカー命名規約と Plan の前提（`forge-{group}-{sub}` 形式）が一致していないため、controller に BLOCKED で報告する。
+
+- [ ] **Step 4: コミット不要、Task 3 はチェックのみ**
+
+このタスクは検証のみで、新たなコミットは作成しない。万一アンカーが見つからなかった場合、Task 1 のテンプレを修正して再度ビルド成果物を更新する必要がある。
+
+---
+
+## Task 4: PR 作成
+
+**Files:**
+- 変更なし（GitHub PR 作成のみ）
+
+- [ ] **Step 1: ローカル状態確認**
+
+```bash
+git status
+```
+期待: `On branch feat/docs-issue-65-docs-html-slim`、working tree clean。
+
+```bash
+git log --oneline main..HEAD
+```
+期待: 3 コミットが確認できる:
+- spec ドキュメント (6329bf8)
+- plan ドキュメント (本コミット、Task 0 で作成 — 注: writing-plans 後に commit 済み)
+- feat: docs.html 再構成
+- chore: ビルド成果物再生成
+
+注: writing-plans skill の plan 文書もこのブランチ上にあるはず。実装時に main..HEAD で確認する。
+
+- [ ] **Step 2: リモートに push**
+
+```bash
+git push -u origin feat/docs-issue-65-docs-html-slim
+```
+期待: 新規ブランチが GitHub に push される。
+
+- [ ] **Step 3: PR 作成**
+
+```bash
+gh pr create --title "feat: docs.html を「カタログ + 主要 6 コマンド」に再構成 (#65)" --body "$(cat <<'EOF'
+## Summary
+
+- \`templates/docs.html.j2\` を 1012 行から約 300 行へ簡素化し、ヒーロー + 主要 6 コマンドのカードグリッド + 全 7 グループのカタログ表に再構成
+- ヒーロー直下とカタログ表後の 2 箇所に MkDocs 公式 cli-reference への誘導 callout を追加
+- 削除: 左サイドバー目次、\`forge {data,strategy,backtest,optimize,pine,dashboard,license}\` の 7 セクション、ワークフロー / TradingView / alpha-strike 連携の 3 ガイドセクション
+- カードクリックで \`/{ja,en}/docs/cli-reference/{group}/#forge-{group}-{sub}\` のサブコマンドアンカーへ直接遷移
+
+## 設計ドキュメント
+
+\`docs/superpowers/specs/2026-04-30-alforge-labs-issue-65-docs-html-slim-design.md\`
+
+## 実装計画
+
+\`docs/superpowers/plans/2026-04-30-alforge-labs-issue-65-docs-html-slim.md\`
+
+## Test plan
+
+- [x] \`uv run python build.py\` が正常終了し \`{ja,en}/docs.html\` のみが再生成される
+- [x] \`grep -c '<a class=\"cmd-card\"' ja/docs.html\` が \`12\` を返す（ja+en 各 6 カード）
+- [x] \`grep -c 'btn-primary' ja/docs.html\` が \`4\` を返す（上下 callout × ja/en）
+- [x] MkDocs cli-reference の各サブコマンドアンカー（\`#forge-{group}-{sub}\`）が実在
+- [x] \`cmd-nav-list\`, \`エンドツーエンド\`, \`TradingView\`, \`alpha-strike\` がいずれも残っていない
+- [x] JSON-LD と hreflang が維持されている
+- [ ] 公開後ブラウザでヒーロー / カードグリッド / カタログ表 / 各リンクの動作を確認
+
+## SEO 影響評価
+
+- \`seo.yaml\` の docs ページコピーは無変更
+- \`sitemap.xml\` の docs エントリ priority \`0.9\` / changefreq \`weekly\` 維持
+- JSON-LD（BreadcrumbList）は build.py で動的生成、構造変更なし
+- hreflang リンク（ja / en / x-default）維持
+
+## フォローアップ（別 issue で対応推奨）
+
+- 削除した 3 ガイドセクション（ワークフロー / TradingView / alpha-strike 連携）の MkDocs 移植
+- React/React-DOM の production build 切り替え（既存 issue #79）
+- HTML テンプレートの lang-content 並列構造の見直し（既存 issue #78）
+
+Closes #65
+EOF
+)"
+```
+期待: PR 番号と URL が表示される。
+
+- [ ] **Step 4: PR 状態確認**
+
+```bash
+gh pr view --json number,url,state,statusCheckRollup
+```
+期待: PR がオープン状態、status check は空 or success（GitHub Pages リポジトリで通常 CI なし）。
+
+- [ ] **Step 5: マージは実施しない**
+
+ユーザー承認待ち。`gh pr merge` は controller 側で実行する。
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+| Spec 要件 | 対応タスク |
+|---|---|
+| ヒーロー: 「forge コマンドの早見表」 | Task 1 Step 2（テンプレ全文に含む） |
+| Docs 誘導 callout（上） | Task 1 Step 2 |
+| 主要 6 コマンドのカードグリッド (CSS Grid) | Task 1 Step 2 |
+| カードのリンク先 (`#forge-{group}-{sub}` アンカー) | Task 1 Step 2、Task 3 で検証 |
+| 全コマンドカタログ表（7 行） | Task 1 Step 2 |
+| Docs 誘導 callout（下） | Task 1 Step 2 |
+| 削除: 左サイドバー、7 コマンドセクション、3 ガイド | Task 1 Step 2（Write で完全置換）、Step 3 で検証 |
+| 新規 CSS をテンプレ内 `<style>` に局所追加 | Task 1 Step 2 |
+| `seo.yaml` 無変更 | （タスク内で触らない） |
+| `page.css` 無変更 | （タスク内で触らない） |
+| build.py で再生成 | Task 2 |
+| MkDocs アンカー存在検証 | Task 3 |
+| 2 コミット粒度 | Task 1 Step 5（テンプレ）+ Task 2 Step 6（成果物） |
+| PR タイトル / Closes #65 | Task 4 Step 3 |
+
+すべての spec 要件にタスクが割り当てられている。ギャップなし。
+
+### Placeholder scan
+
+- [x] "TBD" / "TODO" / "implement later" — なし
+- [x] テンプレ全文が完全に展開されている（Task 1 Step 2）
+- [x] grep 検証コマンドはすべて期待値が具体値で書かれている
+- [x] PR 本文 HEREDOC も実テキストで完成している
+
+### Type / signature 一貫性
+
+- [x] CSS class 名 (`.cmd-card-grid`, `.cmd-card`, `.cmd-card-name`, `.cmd-card-desc`, `.cmd-card-usage`, `.cmd-card-options`, `.cmd-card-option`, `.cmd-card-link`) が CSS 定義と HTML 利用箇所で完全一致
+- [x] カードの href URL (`/ja/docs/cli-reference/{group}/#forge-{group}-{sub}`) が Task 1 と Task 3 の検証で一致
+- [x] カタログ表のグループ別 URL (`/ja/docs/cli-reference/{group}/`) と Task 3 のディレクトリ存在チェック対象が一致
+- [x] ヒーロー文言「forge コマンドの早見表」「forge Command Quick Reference」が Task 1 内と PR タイトル / 検証コマンドで一致

--- a/docs/superpowers/specs/2026-04-30-alforge-labs-issue-65-docs-html-slim-design.md
+++ b/docs/superpowers/specs/2026-04-30-alforge-labs-issue-65-docs-html-slim-design.md
@@ -1,0 +1,516 @@
+# alforge-labs Issue #65 — docs.html 簡素化と「カタログ + 主要 6 コマンド」再構成
+
+## 目的
+
+`{ja,en}/docs.html`（および Jinja2 テンプレート `templates/docs.html.j2`）を簡素化し、現状 1012 行の包括的コマンドリファレンスを「**ヒーロー + 主要 6 コマンドのカードグリッド + 全グループカタログ表 + cli-reference 誘導**」のページに再構成する。MkDocs `cli-reference/` を**正本（source of truth）** とし、HTML ランディングは「サブコマンド早見表」として最短到達を担う。
+
+## 背景
+
+- #49〜#72 で MkDocs 側の `cli-reference/` を「全コマンドカタログ + 7 サブページ（76 サブコマンドの完全詳細）」として整備済み（コミット `3043fbf`〜`a50fe1a`）。
+- 現状の `docs.html` は左サイドバー目次 + `forge data/strategy/backtest/optimize/pine/dashboard/license` の 7 セクション + 「ワークフロー」「TradingView 反映」「alpha-strike 連携」の 3 ガイドセクションで構成され、1012 行に及ぶ。
+- #56 (install.html 簡素化) と同じく MkDocs を正本にする方針で、HTML ランディングは「最短到達」「SEO 維持」が役割。
+
+## スコープ確定事項（ブレインストーミングで決定）
+
+| 論点 | 決定 |
+|------|------|
+| 3 ガイドセクション（workflow / tradingview / strike） | **すべて削除**、将来 MkDocs に移植する別 issue を登録 |
+| 主要 6 コマンドの記述構造 | **ダッシュボード風カードグリッド**（CSS Grid 3 列、auto-fit） |
+| その他コマンドのカタログ | cli-reference の MkDocs グループページに対応する **7 行の表**（backtest/optimize/strategy/data/journal/live/その他） |
+| 左サイドバー（cmd-nav） | **削除**（簡素化後の section 数が少ないため不要） |
+| Docs 誘導の配置 | **ヒーロー直下とカタログ表のあとの 2 箇所** |
+| 実装アプローチ | `templates/docs.html.j2` を **ゼロから書き直し**（既存テンプレ上下の SEO/メタ/ヘッダー/フッター部分はコピーで保護） |
+| 新規 CSS | `templates/docs.html.j2` 内の `<style>` ブロックに `.cmd-card-grid` / `.cmd-card` 関連のローカル CSS を追加（page.css は無変更） |
+
+## ページ構造（簡素化後）
+
+```
+1. ヒーロー
+   - page-label: "Documentation"
+   - h1: "forge コマンドの早見表" / "forge Command Quick Reference"
+   - subtitle: 「主要 6 コマンドのカードと全コマンドカタログ。詳細は公式ドキュメントへ」
+
+2. Docs 誘導 callout（上）— 新規
+   - .callout + .btn-primary
+   - href="/ja/docs/cli-reference/" / "/en/docs/cli-reference/"
+
+3. 主要 6 コマンドのカードグリッド
+   - h2: "主要コマンド" / "Top Commands"
+   - .cmd-card-grid（CSS Grid: repeat(auto-fit, minmax(280px, 1fr))）
+   - 6 カード:
+     a. forge backtest run
+     b. forge optimize run
+     c. forge optimize walk-forward
+     d. forge data fetch
+     e. forge strategy save
+     f. forge journal show
+   - 各カードは <a> タグ（全体クリック可能）、cli-reference のサブコマンドアンカーへリンク
+
+4. 全コマンドカタログ
+   - h2: "全コマンドカタログ" / "All Command Groups"
+   - .cmd-table（既存スタイル流用）
+   - 7 行: backtest(11) / optimize(9) / strategy(7) / data(4) / journal(7) / live(9) / その他 (10 グループ)
+   - グループ名のセルは cli-reference の各ページへリンク
+
+5. Docs 誘導 callout（下）— 新規
+   - 「全 76 サブコマンドの完全詳細はドキュメントへ」
+
+6. サポートメール callout（既存維持）
+   - support@alforgelabs.com
+```
+
+### 削除されるセクション（現状約 700+ 行を削除）
+
+| セクション | 削除理由 | MkDocs での代替 |
+|---|---|---|
+| 左サイドバー `<aside class="cmd-nav">` + 関連 `<style>` (~50 行) | 簡素化後の section 数が少なく不要 | （MkDocs Material のサイドバー） |
+| `forge data` 既存セクション (line 158-187) | 主要 fetch のみカード化、他は MkDocs cli-reference/data/ へ | `mkdocs_src/{ja,en}/cli-reference/data.md` |
+| `forge strategy` 既存セクション (line 192-220) | 同上、save のみカード化 | `cli-reference/strategy.md` |
+| `forge backtest` 既存セクション (line 225-268) | 同上、run のみカード化 | `cli-reference/backtest.md` |
+| `forge optimize` 既存セクション (line 273-305) | 同上、run/walk-forward のみカード化 | `cli-reference/optimize.md` |
+| `forge pine` セクション (line 310-340) | カタログ表で参照 | `cli-reference/other.md` |
+| `forge dashboard` セクション (line 345-351) | カタログ表で参照 | `cli-reference/other.md` |
+| `forge license` セクション (line 353-366) | カタログ表で参照 | `cli-reference/other.md` |
+| 「エンドツーエンド戦略開発ワークフロー」セクション (line 371-443) | 別 issue で MkDocs に移植予定 | （未） |
+| 「TradingView への Pine Script 反映」セクション (line 448-488) | 別 issue で MkDocs に移植予定 | （未） |
+| 「TradingView と alpha-strike の連携」セクション (line 493-562) | 別 issue で MkDocs に移植予定 | （未） |
+| 関連 CSS（`.doc-layout`, `.option-table`, `.payload-table`, `.step-list` 関連 ~80 行） | 削除セクション専用スタイル | （不要） |
+
+### 維持されるセクション（変更なし）
+
+- Jinja2 テンプレ上部（meta タグ・JSON-LD・hreflang・preconnect・theme 初期化スクリプト）
+- ヘッダー（`<div id="site-header"></div>` + `site-header.jsx`）
+- フッター（言語別リンク）
+- React/Babel スクリプトロード
+
+## HTML スニペット
+
+### ヒーロー
+
+**ja**:
+```html
+<div class="page-label">Documentation</div>
+<h1 class="page-title">forge コマンドの早見表</h1>
+<p class="page-subtitle">主要 6 コマンドのカードと全コマンドカタログ。詳細パラメータと出力例は公式ドキュメントへ。</p>
+```
+
+**en**:
+```html
+<div class="page-label">Documentation</div>
+<h1 class="page-title">forge Command Quick Reference</h1>
+<p class="page-subtitle">Cards for the six core commands plus a full command catalog. Detailed parameters and output examples live in the official docs.</p>
+```
+
+### Docs 誘導 callout（上、ヒーロー直下）
+
+**ja**:
+```html
+<div class="callout" style="margin-bottom: 2rem;">
+  <p style="margin-bottom: 0.75rem;">
+    全 76 サブコマンドの詳細パラメータ、出力例、エラーコードは
+    <strong>公式ドキュメント</strong>を参照してください。
+  </p>
+  <a href="/ja/docs/cli-reference/" class="btn-primary">
+    CLI リファレンスを開く →
+  </a>
+</div>
+```
+
+**en**:
+```html
+<div class="callout" style="margin-bottom: 2rem;">
+  <p style="margin-bottom: 0.75rem;">
+    For detailed parameters, output examples, and error codes for all 76 subcommands,
+    see the <strong>official documentation</strong>.
+  </p>
+  <a href="/en/docs/cli-reference/" class="btn-primary">
+    Open CLI Reference →
+  </a>
+</div>
+```
+
+### Docs 誘導 callout（下、カタログ表のあと）
+
+**ja**:
+```html
+<div class="callout" style="margin-top: 2rem;">
+  <p style="margin-bottom: 0.75rem;">
+    各グループの完全なサブコマンドリスト、オプション一覧、戻り値、サンプル出力は
+    ドキュメントの CLI リファレンスを参照してください。
+  </p>
+  <a href="/ja/docs/cli-reference/" class="btn-primary">
+    CLI リファレンスを開く →
+  </a>
+</div>
+```
+
+**en**:
+```html
+<div class="callout" style="margin-top: 2rem;">
+  <p style="margin-bottom: 0.75rem;">
+    For complete subcommand listings, options, return values, and sample output for each group,
+    see the CLI Reference in the official docs.
+  </p>
+  <a href="/en/docs/cli-reference/" class="btn-primary">
+    Open CLI Reference →
+  </a>
+</div>
+```
+
+### カードグリッド用 CSS（`templates/docs.html.j2` 内 `<style>` に追加）
+
+```css
+/* ── CARD GRID ── */
+.cmd-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0 2.5rem;
+}
+.cmd-card {
+  display: block;
+  padding: 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  text-decoration: none;
+  transition: border-color 0.15s, transform 0.15s;
+}
+.cmd-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+.cmd-card-name {
+  font-family: var(--mono);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--accent);
+  margin-bottom: 0.4rem;
+}
+.cmd-card-desc { font-size: 0.85rem; color: var(--text2); margin-bottom: 0.75rem; }
+.cmd-card-usage {
+  background: var(--bg2);
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--text);
+  margin: 0 0 0.75rem;
+  overflow-x: auto;
+}
+.cmd-card-options { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 0.75rem; }
+.cmd-card-option {
+  font-family: var(--mono); font-size: 0.72rem;
+  padding: 0.2rem 0.5rem;
+  background: var(--accent-bg); color: var(--accent);
+  border-radius: 4px;
+}
+.cmd-card-link {
+  font-size: 0.78rem;
+  color: var(--text3);
+  font-family: var(--mono);
+}
+.cmd-card:hover .cmd-card-link { color: var(--accent); }
+```
+
+### 6 カードのコンテンツ（ja の例、en は文言のみ差替）
+
+#### Card 1: forge backtest run
+
+```html
+<a class="cmd-card" href="/ja/docs/cli-reference/backtest/#forge-backtest-run">
+  <div class="cmd-card-name">forge backtest run</div>
+  <div class="cmd-card-desc">単一銘柄に戦略を適用してバックテストを実行する。</div>
+  <pre class="cmd-card-usage"><code>forge backtest run SYMBOL --strategy ID</code></pre>
+  <div class="cmd-card-options">
+    <span class="cmd-card-option">--strategy</span>
+    <span class="cmd-card-option">--start</span>
+    <span class="cmd-card-option">--json</span>
+  </div>
+  <div class="cmd-card-link">cli-reference で詳細 →</div>
+</a>
+```
+
+#### Card 2: forge optimize run
+
+```html
+<a class="cmd-card" href="/ja/docs/cli-reference/optimize/#forge-optimize-run">
+  <div class="cmd-card-name">forge optimize run</div>
+  <div class="cmd-card-desc">Optuna によるパラメータ最適化（TPE）。多目的最適化にも対応。</div>
+  <pre class="cmd-card-usage"><code>forge optimize run SYMBOL --strategy ID</code></pre>
+  <div class="cmd-card-options">
+    <span class="cmd-card-option">--metric</span>
+    <span class="cmd-card-option">--trials</span>
+    <span class="cmd-card-option">--apply</span>
+  </div>
+  <div class="cmd-card-link">cli-reference で詳細 →</div>
+</a>
+```
+
+#### Card 3: forge optimize walk-forward
+
+```html
+<a class="cmd-card" href="/ja/docs/cli-reference/optimize/#forge-optimize-walk-forward">
+  <div class="cmd-card-name">forge optimize walk-forward</div>
+  <div class="cmd-card-desc">時系列をウィンドウ分割し IS 最適化 → OOS 評価で過学習耐性を測定。</div>
+  <pre class="cmd-card-usage"><code>forge optimize walk-forward SYMBOL --strategy ID --windows N</code></pre>
+  <div class="cmd-card-options">
+    <span class="cmd-card-option">--windows</span>
+    <span class="cmd-card-option">--metric</span>
+  </div>
+  <div class="cmd-card-link">cli-reference で詳細 →</div>
+</a>
+```
+
+#### Card 4: forge data fetch
+
+```html
+<a class="cmd-card" href="/ja/docs/cli-reference/data/#forge-data-fetch">
+  <div class="cmd-card-name">forge data fetch</div>
+  <div class="cmd-card-desc">OHLCV をプロバイダーから取得し Parquet で保存。</div>
+  <pre class="cmd-card-usage"><code>forge data fetch SYMBOL --period 5y --interval 1d</code></pre>
+  <div class="cmd-card-options">
+    <span class="cmd-card-option">--period</span>
+    <span class="cmd-card-option">--interval</span>
+    <span class="cmd-card-option">--watchlist</span>
+  </div>
+  <div class="cmd-card-link">cli-reference で詳細 →</div>
+</a>
+```
+
+#### Card 5: forge strategy save
+
+```html
+<a class="cmd-card" href="/ja/docs/cli-reference/strategy/#forge-strategy-save">
+  <div class="cmd-card-name">forge strategy save</div>
+  <div class="cmd-card-desc">戦略 JSON をレジストリに登録（任意で Journal に記録）。</div>
+  <pre class="cmd-card-usage"><code>forge strategy save FILE_PATH</code></pre>
+  <div class="cmd-card-options">
+    <span class="cmd-card-option">--force</span>
+  </div>
+  <div class="cmd-card-link">cli-reference で詳細 →</div>
+</a>
+```
+
+#### Card 6: forge journal show
+
+```html
+<a class="cmd-card" href="/ja/docs/cli-reference/journal/#forge-journal-show">
+  <div class="cmd-card-name">forge journal show</div>
+  <div class="cmd-card-desc">戦略の全履歴（スナップショット・Runs・タグ・ライブサマリ）を表示。</div>
+  <pre class="cmd-card-usage"><code>forge journal show STRATEGY_ID</code></pre>
+  <div class="cmd-card-link">cli-reference で詳細 →</div>
+</a>
+```
+
+`forge journal show` は引数のみのため `.cmd-card-options` ブロックを省略。
+
+### 全コマンドカタログ表（ja）
+
+```html
+<h2 class="section-heading">全コマンドカタログ</h2>
+<table class="cmd-table">
+  <thead>
+    <tr><th>グループ</th><th>説明</th><th>サブコマンド数</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="/ja/docs/cli-reference/backtest/"><code>forge backtest</code></a></td>
+      <td>バックテスト実行・スキャン・カスタム実験</td>
+      <td>11</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/cli-reference/optimize/"><code>forge optimize</code></a></td>
+      <td>パラメータ最適化（grid / bayes / wfa）</td>
+      <td>9</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td>
+      <td>戦略 JSON の保存・検証・適用</td>
+      <td>7</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/cli-reference/data/"><code>forge data</code></a></td>
+      <td>ヒストリカルデータ取得・更新</td>
+      <td>4</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/cli-reference/journal/"><code>forge journal</code></a></td>
+      <td>取引ジャーナル・トレード分析</td>
+      <td>7</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/cli-reference/live/"><code>forge live</code></a></td>
+      <td>ライブトレーディング・ブローカー連携</td>
+      <td>9</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/cli-reference/other/">その他コマンド</a></td>
+      <td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> 他</td>
+      <td>10 グループ</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+### 全コマンドカタログ表（en）
+
+```html
+<h2 class="section-heading">All Command Groups</h2>
+<table class="cmd-table">
+  <thead>
+    <tr><th>Group</th><th>Description</th><th>Subcommands</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="/en/docs/cli-reference/backtest/"><code>forge backtest</code></a></td>
+      <td>Backtest execution, scanning, custom experiments</td>
+      <td>11</td>
+    </tr>
+    <tr>
+      <td><a href="/en/docs/cli-reference/optimize/"><code>forge optimize</code></a></td>
+      <td>Parameter optimization (grid / bayes / wfa)</td>
+      <td>9</td>
+    </tr>
+    <tr>
+      <td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td>
+      <td>Strategy JSON save / validate / apply</td>
+      <td>7</td>
+    </tr>
+    <tr>
+      <td><a href="/en/docs/cli-reference/data/"><code>forge data</code></a></td>
+      <td>Historical data fetch / update</td>
+      <td>4</td>
+    </tr>
+    <tr>
+      <td><a href="/en/docs/cli-reference/journal/"><code>forge journal</code></a></td>
+      <td>Trading journal and trade analysis</td>
+      <td>7</td>
+    </tr>
+    <tr>
+      <td><a href="/en/docs/cli-reference/live/"><code>forge live</code></a></td>
+      <td>Live trading and broker integration</td>
+      <td>9</td>
+    </tr>
+    <tr>
+      <td><a href="/en/docs/cli-reference/other/">Other commands</a></td>
+      <td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> and more</td>
+      <td>10 groups</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+## MkDocs アンカー検証
+
+カードの href（`/ja/docs/cli-reference/backtest/#forge-backtest-run` など）が実際の MkDocs ビルド成果物に存在することを実装フェーズで grep 検証する。MkDocs Material は `## forge backtest run` 見出しに対して `id="forge-backtest-run"` を pymdownx.toc で自動生成する規約。
+
+検証コマンド例:
+```bash
+grep -c 'id="forge-backtest-run"' ja/docs/cli-reference/backtest/index.html
+# 期待: 1
+
+grep -c 'id="forge-optimize-walk-forward"' ja/docs/cli-reference/optimize/index.html
+# 期待: 1
+```
+
+## 影響範囲（ファイル変更）
+
+| ファイル | 変更内容 |
+|---|---|
+| `templates/docs.html.j2` | 全書き直し（簡素化、構造刷新） |
+| `ja/docs.html` | `uv run python build.py` で再生成 |
+| `en/docs.html` | `uv run python build.py` で再生成 |
+| `seo.yaml` | **変更なし**（docs ページの title/description/keywords は依然正確） |
+| `sitemap.xml` | **変更なし**（priority 0.9 / changefreq weekly 維持） |
+| `robots.txt` | **変更なし** |
+| `page.css` | **変更なし**（カードグリッド CSS は `templates/docs.html.j2` 内の `<style>` ブロックに局所追加） |
+| MkDocs 関連 | **一切変更なし** |
+
+## ビルド & 検証
+
+```bash
+cd /Users/sakae/dev/alpha-trade/alforge-labs
+
+# 1. テンプレ書き直し後にビルド
+uv run python build.py
+
+# 2. 差分確認
+git diff --stat templates/docs.html.j2 ja/docs.html en/docs.html
+
+# 3. ビルド成果物の構造検証
+grep -c 'cmd-card' ja/docs.html  # 期待: 6 カード × 2 言語 = 多数（カードクラス使用箇所）
+grep -c 'btn-primary' ja/docs.html  # 期待: 4（上下 callout × ja/en）
+grep -c '/ja/docs/cli-reference/' ja/docs.html  # ja セクション内のリンク総数を確認
+grep -c 'forge コマンドの早見表' ja/docs.html  # 期待: 1
+grep -c 'forge Command Quick Reference' en/docs.html  # 期待: 1
+grep -c 'cmd-nav-list' ja/docs.html  # 期待: 0（左サイドバー削除）
+grep -c '"@context"' ja/docs.html  # 期待: 1（JSON-LD 維持）
+grep -c 'hreflang=' ja/docs.html  # 期待: 3
+
+# 4. 副作用チェック
+git diff --stat ja/ en/ robots.txt sitemap.xml
+# 期待: docs.html のみ変更、他ページ・robots/sitemap は無差分
+
+# 5. MkDocs アンカー存在確認
+grep -c 'id="forge-backtest-run"' ja/docs/cli-reference/backtest/index.html  # 期待: 1
+grep -c 'id="forge-optimize-run"' ja/docs/cli-reference/optimize/index.html  # 期待: 1
+grep -c 'id="forge-optimize-walk-forward"' ja/docs/cli-reference/optimize/index.html  # 期待: 1
+grep -c 'id="forge-data-fetch"' ja/docs/cli-reference/data/index.html  # 期待: 1
+grep -c 'id="forge-strategy-save"' ja/docs/cli-reference/strategy/index.html  # 期待: 1
+grep -c 'id="forge-journal-show"' ja/docs/cli-reference/journal/index.html  # 期待: 1
+
+# 6. ローカルブラウザ確認
+open ja/docs.html
+# 検証: ヒーロー / Docs 誘導 callout（上）/ 6 カード（クリックで cli-reference に飛ぶ） /
+#       全グループカタログ表 / Docs 誘導 callout（下）/ Support callout
+open en/docs.html
+# 同等を英語版で確認
+```
+
+## ロールバック
+
+すべて新規ブランチ上の変更でコミットされる:
+
+```bash
+git checkout main -- templates/docs.html.j2 ja/docs.html en/docs.html
+```
+
+または PR の squash commit を revert。MkDocs 関連ファイルには一切触らないため副作用なし。
+
+## コミット粒度
+
+ブランチ名: `feat/docs-issue-65-docs-html-slim`
+
+```
+コミット 1: feat: docs.html を「カタログ + 主要 6 コマンド」に再構成
+  対象: templates/docs.html.j2
+
+コミット 2: chore: docs.html の build.py 出力を再生成
+  対象: ja/docs.html, en/docs.html
+```
+
+## PR
+
+- タイトル: `feat: docs.html を「カタログ + 主要 6 コマンド」に再構成 (#65)`
+- 本文に `Closes #65` を含める
+- マージ後: `gh pr merge <N> --squash --delete-branch`
+
+## 受入条件チェック（issue #65 より転載）
+
+- [x] `/ja/docs.html` と `/en/docs.html` がスクロールせずに主要情報が読める短さに圧縮されている
+  - 1012 行 → 推定 350-400 行（主要 6 カード + 7 行表 + ヘッダー/フッター/SEO ブロック）
+- [x] `/ja/docs/cli-reference/` への目立つ導線がある
+  - ヒーロー直下の上部 callout、カタログ表後の下部 callout、各カードのクリック、各カタログ表行のリンク = 多数の導線
+- [x] `templates/docs.html.j2` の Jinja2 テンプレートも更新されている
+  - 正本としてテンプレを書き直し、`build.py` でビルド成果物を再生成
+- [x] 既存 SEO（seo.yaml、メタタグ、構造化データ）に大きな悪影響がない
+  - seo.yaml 無変更、JSON-LD は build.py で動的生成され構造変更なし、hreflang 維持
+
+## 今回スコープ外
+
+- ガイドコンテンツ（「エンドツーエンド戦略開発ワークフロー」「TradingView への Pine Script 反映」「TradingView と alpha-strike の連携」）の MkDocs への移植 → 別 issue として登録予定
+- `templates/docs.html.j2` の lang 並列構造（`lang-content lang-ja` / `lang-content lang-en`）の見直し → 別 issue (#78) で扱う
+- React/React-DOM の production build 切り替え → 別 issue (#79) で扱う
+- platform-tabs アクセシビリティ → docs.html ではタブを使用しないため該当なし

--- a/en/docs.html
+++ b/en/docs.html
@@ -10,7 +10,10 @@
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/docs.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/docs.html" />
   <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/en/docs.html" />
+  <meta property="og:title" content="AlphaForge CLI Documentation" />
+  <meta property="og:description" content="Command reference, strategy workflow, and TradingView integration — the official AlphaForge docs." />
   <meta property="og:image" content="https://alforgelabs.com/assets/og-image.png" />
   <meta property="og:locale" content="en_US" />
   <meta property="og:site_name" content="Alforge Labs" />
@@ -42,85 +45,58 @@
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../page.css" />
   <style>
-    .cmd-nav {
-      position: sticky; top: calc(var(--nav-h) + 1rem);
-      align-self: start;
+    /* ── CARD GRID ── */
+    .cmd-card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1rem;
+      margin: 1.5rem 0 2.5rem;
     }
-    .cmd-nav-list { list-style: none; padding: 0; }
-    .cmd-nav-list li a {
-      display: block; padding: 0.3rem 0.75rem;
-      font-family: var(--mono); font-size: 0.75rem; color: var(--text3);
-      text-decoration: none; border-left: 2px solid var(--border);
-      transition: color 0.15s, border-color 0.15s;
+    .cmd-card {
+      display: block;
+      padding: 1.25rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      text-decoration: none;
+      transition: border-color 0.15s, transform 0.15s;
     }
-    .cmd-nav-list li a:hover { color: var(--accent); border-left-color: var(--accent); }
-    .cmd-nav-list .nav-group {
-      font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.12em;
-      color: var(--text3); padding: 0.7rem 0.75rem 0.2rem; font-family: var(--mono);
-      border-left: 2px solid transparent;
+    .cmd-card:hover {
+      border-color: var(--accent);
+      transform: translateY(-2px);
+      text-decoration: none;
     }
-    .doc-layout {
-      display: grid; grid-template-columns: 190px 1fr; gap: 3rem;
+    .cmd-card-name {
+      font-family: var(--mono);
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--accent);
+      margin-bottom: 0.4rem;
     }
-    .option-table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
-    .option-table th {
-      font-family: var(--mono); font-size: 0.65rem; color: var(--text3);
-      text-transform: uppercase; letter-spacing: 0.1em;
-      text-align: left; padding: 0.4rem 0.75rem;
-      border-bottom: 1px solid var(--border); background: var(--bg2);
+    .cmd-card-desc { font-size: 0.85rem; color: var(--text2); margin-bottom: 0.75rem; }
+    .cmd-card-usage {
+      background: var(--bg2);
+      padding: 0.5rem 0.75rem;
+      border-radius: 4px;
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      color: var(--text);
+      margin: 0 0 0.75rem;
+      overflow-x: auto;
     }
-    .option-table td {
-      font-size: 0.85rem; color: var(--text2);
-      padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--border);
-      vertical-align: top;
+    .cmd-card-options { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 0.75rem; }
+    .cmd-card-option {
+      font-family: var(--mono); font-size: 0.72rem;
+      padding: 0.2rem 0.5rem;
+      background: var(--accent-bg); color: var(--accent);
+      border-radius: 4px;
     }
-    .option-table td:first-child code { color: var(--accent); font-family: var(--mono); font-size: 0.82rem; }
-    .option-table tr:last-child td { border-bottom: none; }
-    .cmd-section { scroll-margin-top: calc(var(--nav-h) + 2rem); margin-bottom: 3rem; }
-    .section-divider { border: none; border-top: 1px solid var(--border); margin: 3rem 0 2.5rem; }
-    .section-category {
-      font-size: 0.65rem; font-family: var(--mono); text-transform: uppercase;
-      letter-spacing: 0.14em; color: var(--accent); margin-bottom: 0.5rem;
+    .cmd-card-link {
+      font-size: 0.78rem;
+      color: var(--text3);
+      font-family: var(--mono);
     }
-    .step-list { list-style: none; padding: 0; counter-reset: steps; }
-    .step-list li {
-      counter-increment: steps;
-      display: grid; grid-template-columns: 2rem 1fr; gap: 1rem;
-      margin-bottom: 1.5rem; align-items: start;
-    }
-    .step-list li::before {
-      content: counter(steps);
-      display: flex; align-items: center; justify-content: center;
-      width: 1.75rem; height: 1.75rem;
-      background: var(--accent); color: var(--bg); border-radius: 50%;
-      font-size: 0.8rem; font-weight: 700; flex-shrink: 0; margin-top: 0.1rem;
-    }
-    .step-list li > div > strong { display: block; margin-bottom: 0.3rem; }
-    .callout {
-      background: var(--bg2); border-left: 3px solid var(--accent);
-      padding: 0.85rem 1rem; border-radius: 0 6px 6px 0;
-      font-size: 0.88rem; color: var(--text2); margin: 0.75rem 0 1rem;
-    }
-    .callout code { font-family: var(--mono); font-size: 0.82rem; color: var(--accent); }
-    .payload-table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
-    .payload-table th {
-      font-family: var(--mono); font-size: 0.65rem; color: var(--text3);
-      text-transform: uppercase; letter-spacing: 0.1em;
-      text-align: left; padding: 0.4rem 0.75rem;
-      border-bottom: 1px solid var(--border); background: var(--bg2);
-    }
-    .payload-table td {
-      font-size: 0.83rem; color: var(--text2);
-      padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border);
-      vertical-align: top;
-    }
-    .payload-table td:first-child code { color: var(--amber); font-family: var(--mono); font-size: 0.8rem; }
-    .payload-table td .req { font-size: 0.7rem; color: var(--red, #f87171); }
-    .payload-table tr:last-child td { border-bottom: none; }
-    @media (max-width: 768px) {
-      .doc-layout { grid-template-columns: 1fr; }
-      .cmd-nav { display: none; }
-    }
+    .cmd-card:hover .cmd-card-link { color: var(--accent); }
   </style>
   <script>
     (function() {
@@ -138,877 +114,291 @@
 <body data-theme="dark" data-lang="en">
   <div id="site-header"></div>
 
-  <div class="page-wrap" style="max-width: 1060px;">
+  <div class="page-wrap">
 
     <!-- ==================== 日本語版 ==================== -->
     <div class="lang-content lang-ja">
       <div class="page-label">Documentation</div>
-      <h1 class="page-title">ドキュメント</h1>
-      <p class="page-subtitle">コマンドリファレンス、戦略開発ワークフロー、TradingView 連携ガイド。</p>
-
-      <div class="doc-layout" style="margin-top: 2rem;">
-        <nav class="cmd-nav">
-          <ul class="cmd-nav-list">
-            <li class="nav-group">データ</li>
-            <li><a href="#ja-data">data</a></li>
-            <li class="nav-group">戦略</li>
-            <li><a href="#ja-strategy">strategy</a></li>
-            <li class="nav-group">バックテスト</li>
-            <li><a href="#ja-backtest">backtest</a></li>
-            <li class="nav-group">最適化</li>
-            <li><a href="#ja-optimize">optimize</a></li>
-            <li class="nav-group">Pine Script</li>
-            <li><a href="#ja-pine">pine</a></li>
-            <li class="nav-group">その他</li>
-            <li><a href="#ja-dashboard">dashboard</a></li>
-            <li><a href="#ja-license">license</a></li>
-            <li class="nav-group">ガイド</li>
-            <li><a href="#ja-workflow">開発ワークフロー</a></li>
-            <li><a href="#ja-tradingview">TradingView連携</a></li>
-            <li><a href="#ja-strike">alpha-strike連携</a></li>
-          </ul>
-        </nav>
-
-        <div>
-
-          <!-- data -->
-          <section class="cmd-section" id="ja-data">
-            <div class="section-category">データ管理</div>
-            <h2 class="section-heading">forge data</h2>
-            <p>ヒストリカル市場データの取得・更新・管理を行います。データは <code>alpha-strategies/data/historical/</code> に Parquet 形式で保存されます。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge data fetch &lt;SYMBOL&gt;</code></td><td>指定シンボルのヒストリカルデータを取得・保存</td></tr>
-                <tr><td><code>forge data update</code></td><td>保存済み全データを最新日まで差分更新</td></tr>
-                <tr><td><code>forge data update --symbol &lt;SYMBOL&gt;</code></td><td>特定シンボルのみ更新</td></tr>
-                <tr><td><code>forge data list</code></td><td>保存済みデータ一覧を表示</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># 初回取得
-forge data fetch USDJPY
-forge data fetch CL=F
-forge data fetch SPY QQQ NAS100
-
-# 一括差分更新
-forge data update
-
-# 特定シンボルのみ更新
-forge data update --symbol USDJPY
-
-# 保存済みデータを確認
-forge data list</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- strategy -->
-          <section class="cmd-section" id="ja-strategy">
-            <div class="section-category">戦略管理</div>
-            <h2 class="section-heading">forge strategy</h2>
-            <p>戦略 JSON の作成・登録・確認を行います。戦略は JSON ファイルで定義し、バックテストや最適化の対象として登録します。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge strategy list</code></td><td>登録済み戦略を一覧表示</td></tr>
-                <tr><td><code>forge strategy create</code></td><td>テンプレートから戦略 JSON を作成</td></tr>
-                <tr><td><code>forge strategy save &lt;FILE&gt;</code></td><td>JSON ファイルから戦略を登録</td></tr>
-                <tr><td><code>forge strategy show &lt;ID&gt;</code></td><td>戦略定義 (JSON) を表示</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># テンプレートから新規作成
-forge strategy create --template ema_crossover --id usdjpy_ema_v1 \
-  --out data/strategies/usdjpy_ema_v1.json
-
-# JSON ファイルを登録
-forge strategy save data/strategies/usdjpy_ema_v1.json
-
-# 登録済み戦略を確認
-forge strategy list
-
-# 戦略定義を表示
-forge strategy show usdjpy_ema_v1</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- backtest -->
-          <section class="cmd-section" id="ja-backtest">
-            <div class="section-category">バックテスト</div>
-            <h2 class="section-heading">forge backtest</h2>
-            <p>戦略のバックテスト実行・履歴確認・分析を行います。結果は SQLite DB に自動保存されます。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge backtest run &lt;SYMBOL&gt;</code></td><td>バックテストを実行</td></tr>
-                <tr><td><code>forge backtest wft &lt;SYMBOL&gt;</code></td><td>ウォークフォワードテストを実行</td></tr>
-                <tr><td><code>forge backtest list</code></td><td>保存済みバックテスト結果を一覧表示</td></tr>
-                <tr><td><code>forge backtest report &lt;ID&gt;</code></td><td>バックテスト結果の詳細を表示</td></tr>
-                <tr><td><code>forge backtest compare</code></td><td>複数の戦略結果を並べて比較</td></tr>
-                <tr><td><code>forge backtest chart &lt;SYMBOL&gt;</code></td><td>インタラクティブ HTML チャートを生成</td></tr>
-                <tr><td><code>forge backtest diagnose &lt;SYMBOL&gt;</code></td><td>パフォーマンス問題を自動診断</td></tr>
-                <tr><td><code>forge backtest monte-carlo &lt;SYMBOL&gt;</code></td><td>モンテカルロシミュレーションを実行</td></tr>
-                <tr><td><code>forge backtest portfolio</code></td><td>ポートフォリオバックテストを実行</td></tr>
-                <tr><td><code>forge backtest batch</code></td><td>複数戦略を並列バックテスト</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># 基本的なバックテスト
-forge backtest run USDJPY --strategy usdjpy_ema_v1
-
-# 期間指定
-forge backtest run USDJPY --strategy usdjpy_ema_v1 \
-  --start 2021-01-01 --end 2024-12-31
-
-# JSON 形式で出力
-forge backtest run USDJPY --strategy usdjpy_ema_v1 --json
-
-# ウォークフォワードテスト（5 フォールド）
-forge backtest wft USDJPY --strategy usdjpy_ema_v1 --folds 5
-
-# 結果一覧（Sharpe 降順）
-forge backtest list --sort sharpe --limit 20
-
-# 特定戦略の結果のみ
-forge backtest list --strategy usdjpy_ema_v1
-
-# インタラクティブチャートを生成してブラウザで開く
-forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- optimize -->
-          <section class="cmd-section" id="ja-optimize">
-            <div class="section-category">最適化</div>
-            <h2 class="section-heading">forge optimize</h2>
-            <p>Optuna を使ったベイズ最適化でパラメータを効率的に探索します。過学習リスクの評価や、最適化結果の戦略への適用もできます。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge optimize run &lt;SYMBOL&gt;</code></td><td>ベイズ最適化を実行</td></tr>
-                <tr><td><code>forge optimize apply &lt;RESULT&gt;</code></td><td>最適化結果を戦略に適用して新規保存</td></tr>
-                <tr><td><code>forge optimize walk-forward &lt;SYMBOL&gt;</code></td><td>ウォークフォワード最適化を実行</td></tr>
-                <tr><td><code>forge optimize sensitivity &lt;SYMBOL&gt;</code></td><td>パラメータ感度分析（過学習リスク評価）</td></tr>
-                <tr><td><code>forge optimize history</code></td><td>過去の最適化結果をスコアボード表示</td></tr>
-                <tr><td><code>forge optimize portfolio</code></td><td>ポートフォリオ最適配分を最適化</td></tr>
-                <tr><td><code>forge optimize cross-symbol</code></td><td>複数銘柄への汎化性を最適化</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># Sharpe Ratio を指標に 200 トライアル、4 並列で最適化
-forge optimize run USDJPY --strategy usdjpy_ema_v1 \
-  --metric sharpe_ratio --trials 200 -j 4 --save
-
-# 最適化履歴を確認
-forge optimize history --strategy usdjpy_ema_v1 --sort score
-
-# 最適化結果を新しい戦略として保存
-forge optimize apply data/results/usdjpy_ema_v1_opt.json \
-  --to-strategy usdjpy_ema_v1_optimized
-
-# 感度分析で過学習リスクを評価
-forge optimize sensitivity USDJPY --strategy usdjpy_ema_v1_optimized</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- pine -->
-          <section class="cmd-section" id="ja-pine">
-            <div class="section-category">Pine Script</div>
-            <h2 class="section-heading">forge pine</h2>
-            <p>戦略定義から TradingView 用の Pine Script v6 を自動生成します。HMM などの機械学習インジケータにも対応しています。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge pine generate --strategy &lt;ID&gt;</code></td><td>Pine Script を生成してファイルに出力</td></tr>
-                <tr><td><code>forge pine preview --strategy &lt;ID&gt;</code></td><td>生成される Pine Script を標準出力でプレビュー</td></tr>
-                <tr><td><code>forge pine import &lt;FILE&gt;</code></td><td>.pine ファイルを戦略定義として取り込み</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># Pine Script を生成（output/pinescript/ に保存）
-forge pine generate --strategy usdjpy_ema_v1_optimized
-
-# HMM モデルの学習済みパラメータを埋め込んで生成
-forge pine generate --strategy cl_hmm_bb_rsi_v1 --with-training-data
-
-# 内容をプレビュー（ファイル出力なし）
-forge pine preview --strategy usdjpy_ema_v1_optimized
-
-# 既存 .pine ファイルをインポート
-forge pine import output/pinescript/usdjpy_ema_v1.pine --id usdjpy_ema_imported</code></pre>
-
-            <div class="callout">
-              生成ファイルの保存先は <code>forge.yaml</code> の <code>pinescript.output_path</code> で設定します。デフォルトは <code>output/pinescript/</code> です。
-            </div>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- dashboard & license -->
-          <section class="cmd-section" id="ja-dashboard">
-            <div class="section-category">Web UI</div>
-            <h2 class="section-heading">forge dashboard</h2>
-            <p>Streamlit ベースの Web UI を起動します。バックテスト結果の可視化、戦略ランキング、アイデア管理を一画面で確認できます。</p>
-            <pre><code>forge dashboard
-forge dashboard --port 8501 --no-open</code></pre>
-          </section>
-
-          <section class="cmd-section" id="ja-license" style="margin-top:2rem;">
-            <div class="section-category">ライセンス</div>
-            <h2 class="section-heading">forge license</h2>
-            <p>LemonSqueezy のライセンスキーを認証します。認証情報は <code>~/.forge/license.json</code> にキャッシュされます。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge license activate &lt;KEY&gt;</code></td><td>ライセンスキーを認証</td></tr>
-                <tr><td><code>forge license status</code></td><td>現在のライセンス状態を表示</td></tr>
-                <tr><td><code>forge license deactivate</code></td><td>このデバイスのライセンスを無効化</td></tr>
-              </tbody>
-            </table>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- workflow -->
-          <section class="cmd-section" id="ja-workflow">
-            <div class="section-category">ガイド</div>
-            <h2 class="section-heading">エンドツーエンド 戦略開発ワークフロー</h2>
-            <p>ヒストリカルデータの取得から自動発注まで、典型的な開発フローを示します。Claude Code などのコーディングエージェントと組み合わせると、各ステップの自動化やパラメータ探索を高速化できます。</p>
-
-            <div class="callout">
-              以下のコマンドはすべて <code>alpha-strategies/</code> ディレクトリから <code>FORGE_CONFIG=forge.yaml uv run</code> 付きで実行することを想定しています。
-            </div>
-
-            <ul class="step-list">
-              <li>
-                <div>
-                  <strong>データ取得</strong>
-                  対象シンボルのヒストリカルデータをローカルに保存します。
-                  <pre><code>forge data fetch USDJPY</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>戦略テンプレート作成</strong>
-                  テンプレートから戦略 JSON の雛形を生成し、パラメータを編集します。
-                  <pre><code>forge strategy create --template ema_crossover \
-  --id usdjpy_ema_v1 \
-  --out data/strategies/usdjpy_ema_v1.json
-
-# 生成されたファイルをエディタで編集し、パラメータを調整
-forge strategy save data/strategies/usdjpy_ema_v1.json</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>バックテスト実行</strong>
-                  定義した戦略のパフォーマンスを過去データで検証します。
-                  <pre><code>forge backtest run USDJPY --strategy usdjpy_ema_v1
-
-# インタラクティブチャートで視覚的に確認
-forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>パラメータ最適化</strong>
-                  Optuna のベイズ最適化で最適なパラメータを探索します。
-                  <pre><code>forge optimize run USDJPY --strategy usdjpy_ema_v1 \
-  --metric sharpe_ratio --trials 300 -j 4 --save
-
-# 結果を新しい戦略として保存
-forge optimize apply data/results/usdjpy_ema_v1_opt.json \
-  --to-strategy usdjpy_ema_v1_optimized</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>ウォークフォワード検証</strong>
-                  過学習を検出するために、訓練期間とテスト期間を分けた検証を行います。
-                  <pre><code>forge backtest wft USDJPY --strategy usdjpy_ema_v1_optimized \
-  --folds 5
-
-# 感度分析でパラメータの堅牢性を確認
-forge optimize sensitivity USDJPY \
-  --strategy usdjpy_ema_v1_optimized</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Pine Script 生成</strong>
-                  TradingView 用のアラートスクリプトを自動生成します。
-                  <pre><code>forge pine generate --strategy usdjpy_ema_v1_optimized</code></pre>
-                  出力先: <code>output/pinescript/usdjpy_ema_v1_optimized.pine</code>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- tradingview -->
-          <section class="cmd-section" id="ja-tradingview">
-            <div class="section-category">ガイド</div>
-            <h2 class="section-heading">TradingView への Pine Script 反映</h2>
-            <p><code>forge pine generate</code> で生成した <code>.pine</code> ファイルを TradingView に貼り付けてアラートを設定します。</p>
-
-            <ul class="step-list">
-              <li>
-                <div>
-                  <strong>Pine Script を開く</strong>
-                  TradingView でチャートを開き、画面下部の「Pine エディタ」タブをクリックします。
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>スクリプトを貼り付ける</strong>
-                  生成した <code>.pine</code> ファイルの内容をエディタに貼り付け、「スクリプトを追加」（▶ ボタン）をクリックします。
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>アラートを設定する</strong>
-                  チャート右上のベルアイコン（アラート）→「アラートを追加」をクリック。
-                  <ul style="margin-top:0.4rem; padding-left:1.2rem; font-size:0.88rem; color:var(--text2);">
-                    <li>条件: 追加したスクリプト名を選択</li>
-                    <li>「Webhook URL」にチェックを入れ、alpha-strike のエンドポイントを入力</li>
-                    <li>「メッセージ」に後述の JSON ペイロードを入力</li>
-                  </ul>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>アラートメッセージのヒント</strong>
-                  Pine Script 内でシグナル変数（例: <code>longSignal</code>）を定義しておくと、アラートの条件設定が簡単になります。
-                  <pre><code>// Pine Script 内でのアラート定義例
-longSignal = ta.crossover(ema_fast, ema_slow)
-shortSignal = ta.crossunder(ema_fast, ema_slow)
-alertcondition(longSignal, title="Long Entry", message="long")</code></pre>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- alpha-strike -->
-          <section class="cmd-section" id="ja-strike">
-            <div class="section-category">ガイド</div>
-            <h2 class="section-heading">TradingView と alpha-strike の連携</h2>
-            <p>alpha-strike は TradingView のアラートを Webhook で受け取り、OANDA・moomoo 証券に自動発注します。</p>
-
-            <h3 class="sub-heading">1. 環境変数の設定</h3>
-            <p><code>alpha-strike/.env</code> を作成して以下を設定します。</p>
-            <pre><code># 必須
-WEBHOOK_PASSPHRASE=your-secret-passphrase   # 任意の秘密文字列
-
-# OANDA 使用時
-OANDA_API_KEY=your-personal-access-token
-OANDA_ACCOUNT_ID=your-account-id
-OANDA_ENV=PRACTICE    # 本番は LIVE
-
-# moomoo 使用時
-MOOMOO_HOST=127.0.0.1
-MOOMOO_PORT=11111
-MOOMOO_TRD_ENV=SIMULATE   # 本番は REAL</code></pre>
-
-            <h3 class="sub-heading">2. Webhook URL</h3>
-            <div class="callout">
-              TradingView のアラート Webhook URL に以下を設定します:<br/>
-              <code>http://&lt;your-server&gt;:8080/webhook</code>
-            </div>
-
-            <h3 class="sub-heading">3. ペイロード仕様</h3>
-            <p>TradingView のアラートメッセージに JSON を記述します。</p>
-            <pre><code>{
-  "passphrase": "your-secret-passphrase",
-  "broker": "oanda",
-  "asset_class": "FX",
-  "action": "buy",
-  "ticker": "USDJPY",
-  "quantity": 1000
-}</code></pre>
-
-            <table class="payload-table">
-              <thead><tr><th>フィールド</th><th>説明</th><th>値の例</th></tr></thead>
-              <tbody>
-                <tr><td><code>passphrase</code><br/><span class="req">必須</span></td><td>.env の WEBHOOK_PASSPHRASE と一致させること</td><td>"my-secret"</td></tr>
-                <tr><td><code>broker</code><br/><span class="req">必須</span></td><td>発注先の証券会社</td><td>"oanda" / "moomoo"</td></tr>
-                <tr><td><code>asset_class</code><br/><span class="req">必須</span></td><td>アセットクラス</td><td>"FX" / "COMMODITY" / "US" / "INDEX"</td></tr>
-                <tr><td><code>action</code><br/><span class="req">必須</span></td><td>注文方向</td><td>"buy" / "sell"</td></tr>
-                <tr><td><code>ticker</code><br/><span class="req">必須</span></td><td>銘柄コード（TradingView のシンボル名）</td><td>"USDJPY" / "XAUUSD"</td></tr>
-                <tr><td><code>quantity</code><br/><span class="req">必須</span></td><td>注文数量（0 より大きい正の数）</td><td>1000 / 0.1</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">4. ティッカーと OANDA instrument の対応</h3>
-            <table class="option-table">
-              <thead><tr><th>asset_class</th><th>ticker 例</th><th>OANDA instrument</th></tr></thead>
-              <tbody>
-                <tr><td>FX</td><td>USDJPY</td><td>USD_JPY</td></tr>
-                <tr><td>COMMODITY</td><td>XAUUSD</td><td>XAU_USD</td></tr>
-                <tr><td>INDEX</td><td>NAS100</td><td>NAS100_USD</td></tr>
-                <tr><td>US</td><td>AAPL</td><td>AAPL_USD</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">5. 動作確認</h3>
-            <pre><code># ヘルスチェック
-curl http://localhost:8080/health
-# → {"status":"ok"}
-
-# テスト発注（PRACTICE / SIMULATE 環境で確認）
-curl -X POST http://localhost:8080/webhook \
-  -H "Content-Type: application/json" \
-  -d '{"passphrase":"your-secret","broker":"oanda","asset_class":"FX","action":"buy","ticker":"USDJPY","quantity":1000}'</code></pre>
-          </section>
-
-        </div>
+      <h1 class="page-title">forge コマンドの早見表</h1>
+      <p class="page-subtitle">主要 6 コマンドのカードと全コマンドカタログ。詳細パラメータと出力例は公式ドキュメントへ。</p>
+
+      <div class="callout" style="margin-bottom: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          全 76 サブコマンドの詳細パラメータ、出力例、エラーコードは
+          <strong>公式ドキュメント</strong>を参照してください。
+        </p>
+        <a href="/ja/docs/cli-reference/" class="btn-primary">
+          CLI リファレンスを開く →
+        </a>
       </div>
-    </div><!-- /lang-ja -->
 
+      <h2 class="section-heading">主要コマンド</h2>
+      <div class="cmd-card-grid">
+        <a class="cmd-card" href="/ja/docs/cli-reference/backtest/#forge-backtest-run">
+          <div class="cmd-card-name">forge backtest run</div>
+          <div class="cmd-card-desc">単一銘柄に戦略を適用してバックテストを実行する。</div>
+          <pre class="cmd-card-usage"><code>forge backtest run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--strategy</span>
+            <span class="cmd-card-option">--start</span>
+            <span class="cmd-card-option">--json</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
 
-    <!-- ==================== English version ==================== -->
+        <a class="cmd-card" href="/ja/docs/cli-reference/optimize/#forge-optimize-run">
+          <div class="cmd-card-name">forge optimize run</div>
+          <div class="cmd-card-desc">Optuna によるパラメータ最適化（TPE）。多目的最適化にも対応。</div>
+          <pre class="cmd-card-usage"><code>forge optimize run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--metric</span>
+            <span class="cmd-card-option">--trials</span>
+            <span class="cmd-card-option">--apply</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/optimize/#forge-optimize-walk-forward">
+          <div class="cmd-card-name">forge optimize walk-forward</div>
+          <div class="cmd-card-desc">時系列をウィンドウ分割し IS 最適化 → OOS 評価で過学習耐性を測定。</div>
+          <pre class="cmd-card-usage"><code>forge optimize walk-forward SYMBOL --strategy ID --windows N</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--windows</span>
+            <span class="cmd-card-option">--metric</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/data/#forge-data-fetch">
+          <div class="cmd-card-name">forge data fetch</div>
+          <div class="cmd-card-desc">OHLCV をプロバイダーから取得し Parquet で保存。</div>
+          <pre class="cmd-card-usage"><code>forge data fetch SYMBOL --period 5y --interval 1d</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--period</span>
+            <span class="cmd-card-option">--interval</span>
+            <span class="cmd-card-option">--watchlist</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/strategy/#forge-strategy-save">
+          <div class="cmd-card-name">forge strategy save</div>
+          <div class="cmd-card-desc">戦略 JSON をレジストリに登録（任意で Journal に記録）。</div>
+          <pre class="cmd-card-usage"><code>forge strategy save FILE_PATH</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--force</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/journal/#forge-journal-show">
+          <div class="cmd-card-name">forge journal show</div>
+          <div class="cmd-card-desc">戦略の全履歴（スナップショット・Runs・タグ・ライブサマリ）を表示。</div>
+          <pre class="cmd-card-usage"><code>forge journal show STRATEGY_ID</code></pre>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+      </div>
+
+      <h2 class="section-heading">全コマンドカタログ</h2>
+      <table class="cmd-table">
+        <thead>
+          <tr><th>グループ</th><th>説明</th><th>サブコマンド数</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/backtest/"><code>forge backtest</code></a></td>
+            <td>バックテスト実行・スキャン・カスタム実験</td>
+            <td>11</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/optimize/"><code>forge optimize</code></a></td>
+            <td>パラメータ最適化（grid / bayes / wfa）</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td>
+            <td>戦略 JSON の保存・検証・適用</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/data/"><code>forge data</code></a></td>
+            <td>ヒストリカルデータ取得・更新</td>
+            <td>4</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/journal/"><code>forge journal</code></a></td>
+            <td>取引ジャーナル・トレード分析</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/live/"><code>forge live</code></a></td>
+            <td>ライブトレーディング・ブローカー連携</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/other/">その他コマンド</a></td>
+            <td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> 他</td>
+            <td>10 グループ</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout" style="margin-top: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          各グループの完全なサブコマンドリスト、オプション一覧、戻り値、サンプル出力は
+          ドキュメントの CLI リファレンスを参照してください。
+        </p>
+        <a href="/ja/docs/cli-reference/" class="btn-primary">
+          CLI リファレンスを開く →
+        </a>
+      </div>
+
+      <div class="callout" style="margin-top: 1rem;">
+        <p>サポートが必要な場合は <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a> までお問い合わせください。</p>
+      </div>
+    </div>
+
+    <!-- ==================== English ==================== -->
     <div class="lang-content lang-en">
       <div class="page-label">Documentation</div>
-      <h1 class="page-title">Documentation</h1>
-      <p class="page-subtitle">Command reference, strategy development workflow, and TradingView integration guide.</p>
-
-      <div class="doc-layout" style="margin-top: 2rem;">
-        <nav class="cmd-nav">
-          <ul class="cmd-nav-list">
-            <li class="nav-group">Data</li>
-            <li><a href="#en-data">data</a></li>
-            <li class="nav-group">Strategy</li>
-            <li><a href="#en-strategy">strategy</a></li>
-            <li class="nav-group">Backtest</li>
-            <li><a href="#en-backtest">backtest</a></li>
-            <li class="nav-group">Optimize</li>
-            <li><a href="#en-optimize">optimize</a></li>
-            <li class="nav-group">Pine Script</li>
-            <li><a href="#en-pine">pine</a></li>
-            <li class="nav-group">Other</li>
-            <li><a href="#en-dashboard">dashboard</a></li>
-            <li><a href="#en-license">license</a></li>
-            <li class="nav-group">Guides</li>
-            <li><a href="#en-workflow">Workflow</a></li>
-            <li><a href="#en-tradingview">TradingView</a></li>
-            <li><a href="#en-strike">alpha-strike</a></li>
-          </ul>
-        </nav>
-
-        <div>
-
-          <!-- data -->
-          <section class="cmd-section" id="en-data">
-            <div class="section-category">Data Management</div>
-            <h2 class="section-heading">forge data</h2>
-            <p>Fetch, update, and manage historical market data. Data is stored as Parquet files under <code>alpha-strategies/data/historical/</code>.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge data fetch &lt;SYMBOL&gt;</code></td><td>Fetch and save historical data for a symbol</td></tr>
-                <tr><td><code>forge data update</code></td><td>Incrementally update all saved data to today</td></tr>
-                <tr><td><code>forge data update --symbol &lt;SYMBOL&gt;</code></td><td>Update a specific symbol only</td></tr>
-                <tr><td><code>forge data list</code></td><td>List all saved datasets</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># Initial fetch
-forge data fetch USDJPY
-forge data fetch CL=F
-forge data fetch SPY QQQ NAS100
-
-# Incremental update (all symbols)
-forge data update
-
-# Update a single symbol
-forge data update --symbol USDJPY
-
-# Check what's saved
-forge data list</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- strategy -->
-          <section class="cmd-section" id="en-strategy">
-            <div class="section-category">Strategy Management</div>
-            <h2 class="section-heading">forge strategy</h2>
-            <p>Create, register, and inspect strategy JSON definitions. Strategies must be registered before use in backtests or optimization.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge strategy list</code></td><td>List all registered strategies</td></tr>
-                <tr><td><code>forge strategy create</code></td><td>Generate a strategy JSON from a template</td></tr>
-                <tr><td><code>forge strategy save &lt;FILE&gt;</code></td><td>Register a strategy from a JSON file</td></tr>
-                <tr><td><code>forge strategy show &lt;ID&gt;</code></td><td>Print the strategy definition (JSON)</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># Create from template
-forge strategy create --template ema_crossover --id usdjpy_ema_v1 \
-  --out data/strategies/usdjpy_ema_v1.json
-
-# Register after editing the JSON
-forge strategy save data/strategies/usdjpy_ema_v1.json
-
-# List registered strategies
-forge strategy list
-
-# Inspect a strategy definition
-forge strategy show usdjpy_ema_v1</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- backtest -->
-          <section class="cmd-section" id="en-backtest">
-            <div class="section-category">Backtesting</div>
-            <h2 class="section-heading">forge backtest</h2>
-            <p>Run backtests, view history, and analyse results. All results are automatically saved to SQLite.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge backtest run &lt;SYMBOL&gt;</code></td><td>Run a backtest</td></tr>
-                <tr><td><code>forge backtest wft &lt;SYMBOL&gt;</code></td><td>Run a walk-forward test</td></tr>
-                <tr><td><code>forge backtest list</code></td><td>List saved backtest results</td></tr>
-                <tr><td><code>forge backtest report &lt;ID&gt;</code></td><td>Show detailed result for a run</td></tr>
-                <tr><td><code>forge backtest compare</code></td><td>Compare multiple strategy results side by side</td></tr>
-                <tr><td><code>forge backtest chart &lt;SYMBOL&gt;</code></td><td>Generate an interactive HTML chart</td></tr>
-                <tr><td><code>forge backtest diagnose &lt;SYMBOL&gt;</code></td><td>Auto-diagnose performance issues</td></tr>
-                <tr><td><code>forge backtest monte-carlo &lt;SYMBOL&gt;</code></td><td>Run Monte Carlo simulation</td></tr>
-                <tr><td><code>forge backtest portfolio</code></td><td>Run a portfolio backtest</td></tr>
-                <tr><td><code>forge backtest batch</code></td><td>Parallel backtest across multiple strategies</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># Basic backtest
-forge backtest run USDJPY --strategy usdjpy_ema_v1
-
-# With date range
-forge backtest run USDJPY --strategy usdjpy_ema_v1 \
-  --start 2021-01-01 --end 2024-12-31
-
-# JSON output
-forge backtest run USDJPY --strategy usdjpy_ema_v1 --json
-
-# Walk-forward test (5 folds)
-forge backtest wft USDJPY --strategy usdjpy_ema_v1 --folds 5
-
-# List results sorted by Sharpe
-forge backtest list --sort sharpe --limit 20
-
-# Open interactive chart in browser
-forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- optimize -->
-          <section class="cmd-section" id="en-optimize">
-            <div class="section-category">Optimization</div>
-            <h2 class="section-heading">forge optimize</h2>
-            <p>Bayesian parameter search with Optuna. Includes overfitting risk evaluation, walk-forward optimization, and one-click apply.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge optimize run &lt;SYMBOL&gt;</code></td><td>Run Bayesian optimization</td></tr>
-                <tr><td><code>forge optimize apply &lt;RESULT&gt;</code></td><td>Apply results to a new strategy</td></tr>
-                <tr><td><code>forge optimize walk-forward &lt;SYMBOL&gt;</code></td><td>Walk-forward optimization</td></tr>
-                <tr><td><code>forge optimize sensitivity &lt;SYMBOL&gt;</code></td><td>Parameter sensitivity analysis (overfitting check)</td></tr>
-                <tr><td><code>forge optimize history</code></td><td>Scoreboard of past optimization runs</td></tr>
-                <tr><td><code>forge optimize portfolio</code></td><td>Optimize portfolio allocation weights</td></tr>
-                <tr><td><code>forge optimize cross-symbol</code></td><td>Optimize across multiple symbols for generalization</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># 300 trials, 4 workers, maximize Sharpe
-forge optimize run USDJPY --strategy usdjpy_ema_v1 \
-  --metric sharpe_ratio --trials 300 -j 4 --save
-
-# View optimization history
-forge optimize history --strategy usdjpy_ema_v1 --sort score
-
-# Apply best result as a new strategy
-forge optimize apply data/results/usdjpy_ema_v1_opt.json \
-  --to-strategy usdjpy_ema_v1_optimized
-
-# Check parameter robustness
-forge optimize sensitivity USDJPY --strategy usdjpy_ema_v1_optimized</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- pine -->
-          <section class="cmd-section" id="en-pine">
-            <div class="section-category">Pine Script</div>
-            <h2 class="section-heading">forge pine</h2>
-            <p>Auto-generate TradingView Pine Script v6 from a strategy definition. Supports machine-learning indicators such as HMM by embedding trained parameters.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge pine generate --strategy &lt;ID&gt;</code></td><td>Generate Pine Script and write to file</td></tr>
-                <tr><td><code>forge pine preview --strategy &lt;ID&gt;</code></td><td>Preview Pine Script in stdout (no file written)</td></tr>
-                <tr><td><code>forge pine import &lt;FILE&gt;</code></td><td>Parse a .pine file and import as a strategy</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># Generate Pine Script (saved to output/pinescript/)
-forge pine generate --strategy usdjpy_ema_v1_optimized
-
-# Embed trained HMM parameters
-forge pine generate --strategy cl_hmm_bb_rsi_v1 --with-training-data
-
-# Preview without writing to disk
-forge pine preview --strategy usdjpy_ema_v1_optimized
-
-# Import existing .pine file as a strategy
-forge pine import output/pinescript/usdjpy_ema_v1.pine --id usdjpy_ema_imported</code></pre>
-
-            <div class="callout">
-              The output path is configured via <code>pinescript.output_path</code> in <code>forge.yaml</code>. Default: <code>output/pinescript/</code>.
-            </div>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- dashboard & license -->
-          <section class="cmd-section" id="en-dashboard">
-            <div class="section-category">Web UI</div>
-            <h2 class="section-heading">forge dashboard</h2>
-            <p>Launch the Streamlit-based Web UI for backtest visualisation, strategy rankings, and idea tracking.</p>
-            <pre><code>forge dashboard
-forge dashboard --port 8501 --no-open</code></pre>
-          </section>
-
-          <section class="cmd-section" id="en-license" style="margin-top:2rem;">
-            <div class="section-category">License</div>
-            <h2 class="section-heading">forge license</h2>
-            <p>Activate and manage your LemonSqueezy license. Activation data is cached in <code>~/.forge/license.json</code>.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge license activate &lt;KEY&gt;</code></td><td>Activate a license key on this device</td></tr>
-                <tr><td><code>forge license status</code></td><td>Show current license status</td></tr>
-                <tr><td><code>forge license deactivate</code></td><td>Deactivate this device</td></tr>
-              </tbody>
-            </table>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- workflow -->
-          <section class="cmd-section" id="en-workflow">
-            <div class="section-category">Guide</div>
-            <h2 class="section-heading">End-to-End Strategy Development Workflow</h2>
-            <p>A typical flow from raw data to live execution. This pairs naturally with a coding agent (e.g. Claude Code) for automated parameter exploration and strategy generation.</p>
-
-            <div class="callout">
-              All commands below assume you are running from <code>alpha-strategies/</code> with <code>FORGE_CONFIG=forge.yaml uv run</code> prepended.
-            </div>
-
-            <ul class="step-list">
-              <li>
-                <div>
-                  <strong>Fetch historical data</strong>
-                  <pre><code>forge data fetch USDJPY</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Create a strategy from a template</strong>
-                  Generate a JSON scaffold, edit parameters, then register it.
-                  <pre><code>forge strategy create --template ema_crossover \
-  --id usdjpy_ema_v1 \
-  --out data/strategies/usdjpy_ema_v1.json
-
-# Edit the JSON, then register
-forge strategy save data/strategies/usdjpy_ema_v1.json</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Run a backtest</strong>
-                  <pre><code>forge backtest run USDJPY --strategy usdjpy_ema_v1
-
-# Visual equity curve
-forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Optimize parameters</strong>
-                  Bayesian search with Optuna, then apply the best result.
-                  <pre><code>forge optimize run USDJPY --strategy usdjpy_ema_v1 \
-  --metric sharpe_ratio --trials 300 -j 4 --save
-
-forge optimize apply data/results/usdjpy_ema_v1_opt.json \
-  --to-strategy usdjpy_ema_v1_optimized</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Walk-forward validation</strong>
-                  Detect overfitting with out-of-sample testing.
-                  <pre><code>forge backtest wft USDJPY --strategy usdjpy_ema_v1_optimized \
-  --folds 5
-
-forge optimize sensitivity USDJPY \
-  --strategy usdjpy_ema_v1_optimized</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Generate Pine Script</strong>
-                  Export a TradingView alert script from the optimized strategy.
-                  <pre><code>forge pine generate --strategy usdjpy_ema_v1_optimized</code></pre>
-                  Output: <code>output/pinescript/usdjpy_ema_v1_optimized.pine</code>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- tradingview -->
-          <section class="cmd-section" id="en-tradingview">
-            <div class="section-category">Guide</div>
-            <h2 class="section-heading">Deploying Pine Script to TradingView</h2>
-            <p>Paste the generated <code>.pine</code> file into TradingView and set up an alert to trigger alpha-strike.</p>
-
-            <ul class="step-list">
-              <li>
-                <div>
-                  <strong>Open the Pine Editor</strong>
-                  Open a chart in TradingView and click the "Pine Editor" tab at the bottom.
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Paste the script</strong>
-                  Copy the contents of the generated <code>.pine</code> file and paste it into the editor. Click "Add to chart" (▶).
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Create an alert</strong>
-                  Click the bell icon (Alerts) → "Create alert". Set the condition to your script, enable "Webhook URL", and paste the alpha-strike endpoint.
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Tip: in-script alert conditions</strong>
-                  Define <code>alertcondition</code> in Pine Script for cleaner alert setup.
-                  <pre><code>longSignal = ta.crossover(ema_fast, ema_slow)
-alertcondition(longSignal, title="Long Entry", message="long")</code></pre>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- alpha-strike -->
-          <section class="cmd-section" id="en-strike">
-            <div class="section-category">Guide</div>
-            <h2 class="section-heading">Connecting TradingView to alpha-strike</h2>
-            <p>alpha-strike receives TradingView webhook alerts and forwards orders to OANDA or moomoo.</p>
-
-            <h3 class="sub-heading">1. Configure environment variables</h3>
-            <p>Create <code>alpha-strike/.env</code> from the provided example:</p>
-            <pre><code># Required
-WEBHOOK_PASSPHRASE=your-secret-passphrase
-
-# OANDA
-OANDA_API_KEY=your-personal-access-token
-OANDA_ACCOUNT_ID=your-account-id
-OANDA_ENV=PRACTICE    # or LIVE
-
-# moomoo
-MOOMOO_HOST=127.0.0.1
-MOOMOO_PORT=11111
-MOOMOO_TRD_ENV=SIMULATE   # or REAL</code></pre>
-
-            <h3 class="sub-heading">2. Webhook URL</h3>
-            <div class="callout">
-              Set the TradingView alert Webhook URL to:<br/>
-              <code>http://&lt;your-server&gt;:8080/webhook</code>
-            </div>
-
-            <h3 class="sub-heading">3. Payload format</h3>
-            <pre><code>{
-  "passphrase": "your-secret-passphrase",
-  "broker": "oanda",
-  "asset_class": "FX",
-  "action": "buy",
-  "ticker": "USDJPY",
-  "quantity": 1000
-}</code></pre>
-
-            <table class="payload-table">
-              <thead><tr><th>Field</th><th>Description</th><th>Example</th></tr></thead>
-              <tbody>
-                <tr><td><code>passphrase</code><br/><span class="req">required</span></td><td>Must match WEBHOOK_PASSPHRASE in .env</td><td>"my-secret"</td></tr>
-                <tr><td><code>broker</code><br/><span class="req">required</span></td><td>Target broker</td><td>"oanda" / "moomoo"</td></tr>
-                <tr><td><code>asset_class</code><br/><span class="req">required</span></td><td>Asset class</td><td>"FX" / "COMMODITY" / "US" / "INDEX"</td></tr>
-                <tr><td><code>action</code><br/><span class="req">required</span></td><td>Order direction</td><td>"buy" / "sell"</td></tr>
-                <tr><td><code>ticker</code><br/><span class="req">required</span></td><td>Symbol (TradingView notation)</td><td>"USDJPY" / "XAUUSD"</td></tr>
-                <tr><td><code>quantity</code><br/><span class="req">required</span></td><td>Order size (positive number)</td><td>1000 / 0.1</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">4. Ticker to OANDA instrument mapping</h3>
-            <table class="option-table">
-              <thead><tr><th>asset_class</th><th>ticker</th><th>OANDA instrument</th></tr></thead>
-              <tbody>
-                <tr><td>FX</td><td>USDJPY</td><td>USD_JPY</td></tr>
-                <tr><td>COMMODITY</td><td>XAUUSD</td><td>XAU_USD</td></tr>
-                <tr><td>INDEX</td><td>NAS100</td><td>NAS100_USD</td></tr>
-                <tr><td>US</td><td>AAPL</td><td>AAPL_USD</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">5. Verify connectivity</h3>
-            <pre><code># Health check
-curl http://localhost:8080/health
-# → {"status":"ok"}
-
-# Test order (use PRACTICE / SIMULATE environment)
-curl -X POST http://localhost:8080/webhook \
-  -H "Content-Type: application/json" \
-  -d '{"passphrase":"your-secret","broker":"oanda","asset_class":"FX","action":"buy","ticker":"USDJPY","quantity":1000}'</code></pre>
-          </section>
-
-        </div>
+      <h1 class="page-title">forge Command Quick Reference</h1>
+      <p class="page-subtitle">Cards for the six core commands plus a full command catalog. Detailed parameters and output examples live in the official docs.</p>
+
+      <div class="callout" style="margin-bottom: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          For detailed parameters, output examples, and error codes for all 76 subcommands,
+          see the <strong>official documentation</strong>.
+        </p>
+        <a href="/en/docs/cli-reference/" class="btn-primary">
+          Open CLI Reference →
+        </a>
       </div>
-    </div><!-- /lang-en -->
+
+      <h2 class="section-heading">Top Commands</h2>
+      <div class="cmd-card-grid">
+        <a class="cmd-card" href="/en/docs/cli-reference/backtest/#forge-backtest-run">
+          <div class="cmd-card-name">forge backtest run</div>
+          <div class="cmd-card-desc">Run a backtest applying a strategy to a single symbol.</div>
+          <pre class="cmd-card-usage"><code>forge backtest run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--strategy</span>
+            <span class="cmd-card-option">--start</span>
+            <span class="cmd-card-option">--json</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/optimize/#forge-optimize-run">
+          <div class="cmd-card-name">forge optimize run</div>
+          <div class="cmd-card-desc">Parameter optimization with Optuna (TPE). Multi-objective also supported.</div>
+          <pre class="cmd-card-usage"><code>forge optimize run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--metric</span>
+            <span class="cmd-card-option">--trials</span>
+            <span class="cmd-card-option">--apply</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/optimize/#forge-optimize-walk-forward">
+          <div class="cmd-card-name">forge optimize walk-forward</div>
+          <div class="cmd-card-desc">Split time series into windows; IS optimization → OOS evaluation for overfitting resistance.</div>
+          <pre class="cmd-card-usage"><code>forge optimize walk-forward SYMBOL --strategy ID --windows N</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--windows</span>
+            <span class="cmd-card-option">--metric</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/data/#forge-data-fetch">
+          <div class="cmd-card-name">forge data fetch</div>
+          <div class="cmd-card-desc">Fetch OHLCV from a provider and store as Parquet.</div>
+          <pre class="cmd-card-usage"><code>forge data fetch SYMBOL --period 5y --interval 1d</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--period</span>
+            <span class="cmd-card-option">--interval</span>
+            <span class="cmd-card-option">--watchlist</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/strategy/#forge-strategy-save">
+          <div class="cmd-card-name">forge strategy save</div>
+          <div class="cmd-card-desc">Register a strategy JSON to the registry (optionally recorded in the Journal).</div>
+          <pre class="cmd-card-usage"><code>forge strategy save FILE_PATH</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--force</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/journal/#forge-journal-show">
+          <div class="cmd-card-name">forge journal show</div>
+          <div class="cmd-card-desc">Show the full history of a strategy (snapshots, runs, tags, live summary).</div>
+          <pre class="cmd-card-usage"><code>forge journal show STRATEGY_ID</code></pre>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+      </div>
+
+      <h2 class="section-heading">All Command Groups</h2>
+      <table class="cmd-table">
+        <thead>
+          <tr><th>Group</th><th>Description</th><th>Subcommands</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="/en/docs/cli-reference/backtest/"><code>forge backtest</code></a></td>
+            <td>Backtest execution, scanning, custom experiments</td>
+            <td>11</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/optimize/"><code>forge optimize</code></a></td>
+            <td>Parameter optimization (grid / bayes / wfa)</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td>
+            <td>Strategy JSON save / validate / apply</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/data/"><code>forge data</code></a></td>
+            <td>Historical data fetch / update</td>
+            <td>4</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/journal/"><code>forge journal</code></a></td>
+            <td>Trading journal and trade analysis</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/live/"><code>forge live</code></a></td>
+            <td>Live trading and broker integration</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/other/">Other commands</a></td>
+            <td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> and more</td>
+            <td>10 groups</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout" style="margin-top: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          For complete subcommand listings, options, return values, and sample output for each group,
+          see the CLI Reference in the official docs.
+        </p>
+        <a href="/en/docs/cli-reference/" class="btn-primary">
+          Open CLI Reference →
+        </a>
+      </div>
+
+      <div class="callout" style="margin-top: 1rem;">
+        <p>If you need help, contact <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a>.</p>
+      </div>
+    </div>
 
   </div>
 

--- a/ja/docs.html
+++ b/ja/docs.html
@@ -10,7 +10,10 @@
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/docs.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/docs.html" />
   <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/ja/docs.html" />
+  <meta property="og:title" content="AlphaForge CLI ドキュメント" />
+  <meta property="og:description" content="コマンドリファレンスから戦略開発ワークフロー、TradingView 連携まで網羅した公式ドキュメント。" />
   <meta property="og:image" content="https://alforgelabs.com/assets/og-image.png" />
   <meta property="og:locale" content="ja_JP" />
   <meta property="og:site_name" content="Alforge Labs" />
@@ -42,85 +45,58 @@
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../page.css" />
   <style>
-    .cmd-nav {
-      position: sticky; top: calc(var(--nav-h) + 1rem);
-      align-self: start;
+    /* ── CARD GRID ── */
+    .cmd-card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1rem;
+      margin: 1.5rem 0 2.5rem;
     }
-    .cmd-nav-list { list-style: none; padding: 0; }
-    .cmd-nav-list li a {
-      display: block; padding: 0.3rem 0.75rem;
-      font-family: var(--mono); font-size: 0.75rem; color: var(--text3);
-      text-decoration: none; border-left: 2px solid var(--border);
-      transition: color 0.15s, border-color 0.15s;
+    .cmd-card {
+      display: block;
+      padding: 1.25rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      text-decoration: none;
+      transition: border-color 0.15s, transform 0.15s;
     }
-    .cmd-nav-list li a:hover { color: var(--accent); border-left-color: var(--accent); }
-    .cmd-nav-list .nav-group {
-      font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.12em;
-      color: var(--text3); padding: 0.7rem 0.75rem 0.2rem; font-family: var(--mono);
-      border-left: 2px solid transparent;
+    .cmd-card:hover {
+      border-color: var(--accent);
+      transform: translateY(-2px);
+      text-decoration: none;
     }
-    .doc-layout {
-      display: grid; grid-template-columns: 190px 1fr; gap: 3rem;
+    .cmd-card-name {
+      font-family: var(--mono);
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--accent);
+      margin-bottom: 0.4rem;
     }
-    .option-table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
-    .option-table th {
-      font-family: var(--mono); font-size: 0.65rem; color: var(--text3);
-      text-transform: uppercase; letter-spacing: 0.1em;
-      text-align: left; padding: 0.4rem 0.75rem;
-      border-bottom: 1px solid var(--border); background: var(--bg2);
+    .cmd-card-desc { font-size: 0.85rem; color: var(--text2); margin-bottom: 0.75rem; }
+    .cmd-card-usage {
+      background: var(--bg2);
+      padding: 0.5rem 0.75rem;
+      border-radius: 4px;
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      color: var(--text);
+      margin: 0 0 0.75rem;
+      overflow-x: auto;
     }
-    .option-table td {
-      font-size: 0.85rem; color: var(--text2);
-      padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--border);
-      vertical-align: top;
+    .cmd-card-options { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 0.75rem; }
+    .cmd-card-option {
+      font-family: var(--mono); font-size: 0.72rem;
+      padding: 0.2rem 0.5rem;
+      background: var(--accent-bg); color: var(--accent);
+      border-radius: 4px;
     }
-    .option-table td:first-child code { color: var(--accent); font-family: var(--mono); font-size: 0.82rem; }
-    .option-table tr:last-child td { border-bottom: none; }
-    .cmd-section { scroll-margin-top: calc(var(--nav-h) + 2rem); margin-bottom: 3rem; }
-    .section-divider { border: none; border-top: 1px solid var(--border); margin: 3rem 0 2.5rem; }
-    .section-category {
-      font-size: 0.65rem; font-family: var(--mono); text-transform: uppercase;
-      letter-spacing: 0.14em; color: var(--accent); margin-bottom: 0.5rem;
+    .cmd-card-link {
+      font-size: 0.78rem;
+      color: var(--text3);
+      font-family: var(--mono);
     }
-    .step-list { list-style: none; padding: 0; counter-reset: steps; }
-    .step-list li {
-      counter-increment: steps;
-      display: grid; grid-template-columns: 2rem 1fr; gap: 1rem;
-      margin-bottom: 1.5rem; align-items: start;
-    }
-    .step-list li::before {
-      content: counter(steps);
-      display: flex; align-items: center; justify-content: center;
-      width: 1.75rem; height: 1.75rem;
-      background: var(--accent); color: var(--bg); border-radius: 50%;
-      font-size: 0.8rem; font-weight: 700; flex-shrink: 0; margin-top: 0.1rem;
-    }
-    .step-list li > div > strong { display: block; margin-bottom: 0.3rem; }
-    .callout {
-      background: var(--bg2); border-left: 3px solid var(--accent);
-      padding: 0.85rem 1rem; border-radius: 0 6px 6px 0;
-      font-size: 0.88rem; color: var(--text2); margin: 0.75rem 0 1rem;
-    }
-    .callout code { font-family: var(--mono); font-size: 0.82rem; color: var(--accent); }
-    .payload-table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
-    .payload-table th {
-      font-family: var(--mono); font-size: 0.65rem; color: var(--text3);
-      text-transform: uppercase; letter-spacing: 0.1em;
-      text-align: left; padding: 0.4rem 0.75rem;
-      border-bottom: 1px solid var(--border); background: var(--bg2);
-    }
-    .payload-table td {
-      font-size: 0.83rem; color: var(--text2);
-      padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border);
-      vertical-align: top;
-    }
-    .payload-table td:first-child code { color: var(--amber); font-family: var(--mono); font-size: 0.8rem; }
-    .payload-table td .req { font-size: 0.7rem; color: var(--red, #f87171); }
-    .payload-table tr:last-child td { border-bottom: none; }
-    @media (max-width: 768px) {
-      .doc-layout { grid-template-columns: 1fr; }
-      .cmd-nav { display: none; }
-    }
+    .cmd-card:hover .cmd-card-link { color: var(--accent); }
   </style>
   <script>
     (function() {
@@ -138,877 +114,291 @@
 <body data-theme="dark" data-lang="ja">
   <div id="site-header"></div>
 
-  <div class="page-wrap" style="max-width: 1060px;">
+  <div class="page-wrap">
 
     <!-- ==================== 日本語版 ==================== -->
     <div class="lang-content lang-ja">
       <div class="page-label">Documentation</div>
-      <h1 class="page-title">ドキュメント</h1>
-      <p class="page-subtitle">コマンドリファレンス、戦略開発ワークフロー、TradingView 連携ガイド。</p>
-
-      <div class="doc-layout" style="margin-top: 2rem;">
-        <nav class="cmd-nav">
-          <ul class="cmd-nav-list">
-            <li class="nav-group">データ</li>
-            <li><a href="#ja-data">data</a></li>
-            <li class="nav-group">戦略</li>
-            <li><a href="#ja-strategy">strategy</a></li>
-            <li class="nav-group">バックテスト</li>
-            <li><a href="#ja-backtest">backtest</a></li>
-            <li class="nav-group">最適化</li>
-            <li><a href="#ja-optimize">optimize</a></li>
-            <li class="nav-group">Pine Script</li>
-            <li><a href="#ja-pine">pine</a></li>
-            <li class="nav-group">その他</li>
-            <li><a href="#ja-dashboard">dashboard</a></li>
-            <li><a href="#ja-license">license</a></li>
-            <li class="nav-group">ガイド</li>
-            <li><a href="#ja-workflow">開発ワークフロー</a></li>
-            <li><a href="#ja-tradingview">TradingView連携</a></li>
-            <li><a href="#ja-strike">alpha-strike連携</a></li>
-          </ul>
-        </nav>
-
-        <div>
-
-          <!-- data -->
-          <section class="cmd-section" id="ja-data">
-            <div class="section-category">データ管理</div>
-            <h2 class="section-heading">forge data</h2>
-            <p>ヒストリカル市場データの取得・更新・管理を行います。データは <code>alpha-strategies/data/historical/</code> に Parquet 形式で保存されます。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge data fetch &lt;SYMBOL&gt;</code></td><td>指定シンボルのヒストリカルデータを取得・保存</td></tr>
-                <tr><td><code>forge data update</code></td><td>保存済み全データを最新日まで差分更新</td></tr>
-                <tr><td><code>forge data update --symbol &lt;SYMBOL&gt;</code></td><td>特定シンボルのみ更新</td></tr>
-                <tr><td><code>forge data list</code></td><td>保存済みデータ一覧を表示</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># 初回取得
-forge data fetch USDJPY
-forge data fetch CL=F
-forge data fetch SPY QQQ NAS100
-
-# 一括差分更新
-forge data update
-
-# 特定シンボルのみ更新
-forge data update --symbol USDJPY
-
-# 保存済みデータを確認
-forge data list</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- strategy -->
-          <section class="cmd-section" id="ja-strategy">
-            <div class="section-category">戦略管理</div>
-            <h2 class="section-heading">forge strategy</h2>
-            <p>戦略 JSON の作成・登録・確認を行います。戦略は JSON ファイルで定義し、バックテストや最適化の対象として登録します。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge strategy list</code></td><td>登録済み戦略を一覧表示</td></tr>
-                <tr><td><code>forge strategy create</code></td><td>テンプレートから戦略 JSON を作成</td></tr>
-                <tr><td><code>forge strategy save &lt;FILE&gt;</code></td><td>JSON ファイルから戦略を登録</td></tr>
-                <tr><td><code>forge strategy show &lt;ID&gt;</code></td><td>戦略定義 (JSON) を表示</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># テンプレートから新規作成
-forge strategy create --template ema_crossover --id usdjpy_ema_v1 \
-  --out data/strategies/usdjpy_ema_v1.json
-
-# JSON ファイルを登録
-forge strategy save data/strategies/usdjpy_ema_v1.json
-
-# 登録済み戦略を確認
-forge strategy list
-
-# 戦略定義を表示
-forge strategy show usdjpy_ema_v1</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- backtest -->
-          <section class="cmd-section" id="ja-backtest">
-            <div class="section-category">バックテスト</div>
-            <h2 class="section-heading">forge backtest</h2>
-            <p>戦略のバックテスト実行・履歴確認・分析を行います。結果は SQLite DB に自動保存されます。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge backtest run &lt;SYMBOL&gt;</code></td><td>バックテストを実行</td></tr>
-                <tr><td><code>forge backtest wft &lt;SYMBOL&gt;</code></td><td>ウォークフォワードテストを実行</td></tr>
-                <tr><td><code>forge backtest list</code></td><td>保存済みバックテスト結果を一覧表示</td></tr>
-                <tr><td><code>forge backtest report &lt;ID&gt;</code></td><td>バックテスト結果の詳細を表示</td></tr>
-                <tr><td><code>forge backtest compare</code></td><td>複数の戦略結果を並べて比較</td></tr>
-                <tr><td><code>forge backtest chart &lt;SYMBOL&gt;</code></td><td>インタラクティブ HTML チャートを生成</td></tr>
-                <tr><td><code>forge backtest diagnose &lt;SYMBOL&gt;</code></td><td>パフォーマンス問題を自動診断</td></tr>
-                <tr><td><code>forge backtest monte-carlo &lt;SYMBOL&gt;</code></td><td>モンテカルロシミュレーションを実行</td></tr>
-                <tr><td><code>forge backtest portfolio</code></td><td>ポートフォリオバックテストを実行</td></tr>
-                <tr><td><code>forge backtest batch</code></td><td>複数戦略を並列バックテスト</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># 基本的なバックテスト
-forge backtest run USDJPY --strategy usdjpy_ema_v1
-
-# 期間指定
-forge backtest run USDJPY --strategy usdjpy_ema_v1 \
-  --start 2021-01-01 --end 2024-12-31
-
-# JSON 形式で出力
-forge backtest run USDJPY --strategy usdjpy_ema_v1 --json
-
-# ウォークフォワードテスト（5 フォールド）
-forge backtest wft USDJPY --strategy usdjpy_ema_v1 --folds 5
-
-# 結果一覧（Sharpe 降順）
-forge backtest list --sort sharpe --limit 20
-
-# 特定戦略の結果のみ
-forge backtest list --strategy usdjpy_ema_v1
-
-# インタラクティブチャートを生成してブラウザで開く
-forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- optimize -->
-          <section class="cmd-section" id="ja-optimize">
-            <div class="section-category">最適化</div>
-            <h2 class="section-heading">forge optimize</h2>
-            <p>Optuna を使ったベイズ最適化でパラメータを効率的に探索します。過学習リスクの評価や、最適化結果の戦略への適用もできます。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge optimize run &lt;SYMBOL&gt;</code></td><td>ベイズ最適化を実行</td></tr>
-                <tr><td><code>forge optimize apply &lt;RESULT&gt;</code></td><td>最適化結果を戦略に適用して新規保存</td></tr>
-                <tr><td><code>forge optimize walk-forward &lt;SYMBOL&gt;</code></td><td>ウォークフォワード最適化を実行</td></tr>
-                <tr><td><code>forge optimize sensitivity &lt;SYMBOL&gt;</code></td><td>パラメータ感度分析（過学習リスク評価）</td></tr>
-                <tr><td><code>forge optimize history</code></td><td>過去の最適化結果をスコアボード表示</td></tr>
-                <tr><td><code>forge optimize portfolio</code></td><td>ポートフォリオ最適配分を最適化</td></tr>
-                <tr><td><code>forge optimize cross-symbol</code></td><td>複数銘柄への汎化性を最適化</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># Sharpe Ratio を指標に 200 トライアル、4 並列で最適化
-forge optimize run USDJPY --strategy usdjpy_ema_v1 \
-  --metric sharpe_ratio --trials 200 -j 4 --save
-
-# 最適化履歴を確認
-forge optimize history --strategy usdjpy_ema_v1 --sort score
-
-# 最適化結果を新しい戦略として保存
-forge optimize apply data/results/usdjpy_ema_v1_opt.json \
-  --to-strategy usdjpy_ema_v1_optimized
-
-# 感度分析で過学習リスクを評価
-forge optimize sensitivity USDJPY --strategy usdjpy_ema_v1_optimized</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- pine -->
-          <section class="cmd-section" id="ja-pine">
-            <div class="section-category">Pine Script</div>
-            <h2 class="section-heading">forge pine</h2>
-            <p>戦略定義から TradingView 用の Pine Script v6 を自動生成します。HMM などの機械学習インジケータにも対応しています。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge pine generate --strategy &lt;ID&gt;</code></td><td>Pine Script を生成してファイルに出力</td></tr>
-                <tr><td><code>forge pine preview --strategy &lt;ID&gt;</code></td><td>生成される Pine Script を標準出力でプレビュー</td></tr>
-                <tr><td><code>forge pine import &lt;FILE&gt;</code></td><td>.pine ファイルを戦略定義として取り込み</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># Pine Script を生成（output/pinescript/ に保存）
-forge pine generate --strategy usdjpy_ema_v1_optimized
-
-# HMM モデルの学習済みパラメータを埋め込んで生成
-forge pine generate --strategy cl_hmm_bb_rsi_v1 --with-training-data
-
-# 内容をプレビュー（ファイル出力なし）
-forge pine preview --strategy usdjpy_ema_v1_optimized
-
-# 既存 .pine ファイルをインポート
-forge pine import output/pinescript/usdjpy_ema_v1.pine --id usdjpy_ema_imported</code></pre>
-
-            <div class="callout">
-              生成ファイルの保存先は <code>forge.yaml</code> の <code>pinescript.output_path</code> で設定します。デフォルトは <code>output/pinescript/</code> です。
-            </div>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- dashboard & license -->
-          <section class="cmd-section" id="ja-dashboard">
-            <div class="section-category">Web UI</div>
-            <h2 class="section-heading">forge dashboard</h2>
-            <p>Streamlit ベースの Web UI を起動します。バックテスト結果の可視化、戦略ランキング、アイデア管理を一画面で確認できます。</p>
-            <pre><code>forge dashboard
-forge dashboard --port 8501 --no-open</code></pre>
-          </section>
-
-          <section class="cmd-section" id="ja-license" style="margin-top:2rem;">
-            <div class="section-category">ライセンス</div>
-            <h2 class="section-heading">forge license</h2>
-            <p>LemonSqueezy のライセンスキーを認証します。認証情報は <code>~/.forge/license.json</code> にキャッシュされます。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge license activate &lt;KEY&gt;</code></td><td>ライセンスキーを認証</td></tr>
-                <tr><td><code>forge license status</code></td><td>現在のライセンス状態を表示</td></tr>
-                <tr><td><code>forge license deactivate</code></td><td>このデバイスのライセンスを無効化</td></tr>
-              </tbody>
-            </table>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- workflow -->
-          <section class="cmd-section" id="ja-workflow">
-            <div class="section-category">ガイド</div>
-            <h2 class="section-heading">エンドツーエンド 戦略開発ワークフロー</h2>
-            <p>ヒストリカルデータの取得から自動発注まで、典型的な開発フローを示します。Claude Code などのコーディングエージェントと組み合わせると、各ステップの自動化やパラメータ探索を高速化できます。</p>
-
-            <div class="callout">
-              以下のコマンドはすべて <code>alpha-strategies/</code> ディレクトリから <code>FORGE_CONFIG=forge.yaml uv run</code> 付きで実行することを想定しています。
-            </div>
-
-            <ul class="step-list">
-              <li>
-                <div>
-                  <strong>データ取得</strong>
-                  対象シンボルのヒストリカルデータをローカルに保存します。
-                  <pre><code>forge data fetch USDJPY</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>戦略テンプレート作成</strong>
-                  テンプレートから戦略 JSON の雛形を生成し、パラメータを編集します。
-                  <pre><code>forge strategy create --template ema_crossover \
-  --id usdjpy_ema_v1 \
-  --out data/strategies/usdjpy_ema_v1.json
-
-# 生成されたファイルをエディタで編集し、パラメータを調整
-forge strategy save data/strategies/usdjpy_ema_v1.json</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>バックテスト実行</strong>
-                  定義した戦略のパフォーマンスを過去データで検証します。
-                  <pre><code>forge backtest run USDJPY --strategy usdjpy_ema_v1
-
-# インタラクティブチャートで視覚的に確認
-forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>パラメータ最適化</strong>
-                  Optuna のベイズ最適化で最適なパラメータを探索します。
-                  <pre><code>forge optimize run USDJPY --strategy usdjpy_ema_v1 \
-  --metric sharpe_ratio --trials 300 -j 4 --save
-
-# 結果を新しい戦略として保存
-forge optimize apply data/results/usdjpy_ema_v1_opt.json \
-  --to-strategy usdjpy_ema_v1_optimized</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>ウォークフォワード検証</strong>
-                  過学習を検出するために、訓練期間とテスト期間を分けた検証を行います。
-                  <pre><code>forge backtest wft USDJPY --strategy usdjpy_ema_v1_optimized \
-  --folds 5
-
-# 感度分析でパラメータの堅牢性を確認
-forge optimize sensitivity USDJPY \
-  --strategy usdjpy_ema_v1_optimized</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Pine Script 生成</strong>
-                  TradingView 用のアラートスクリプトを自動生成します。
-                  <pre><code>forge pine generate --strategy usdjpy_ema_v1_optimized</code></pre>
-                  出力先: <code>output/pinescript/usdjpy_ema_v1_optimized.pine</code>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- tradingview -->
-          <section class="cmd-section" id="ja-tradingview">
-            <div class="section-category">ガイド</div>
-            <h2 class="section-heading">TradingView への Pine Script 反映</h2>
-            <p><code>forge pine generate</code> で生成した <code>.pine</code> ファイルを TradingView に貼り付けてアラートを設定します。</p>
-
-            <ul class="step-list">
-              <li>
-                <div>
-                  <strong>Pine Script を開く</strong>
-                  TradingView でチャートを開き、画面下部の「Pine エディタ」タブをクリックします。
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>スクリプトを貼り付ける</strong>
-                  生成した <code>.pine</code> ファイルの内容をエディタに貼り付け、「スクリプトを追加」（▶ ボタン）をクリックします。
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>アラートを設定する</strong>
-                  チャート右上のベルアイコン（アラート）→「アラートを追加」をクリック。
-                  <ul style="margin-top:0.4rem; padding-left:1.2rem; font-size:0.88rem; color:var(--text2);">
-                    <li>条件: 追加したスクリプト名を選択</li>
-                    <li>「Webhook URL」にチェックを入れ、alpha-strike のエンドポイントを入力</li>
-                    <li>「メッセージ」に後述の JSON ペイロードを入力</li>
-                  </ul>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>アラートメッセージのヒント</strong>
-                  Pine Script 内でシグナル変数（例: <code>longSignal</code>）を定義しておくと、アラートの条件設定が簡単になります。
-                  <pre><code>// Pine Script 内でのアラート定義例
-longSignal = ta.crossover(ema_fast, ema_slow)
-shortSignal = ta.crossunder(ema_fast, ema_slow)
-alertcondition(longSignal, title="Long Entry", message="long")</code></pre>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- alpha-strike -->
-          <section class="cmd-section" id="ja-strike">
-            <div class="section-category">ガイド</div>
-            <h2 class="section-heading">TradingView と alpha-strike の連携</h2>
-            <p>alpha-strike は TradingView のアラートを Webhook で受け取り、OANDA・moomoo 証券に自動発注します。</p>
-
-            <h3 class="sub-heading">1. 環境変数の設定</h3>
-            <p><code>alpha-strike/.env</code> を作成して以下を設定します。</p>
-            <pre><code># 必須
-WEBHOOK_PASSPHRASE=your-secret-passphrase   # 任意の秘密文字列
-
-# OANDA 使用時
-OANDA_API_KEY=your-personal-access-token
-OANDA_ACCOUNT_ID=your-account-id
-OANDA_ENV=PRACTICE    # 本番は LIVE
-
-# moomoo 使用時
-MOOMOO_HOST=127.0.0.1
-MOOMOO_PORT=11111
-MOOMOO_TRD_ENV=SIMULATE   # 本番は REAL</code></pre>
-
-            <h3 class="sub-heading">2. Webhook URL</h3>
-            <div class="callout">
-              TradingView のアラート Webhook URL に以下を設定します:<br/>
-              <code>http://&lt;your-server&gt;:8080/webhook</code>
-            </div>
-
-            <h3 class="sub-heading">3. ペイロード仕様</h3>
-            <p>TradingView のアラートメッセージに JSON を記述します。</p>
-            <pre><code>{
-  "passphrase": "your-secret-passphrase",
-  "broker": "oanda",
-  "asset_class": "FX",
-  "action": "buy",
-  "ticker": "USDJPY",
-  "quantity": 1000
-}</code></pre>
-
-            <table class="payload-table">
-              <thead><tr><th>フィールド</th><th>説明</th><th>値の例</th></tr></thead>
-              <tbody>
-                <tr><td><code>passphrase</code><br/><span class="req">必須</span></td><td>.env の WEBHOOK_PASSPHRASE と一致させること</td><td>"my-secret"</td></tr>
-                <tr><td><code>broker</code><br/><span class="req">必須</span></td><td>発注先の証券会社</td><td>"oanda" / "moomoo"</td></tr>
-                <tr><td><code>asset_class</code><br/><span class="req">必須</span></td><td>アセットクラス</td><td>"FX" / "COMMODITY" / "US" / "INDEX"</td></tr>
-                <tr><td><code>action</code><br/><span class="req">必須</span></td><td>注文方向</td><td>"buy" / "sell"</td></tr>
-                <tr><td><code>ticker</code><br/><span class="req">必須</span></td><td>銘柄コード（TradingView のシンボル名）</td><td>"USDJPY" / "XAUUSD"</td></tr>
-                <tr><td><code>quantity</code><br/><span class="req">必須</span></td><td>注文数量（0 より大きい正の数）</td><td>1000 / 0.1</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">4. ティッカーと OANDA instrument の対応</h3>
-            <table class="option-table">
-              <thead><tr><th>asset_class</th><th>ticker 例</th><th>OANDA instrument</th></tr></thead>
-              <tbody>
-                <tr><td>FX</td><td>USDJPY</td><td>USD_JPY</td></tr>
-                <tr><td>COMMODITY</td><td>XAUUSD</td><td>XAU_USD</td></tr>
-                <tr><td>INDEX</td><td>NAS100</td><td>NAS100_USD</td></tr>
-                <tr><td>US</td><td>AAPL</td><td>AAPL_USD</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">5. 動作確認</h3>
-            <pre><code># ヘルスチェック
-curl http://localhost:8080/health
-# → {"status":"ok"}
-
-# テスト発注（PRACTICE / SIMULATE 環境で確認）
-curl -X POST http://localhost:8080/webhook \
-  -H "Content-Type: application/json" \
-  -d '{"passphrase":"your-secret","broker":"oanda","asset_class":"FX","action":"buy","ticker":"USDJPY","quantity":1000}'</code></pre>
-          </section>
-
-        </div>
+      <h1 class="page-title">forge コマンドの早見表</h1>
+      <p class="page-subtitle">主要 6 コマンドのカードと全コマンドカタログ。詳細パラメータと出力例は公式ドキュメントへ。</p>
+
+      <div class="callout" style="margin-bottom: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          全 76 サブコマンドの詳細パラメータ、出力例、エラーコードは
+          <strong>公式ドキュメント</strong>を参照してください。
+        </p>
+        <a href="/ja/docs/cli-reference/" class="btn-primary">
+          CLI リファレンスを開く →
+        </a>
       </div>
-    </div><!-- /lang-ja -->
 
+      <h2 class="section-heading">主要コマンド</h2>
+      <div class="cmd-card-grid">
+        <a class="cmd-card" href="/ja/docs/cli-reference/backtest/#forge-backtest-run">
+          <div class="cmd-card-name">forge backtest run</div>
+          <div class="cmd-card-desc">単一銘柄に戦略を適用してバックテストを実行する。</div>
+          <pre class="cmd-card-usage"><code>forge backtest run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--strategy</span>
+            <span class="cmd-card-option">--start</span>
+            <span class="cmd-card-option">--json</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
 
-    <!-- ==================== English version ==================== -->
+        <a class="cmd-card" href="/ja/docs/cli-reference/optimize/#forge-optimize-run">
+          <div class="cmd-card-name">forge optimize run</div>
+          <div class="cmd-card-desc">Optuna によるパラメータ最適化（TPE）。多目的最適化にも対応。</div>
+          <pre class="cmd-card-usage"><code>forge optimize run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--metric</span>
+            <span class="cmd-card-option">--trials</span>
+            <span class="cmd-card-option">--apply</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/optimize/#forge-optimize-walk-forward">
+          <div class="cmd-card-name">forge optimize walk-forward</div>
+          <div class="cmd-card-desc">時系列をウィンドウ分割し IS 最適化 → OOS 評価で過学習耐性を測定。</div>
+          <pre class="cmd-card-usage"><code>forge optimize walk-forward SYMBOL --strategy ID --windows N</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--windows</span>
+            <span class="cmd-card-option">--metric</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/data/#forge-data-fetch">
+          <div class="cmd-card-name">forge data fetch</div>
+          <div class="cmd-card-desc">OHLCV をプロバイダーから取得し Parquet で保存。</div>
+          <pre class="cmd-card-usage"><code>forge data fetch SYMBOL --period 5y --interval 1d</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--period</span>
+            <span class="cmd-card-option">--interval</span>
+            <span class="cmd-card-option">--watchlist</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/strategy/#forge-strategy-save">
+          <div class="cmd-card-name">forge strategy save</div>
+          <div class="cmd-card-desc">戦略 JSON をレジストリに登録（任意で Journal に記録）。</div>
+          <pre class="cmd-card-usage"><code>forge strategy save FILE_PATH</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--force</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/journal/#forge-journal-show">
+          <div class="cmd-card-name">forge journal show</div>
+          <div class="cmd-card-desc">戦略の全履歴（スナップショット・Runs・タグ・ライブサマリ）を表示。</div>
+          <pre class="cmd-card-usage"><code>forge journal show STRATEGY_ID</code></pre>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+      </div>
+
+      <h2 class="section-heading">全コマンドカタログ</h2>
+      <table class="cmd-table">
+        <thead>
+          <tr><th>グループ</th><th>説明</th><th>サブコマンド数</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/backtest/"><code>forge backtest</code></a></td>
+            <td>バックテスト実行・スキャン・カスタム実験</td>
+            <td>11</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/optimize/"><code>forge optimize</code></a></td>
+            <td>パラメータ最適化（grid / bayes / wfa）</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td>
+            <td>戦略 JSON の保存・検証・適用</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/data/"><code>forge data</code></a></td>
+            <td>ヒストリカルデータ取得・更新</td>
+            <td>4</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/journal/"><code>forge journal</code></a></td>
+            <td>取引ジャーナル・トレード分析</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/live/"><code>forge live</code></a></td>
+            <td>ライブトレーディング・ブローカー連携</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/other/">その他コマンド</a></td>
+            <td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> 他</td>
+            <td>10 グループ</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout" style="margin-top: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          各グループの完全なサブコマンドリスト、オプション一覧、戻り値、サンプル出力は
+          ドキュメントの CLI リファレンスを参照してください。
+        </p>
+        <a href="/ja/docs/cli-reference/" class="btn-primary">
+          CLI リファレンスを開く →
+        </a>
+      </div>
+
+      <div class="callout" style="margin-top: 1rem;">
+        <p>サポートが必要な場合は <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a> までお問い合わせください。</p>
+      </div>
+    </div>
+
+    <!-- ==================== English ==================== -->
     <div class="lang-content lang-en">
       <div class="page-label">Documentation</div>
-      <h1 class="page-title">Documentation</h1>
-      <p class="page-subtitle">Command reference, strategy development workflow, and TradingView integration guide.</p>
-
-      <div class="doc-layout" style="margin-top: 2rem;">
-        <nav class="cmd-nav">
-          <ul class="cmd-nav-list">
-            <li class="nav-group">Data</li>
-            <li><a href="#en-data">data</a></li>
-            <li class="nav-group">Strategy</li>
-            <li><a href="#en-strategy">strategy</a></li>
-            <li class="nav-group">Backtest</li>
-            <li><a href="#en-backtest">backtest</a></li>
-            <li class="nav-group">Optimize</li>
-            <li><a href="#en-optimize">optimize</a></li>
-            <li class="nav-group">Pine Script</li>
-            <li><a href="#en-pine">pine</a></li>
-            <li class="nav-group">Other</li>
-            <li><a href="#en-dashboard">dashboard</a></li>
-            <li><a href="#en-license">license</a></li>
-            <li class="nav-group">Guides</li>
-            <li><a href="#en-workflow">Workflow</a></li>
-            <li><a href="#en-tradingview">TradingView</a></li>
-            <li><a href="#en-strike">alpha-strike</a></li>
-          </ul>
-        </nav>
-
-        <div>
-
-          <!-- data -->
-          <section class="cmd-section" id="en-data">
-            <div class="section-category">Data Management</div>
-            <h2 class="section-heading">forge data</h2>
-            <p>Fetch, update, and manage historical market data. Data is stored as Parquet files under <code>alpha-strategies/data/historical/</code>.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge data fetch &lt;SYMBOL&gt;</code></td><td>Fetch and save historical data for a symbol</td></tr>
-                <tr><td><code>forge data update</code></td><td>Incrementally update all saved data to today</td></tr>
-                <tr><td><code>forge data update --symbol &lt;SYMBOL&gt;</code></td><td>Update a specific symbol only</td></tr>
-                <tr><td><code>forge data list</code></td><td>List all saved datasets</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># Initial fetch
-forge data fetch USDJPY
-forge data fetch CL=F
-forge data fetch SPY QQQ NAS100
-
-# Incremental update (all symbols)
-forge data update
-
-# Update a single symbol
-forge data update --symbol USDJPY
-
-# Check what's saved
-forge data list</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- strategy -->
-          <section class="cmd-section" id="en-strategy">
-            <div class="section-category">Strategy Management</div>
-            <h2 class="section-heading">forge strategy</h2>
-            <p>Create, register, and inspect strategy JSON definitions. Strategies must be registered before use in backtests or optimization.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge strategy list</code></td><td>List all registered strategies</td></tr>
-                <tr><td><code>forge strategy create</code></td><td>Generate a strategy JSON from a template</td></tr>
-                <tr><td><code>forge strategy save &lt;FILE&gt;</code></td><td>Register a strategy from a JSON file</td></tr>
-                <tr><td><code>forge strategy show &lt;ID&gt;</code></td><td>Print the strategy definition (JSON)</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># Create from template
-forge strategy create --template ema_crossover --id usdjpy_ema_v1 \
-  --out data/strategies/usdjpy_ema_v1.json
-
-# Register after editing the JSON
-forge strategy save data/strategies/usdjpy_ema_v1.json
-
-# List registered strategies
-forge strategy list
-
-# Inspect a strategy definition
-forge strategy show usdjpy_ema_v1</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- backtest -->
-          <section class="cmd-section" id="en-backtest">
-            <div class="section-category">Backtesting</div>
-            <h2 class="section-heading">forge backtest</h2>
-            <p>Run backtests, view history, and analyse results. All results are automatically saved to SQLite.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge backtest run &lt;SYMBOL&gt;</code></td><td>Run a backtest</td></tr>
-                <tr><td><code>forge backtest wft &lt;SYMBOL&gt;</code></td><td>Run a walk-forward test</td></tr>
-                <tr><td><code>forge backtest list</code></td><td>List saved backtest results</td></tr>
-                <tr><td><code>forge backtest report &lt;ID&gt;</code></td><td>Show detailed result for a run</td></tr>
-                <tr><td><code>forge backtest compare</code></td><td>Compare multiple strategy results side by side</td></tr>
-                <tr><td><code>forge backtest chart &lt;SYMBOL&gt;</code></td><td>Generate an interactive HTML chart</td></tr>
-                <tr><td><code>forge backtest diagnose &lt;SYMBOL&gt;</code></td><td>Auto-diagnose performance issues</td></tr>
-                <tr><td><code>forge backtest monte-carlo &lt;SYMBOL&gt;</code></td><td>Run Monte Carlo simulation</td></tr>
-                <tr><td><code>forge backtest portfolio</code></td><td>Run a portfolio backtest</td></tr>
-                <tr><td><code>forge backtest batch</code></td><td>Parallel backtest across multiple strategies</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># Basic backtest
-forge backtest run USDJPY --strategy usdjpy_ema_v1
-
-# With date range
-forge backtest run USDJPY --strategy usdjpy_ema_v1 \
-  --start 2021-01-01 --end 2024-12-31
-
-# JSON output
-forge backtest run USDJPY --strategy usdjpy_ema_v1 --json
-
-# Walk-forward test (5 folds)
-forge backtest wft USDJPY --strategy usdjpy_ema_v1 --folds 5
-
-# List results sorted by Sharpe
-forge backtest list --sort sharpe --limit 20
-
-# Open interactive chart in browser
-forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- optimize -->
-          <section class="cmd-section" id="en-optimize">
-            <div class="section-category">Optimization</div>
-            <h2 class="section-heading">forge optimize</h2>
-            <p>Bayesian parameter search with Optuna. Includes overfitting risk evaluation, walk-forward optimization, and one-click apply.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge optimize run &lt;SYMBOL&gt;</code></td><td>Run Bayesian optimization</td></tr>
-                <tr><td><code>forge optimize apply &lt;RESULT&gt;</code></td><td>Apply results to a new strategy</td></tr>
-                <tr><td><code>forge optimize walk-forward &lt;SYMBOL&gt;</code></td><td>Walk-forward optimization</td></tr>
-                <tr><td><code>forge optimize sensitivity &lt;SYMBOL&gt;</code></td><td>Parameter sensitivity analysis (overfitting check)</td></tr>
-                <tr><td><code>forge optimize history</code></td><td>Scoreboard of past optimization runs</td></tr>
-                <tr><td><code>forge optimize portfolio</code></td><td>Optimize portfolio allocation weights</td></tr>
-                <tr><td><code>forge optimize cross-symbol</code></td><td>Optimize across multiple symbols for generalization</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># 300 trials, 4 workers, maximize Sharpe
-forge optimize run USDJPY --strategy usdjpy_ema_v1 \
-  --metric sharpe_ratio --trials 300 -j 4 --save
-
-# View optimization history
-forge optimize history --strategy usdjpy_ema_v1 --sort score
-
-# Apply best result as a new strategy
-forge optimize apply data/results/usdjpy_ema_v1_opt.json \
-  --to-strategy usdjpy_ema_v1_optimized
-
-# Check parameter robustness
-forge optimize sensitivity USDJPY --strategy usdjpy_ema_v1_optimized</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- pine -->
-          <section class="cmd-section" id="en-pine">
-            <div class="section-category">Pine Script</div>
-            <h2 class="section-heading">forge pine</h2>
-            <p>Auto-generate TradingView Pine Script v6 from a strategy definition. Supports machine-learning indicators such as HMM by embedding trained parameters.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge pine generate --strategy &lt;ID&gt;</code></td><td>Generate Pine Script and write to file</td></tr>
-                <tr><td><code>forge pine preview --strategy &lt;ID&gt;</code></td><td>Preview Pine Script in stdout (no file written)</td></tr>
-                <tr><td><code>forge pine import &lt;FILE&gt;</code></td><td>Parse a .pine file and import as a strategy</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># Generate Pine Script (saved to output/pinescript/)
-forge pine generate --strategy usdjpy_ema_v1_optimized
-
-# Embed trained HMM parameters
-forge pine generate --strategy cl_hmm_bb_rsi_v1 --with-training-data
-
-# Preview without writing to disk
-forge pine preview --strategy usdjpy_ema_v1_optimized
-
-# Import existing .pine file as a strategy
-forge pine import output/pinescript/usdjpy_ema_v1.pine --id usdjpy_ema_imported</code></pre>
-
-            <div class="callout">
-              The output path is configured via <code>pinescript.output_path</code> in <code>forge.yaml</code>. Default: <code>output/pinescript/</code>.
-            </div>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- dashboard & license -->
-          <section class="cmd-section" id="en-dashboard">
-            <div class="section-category">Web UI</div>
-            <h2 class="section-heading">forge dashboard</h2>
-            <p>Launch the Streamlit-based Web UI for backtest visualisation, strategy rankings, and idea tracking.</p>
-            <pre><code>forge dashboard
-forge dashboard --port 8501 --no-open</code></pre>
-          </section>
-
-          <section class="cmd-section" id="en-license" style="margin-top:2rem;">
-            <div class="section-category">License</div>
-            <h2 class="section-heading">forge license</h2>
-            <p>Activate and manage your LemonSqueezy license. Activation data is cached in <code>~/.forge/license.json</code>.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge license activate &lt;KEY&gt;</code></td><td>Activate a license key on this device</td></tr>
-                <tr><td><code>forge license status</code></td><td>Show current license status</td></tr>
-                <tr><td><code>forge license deactivate</code></td><td>Deactivate this device</td></tr>
-              </tbody>
-            </table>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- workflow -->
-          <section class="cmd-section" id="en-workflow">
-            <div class="section-category">Guide</div>
-            <h2 class="section-heading">End-to-End Strategy Development Workflow</h2>
-            <p>A typical flow from raw data to live execution. This pairs naturally with a coding agent (e.g. Claude Code) for automated parameter exploration and strategy generation.</p>
-
-            <div class="callout">
-              All commands below assume you are running from <code>alpha-strategies/</code> with <code>FORGE_CONFIG=forge.yaml uv run</code> prepended.
-            </div>
-
-            <ul class="step-list">
-              <li>
-                <div>
-                  <strong>Fetch historical data</strong>
-                  <pre><code>forge data fetch USDJPY</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Create a strategy from a template</strong>
-                  Generate a JSON scaffold, edit parameters, then register it.
-                  <pre><code>forge strategy create --template ema_crossover \
-  --id usdjpy_ema_v1 \
-  --out data/strategies/usdjpy_ema_v1.json
-
-# Edit the JSON, then register
-forge strategy save data/strategies/usdjpy_ema_v1.json</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Run a backtest</strong>
-                  <pre><code>forge backtest run USDJPY --strategy usdjpy_ema_v1
-
-# Visual equity curve
-forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Optimize parameters</strong>
-                  Bayesian search with Optuna, then apply the best result.
-                  <pre><code>forge optimize run USDJPY --strategy usdjpy_ema_v1 \
-  --metric sharpe_ratio --trials 300 -j 4 --save
-
-forge optimize apply data/results/usdjpy_ema_v1_opt.json \
-  --to-strategy usdjpy_ema_v1_optimized</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Walk-forward validation</strong>
-                  Detect overfitting with out-of-sample testing.
-                  <pre><code>forge backtest wft USDJPY --strategy usdjpy_ema_v1_optimized \
-  --folds 5
-
-forge optimize sensitivity USDJPY \
-  --strategy usdjpy_ema_v1_optimized</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Generate Pine Script</strong>
-                  Export a TradingView alert script from the optimized strategy.
-                  <pre><code>forge pine generate --strategy usdjpy_ema_v1_optimized</code></pre>
-                  Output: <code>output/pinescript/usdjpy_ema_v1_optimized.pine</code>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- tradingview -->
-          <section class="cmd-section" id="en-tradingview">
-            <div class="section-category">Guide</div>
-            <h2 class="section-heading">Deploying Pine Script to TradingView</h2>
-            <p>Paste the generated <code>.pine</code> file into TradingView and set up an alert to trigger alpha-strike.</p>
-
-            <ul class="step-list">
-              <li>
-                <div>
-                  <strong>Open the Pine Editor</strong>
-                  Open a chart in TradingView and click the "Pine Editor" tab at the bottom.
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Paste the script</strong>
-                  Copy the contents of the generated <code>.pine</code> file and paste it into the editor. Click "Add to chart" (▶).
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Create an alert</strong>
-                  Click the bell icon (Alerts) → "Create alert". Set the condition to your script, enable "Webhook URL", and paste the alpha-strike endpoint.
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Tip: in-script alert conditions</strong>
-                  Define <code>alertcondition</code> in Pine Script for cleaner alert setup.
-                  <pre><code>longSignal = ta.crossover(ema_fast, ema_slow)
-alertcondition(longSignal, title="Long Entry", message="long")</code></pre>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- alpha-strike -->
-          <section class="cmd-section" id="en-strike">
-            <div class="section-category">Guide</div>
-            <h2 class="section-heading">Connecting TradingView to alpha-strike</h2>
-            <p>alpha-strike receives TradingView webhook alerts and forwards orders to OANDA or moomoo.</p>
-
-            <h3 class="sub-heading">1. Configure environment variables</h3>
-            <p>Create <code>alpha-strike/.env</code> from the provided example:</p>
-            <pre><code># Required
-WEBHOOK_PASSPHRASE=your-secret-passphrase
-
-# OANDA
-OANDA_API_KEY=your-personal-access-token
-OANDA_ACCOUNT_ID=your-account-id
-OANDA_ENV=PRACTICE    # or LIVE
-
-# moomoo
-MOOMOO_HOST=127.0.0.1
-MOOMOO_PORT=11111
-MOOMOO_TRD_ENV=SIMULATE   # or REAL</code></pre>
-
-            <h3 class="sub-heading">2. Webhook URL</h3>
-            <div class="callout">
-              Set the TradingView alert Webhook URL to:<br/>
-              <code>http://&lt;your-server&gt;:8080/webhook</code>
-            </div>
-
-            <h3 class="sub-heading">3. Payload format</h3>
-            <pre><code>{
-  "passphrase": "your-secret-passphrase",
-  "broker": "oanda",
-  "asset_class": "FX",
-  "action": "buy",
-  "ticker": "USDJPY",
-  "quantity": 1000
-}</code></pre>
-
-            <table class="payload-table">
-              <thead><tr><th>Field</th><th>Description</th><th>Example</th></tr></thead>
-              <tbody>
-                <tr><td><code>passphrase</code><br/><span class="req">required</span></td><td>Must match WEBHOOK_PASSPHRASE in .env</td><td>"my-secret"</td></tr>
-                <tr><td><code>broker</code><br/><span class="req">required</span></td><td>Target broker</td><td>"oanda" / "moomoo"</td></tr>
-                <tr><td><code>asset_class</code><br/><span class="req">required</span></td><td>Asset class</td><td>"FX" / "COMMODITY" / "US" / "INDEX"</td></tr>
-                <tr><td><code>action</code><br/><span class="req">required</span></td><td>Order direction</td><td>"buy" / "sell"</td></tr>
-                <tr><td><code>ticker</code><br/><span class="req">required</span></td><td>Symbol (TradingView notation)</td><td>"USDJPY" / "XAUUSD"</td></tr>
-                <tr><td><code>quantity</code><br/><span class="req">required</span></td><td>Order size (positive number)</td><td>1000 / 0.1</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">4. Ticker to OANDA instrument mapping</h3>
-            <table class="option-table">
-              <thead><tr><th>asset_class</th><th>ticker</th><th>OANDA instrument</th></tr></thead>
-              <tbody>
-                <tr><td>FX</td><td>USDJPY</td><td>USD_JPY</td></tr>
-                <tr><td>COMMODITY</td><td>XAUUSD</td><td>XAU_USD</td></tr>
-                <tr><td>INDEX</td><td>NAS100</td><td>NAS100_USD</td></tr>
-                <tr><td>US</td><td>AAPL</td><td>AAPL_USD</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">5. Verify connectivity</h3>
-            <pre><code># Health check
-curl http://localhost:8080/health
-# → {"status":"ok"}
-
-# Test order (use PRACTICE / SIMULATE environment)
-curl -X POST http://localhost:8080/webhook \
-  -H "Content-Type: application/json" \
-  -d '{"passphrase":"your-secret","broker":"oanda","asset_class":"FX","action":"buy","ticker":"USDJPY","quantity":1000}'</code></pre>
-          </section>
-
-        </div>
+      <h1 class="page-title">forge Command Quick Reference</h1>
+      <p class="page-subtitle">Cards for the six core commands plus a full command catalog. Detailed parameters and output examples live in the official docs.</p>
+
+      <div class="callout" style="margin-bottom: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          For detailed parameters, output examples, and error codes for all 76 subcommands,
+          see the <strong>official documentation</strong>.
+        </p>
+        <a href="/en/docs/cli-reference/" class="btn-primary">
+          Open CLI Reference →
+        </a>
       </div>
-    </div><!-- /lang-en -->
+
+      <h2 class="section-heading">Top Commands</h2>
+      <div class="cmd-card-grid">
+        <a class="cmd-card" href="/en/docs/cli-reference/backtest/#forge-backtest-run">
+          <div class="cmd-card-name">forge backtest run</div>
+          <div class="cmd-card-desc">Run a backtest applying a strategy to a single symbol.</div>
+          <pre class="cmd-card-usage"><code>forge backtest run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--strategy</span>
+            <span class="cmd-card-option">--start</span>
+            <span class="cmd-card-option">--json</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/optimize/#forge-optimize-run">
+          <div class="cmd-card-name">forge optimize run</div>
+          <div class="cmd-card-desc">Parameter optimization with Optuna (TPE). Multi-objective also supported.</div>
+          <pre class="cmd-card-usage"><code>forge optimize run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--metric</span>
+            <span class="cmd-card-option">--trials</span>
+            <span class="cmd-card-option">--apply</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/optimize/#forge-optimize-walk-forward">
+          <div class="cmd-card-name">forge optimize walk-forward</div>
+          <div class="cmd-card-desc">Split time series into windows; IS optimization → OOS evaluation for overfitting resistance.</div>
+          <pre class="cmd-card-usage"><code>forge optimize walk-forward SYMBOL --strategy ID --windows N</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--windows</span>
+            <span class="cmd-card-option">--metric</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/data/#forge-data-fetch">
+          <div class="cmd-card-name">forge data fetch</div>
+          <div class="cmd-card-desc">Fetch OHLCV from a provider and store as Parquet.</div>
+          <pre class="cmd-card-usage"><code>forge data fetch SYMBOL --period 5y --interval 1d</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--period</span>
+            <span class="cmd-card-option">--interval</span>
+            <span class="cmd-card-option">--watchlist</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/strategy/#forge-strategy-save">
+          <div class="cmd-card-name">forge strategy save</div>
+          <div class="cmd-card-desc">Register a strategy JSON to the registry (optionally recorded in the Journal).</div>
+          <pre class="cmd-card-usage"><code>forge strategy save FILE_PATH</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--force</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/journal/#forge-journal-show">
+          <div class="cmd-card-name">forge journal show</div>
+          <div class="cmd-card-desc">Show the full history of a strategy (snapshots, runs, tags, live summary).</div>
+          <pre class="cmd-card-usage"><code>forge journal show STRATEGY_ID</code></pre>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+      </div>
+
+      <h2 class="section-heading">All Command Groups</h2>
+      <table class="cmd-table">
+        <thead>
+          <tr><th>Group</th><th>Description</th><th>Subcommands</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="/en/docs/cli-reference/backtest/"><code>forge backtest</code></a></td>
+            <td>Backtest execution, scanning, custom experiments</td>
+            <td>11</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/optimize/"><code>forge optimize</code></a></td>
+            <td>Parameter optimization (grid / bayes / wfa)</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td>
+            <td>Strategy JSON save / validate / apply</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/data/"><code>forge data</code></a></td>
+            <td>Historical data fetch / update</td>
+            <td>4</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/journal/"><code>forge journal</code></a></td>
+            <td>Trading journal and trade analysis</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/live/"><code>forge live</code></a></td>
+            <td>Live trading and broker integration</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/other/">Other commands</a></td>
+            <td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> and more</td>
+            <td>10 groups</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout" style="margin-top: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          For complete subcommand listings, options, return values, and sample output for each group,
+          see the CLI Reference in the official docs.
+        </p>
+        <a href="/en/docs/cli-reference/" class="btn-primary">
+          Open CLI Reference →
+        </a>
+      </div>
+
+      <div class="callout" style="margin-top: 1rem;">
+        <p>If you need help, contact <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a>.</p>
+      </div>
+    </div>
 
   </div>
 

--- a/templates/docs.html.j2
+++ b/templates/docs.html.j2
@@ -25,85 +25,58 @@
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../page.css" />
   <style>
-    .cmd-nav {
-      position: sticky; top: calc(var(--nav-h) + 1rem);
-      align-self: start;
+    /* ── CARD GRID ── */
+    .cmd-card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1rem;
+      margin: 1.5rem 0 2.5rem;
     }
-    .cmd-nav-list { list-style: none; padding: 0; }
-    .cmd-nav-list li a {
-      display: block; padding: 0.3rem 0.75rem;
-      font-family: var(--mono); font-size: 0.75rem; color: var(--text3);
-      text-decoration: none; border-left: 2px solid var(--border);
-      transition: color 0.15s, border-color 0.15s;
+    .cmd-card {
+      display: block;
+      padding: 1.25rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      text-decoration: none;
+      transition: border-color 0.15s, transform 0.15s;
     }
-    .cmd-nav-list li a:hover { color: var(--accent); border-left-color: var(--accent); }
-    .cmd-nav-list .nav-group {
-      font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.12em;
-      color: var(--text3); padding: 0.7rem 0.75rem 0.2rem; font-family: var(--mono);
-      border-left: 2px solid transparent;
+    .cmd-card:hover {
+      border-color: var(--accent);
+      transform: translateY(-2px);
+      text-decoration: none;
     }
-    .doc-layout {
-      display: grid; grid-template-columns: 190px 1fr; gap: 3rem;
+    .cmd-card-name {
+      font-family: var(--mono);
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--accent);
+      margin-bottom: 0.4rem;
     }
-    .option-table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
-    .option-table th {
-      font-family: var(--mono); font-size: 0.65rem; color: var(--text3);
-      text-transform: uppercase; letter-spacing: 0.1em;
-      text-align: left; padding: 0.4rem 0.75rem;
-      border-bottom: 1px solid var(--border); background: var(--bg2);
+    .cmd-card-desc { font-size: 0.85rem; color: var(--text2); margin-bottom: 0.75rem; }
+    .cmd-card-usage {
+      background: var(--bg2);
+      padding: 0.5rem 0.75rem;
+      border-radius: 4px;
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      color: var(--text);
+      margin: 0 0 0.75rem;
+      overflow-x: auto;
     }
-    .option-table td {
-      font-size: 0.85rem; color: var(--text2);
-      padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--border);
-      vertical-align: top;
+    .cmd-card-options { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 0.75rem; }
+    .cmd-card-option {
+      font-family: var(--mono); font-size: 0.72rem;
+      padding: 0.2rem 0.5rem;
+      background: var(--accent-bg); color: var(--accent);
+      border-radius: 4px;
     }
-    .option-table td:first-child code { color: var(--accent); font-family: var(--mono); font-size: 0.82rem; }
-    .option-table tr:last-child td { border-bottom: none; }
-    .cmd-section { scroll-margin-top: calc(var(--nav-h) + 2rem); margin-bottom: 3rem; }
-    .section-divider { border: none; border-top: 1px solid var(--border); margin: 3rem 0 2.5rem; }
-    .section-category {
-      font-size: 0.65rem; font-family: var(--mono); text-transform: uppercase;
-      letter-spacing: 0.14em; color: var(--accent); margin-bottom: 0.5rem;
+    .cmd-card-link {
+      font-size: 0.78rem;
+      color: var(--text3);
+      font-family: var(--mono);
     }
-    .step-list { list-style: none; padding: 0; counter-reset: steps; }
-    .step-list li {
-      counter-increment: steps;
-      display: grid; grid-template-columns: 2rem 1fr; gap: 1rem;
-      margin-bottom: 1.5rem; align-items: start;
-    }
-    .step-list li::before {
-      content: counter(steps);
-      display: flex; align-items: center; justify-content: center;
-      width: 1.75rem; height: 1.75rem;
-      background: var(--accent); color: var(--bg); border-radius: 50%;
-      font-size: 0.8rem; font-weight: 700; flex-shrink: 0; margin-top: 0.1rem;
-    }
-    .step-list li > div > strong { display: block; margin-bottom: 0.3rem; }
-    .callout {
-      background: var(--bg2); border-left: 3px solid var(--accent);
-      padding: 0.85rem 1rem; border-radius: 0 6px 6px 0;
-      font-size: 0.88rem; color: var(--text2); margin: 0.75rem 0 1rem;
-    }
-    .callout code { font-family: var(--mono); font-size: 0.82rem; color: var(--accent); }
-    .payload-table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
-    .payload-table th {
-      font-family: var(--mono); font-size: 0.65rem; color: var(--text3);
-      text-transform: uppercase; letter-spacing: 0.1em;
-      text-align: left; padding: 0.4rem 0.75rem;
-      border-bottom: 1px solid var(--border); background: var(--bg2);
-    }
-    .payload-table td {
-      font-size: 0.83rem; color: var(--text2);
-      padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border);
-      vertical-align: top;
-    }
-    .payload-table td:first-child code { color: var(--amber); font-family: var(--mono); font-size: 0.8rem; }
-    .payload-table td .req { font-size: 0.7rem; color: var(--red, #f87171); }
-    .payload-table tr:last-child td { border-bottom: none; }
-    @media (max-width: 768px) {
-      .doc-layout { grid-template-columns: 1fr; }
-      .cmd-nav { display: none; }
-    }
+    .cmd-card:hover .cmd-card-link { color: var(--accent); }
   </style>
   <script>
     (function() {
@@ -121,877 +94,291 @@
 <body data-theme="dark" data-lang="{{ lang }}">
   <div id="site-header"></div>
 
-  <div class="page-wrap" style="max-width: 1060px;">
+  <div class="page-wrap">
 
     <!-- ==================== 日本語版 ==================== -->
     <div class="lang-content lang-ja">
       <div class="page-label">Documentation</div>
-      <h1 class="page-title">ドキュメント</h1>
-      <p class="page-subtitle">コマンドリファレンス、戦略開発ワークフロー、TradingView 連携ガイド。</p>
-
-      <div class="doc-layout" style="margin-top: 2rem;">
-        <nav class="cmd-nav">
-          <ul class="cmd-nav-list">
-            <li class="nav-group">データ</li>
-            <li><a href="#ja-data">data</a></li>
-            <li class="nav-group">戦略</li>
-            <li><a href="#ja-strategy">strategy</a></li>
-            <li class="nav-group">バックテスト</li>
-            <li><a href="#ja-backtest">backtest</a></li>
-            <li class="nav-group">最適化</li>
-            <li><a href="#ja-optimize">optimize</a></li>
-            <li class="nav-group">Pine Script</li>
-            <li><a href="#ja-pine">pine</a></li>
-            <li class="nav-group">その他</li>
-            <li><a href="#ja-dashboard">dashboard</a></li>
-            <li><a href="#ja-license">license</a></li>
-            <li class="nav-group">ガイド</li>
-            <li><a href="#ja-workflow">開発ワークフロー</a></li>
-            <li><a href="#ja-tradingview">TradingView連携</a></li>
-            <li><a href="#ja-strike">alpha-strike連携</a></li>
-          </ul>
-        </nav>
-
-        <div>
-
-          <!-- data -->
-          <section class="cmd-section" id="ja-data">
-            <div class="section-category">データ管理</div>
-            <h2 class="section-heading">forge data</h2>
-            <p>ヒストリカル市場データの取得・更新・管理を行います。データは <code>alpha-strategies/data/historical/</code> に Parquet 形式で保存されます。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge data fetch &lt;SYMBOL&gt;</code></td><td>指定シンボルのヒストリカルデータを取得・保存</td></tr>
-                <tr><td><code>forge data update</code></td><td>保存済み全データを最新日まで差分更新</td></tr>
-                <tr><td><code>forge data update --symbol &lt;SYMBOL&gt;</code></td><td>特定シンボルのみ更新</td></tr>
-                <tr><td><code>forge data list</code></td><td>保存済みデータ一覧を表示</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># 初回取得
-forge data fetch USDJPY
-forge data fetch CL=F
-forge data fetch SPY QQQ NAS100
-
-# 一括差分更新
-forge data update
-
-# 特定シンボルのみ更新
-forge data update --symbol USDJPY
-
-# 保存済みデータを確認
-forge data list</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- strategy -->
-          <section class="cmd-section" id="ja-strategy">
-            <div class="section-category">戦略管理</div>
-            <h2 class="section-heading">forge strategy</h2>
-            <p>戦略 JSON の作成・登録・確認を行います。戦略は JSON ファイルで定義し、バックテストや最適化の対象として登録します。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge strategy list</code></td><td>登録済み戦略を一覧表示</td></tr>
-                <tr><td><code>forge strategy create</code></td><td>テンプレートから戦略 JSON を作成</td></tr>
-                <tr><td><code>forge strategy save &lt;FILE&gt;</code></td><td>JSON ファイルから戦略を登録</td></tr>
-                <tr><td><code>forge strategy show &lt;ID&gt;</code></td><td>戦略定義 (JSON) を表示</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># テンプレートから新規作成
-forge strategy create --template ema_crossover --id usdjpy_ema_v1 \
-  --out data/strategies/usdjpy_ema_v1.json
-
-# JSON ファイルを登録
-forge strategy save data/strategies/usdjpy_ema_v1.json
-
-# 登録済み戦略を確認
-forge strategy list
-
-# 戦略定義を表示
-forge strategy show usdjpy_ema_v1</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- backtest -->
-          <section class="cmd-section" id="ja-backtest">
-            <div class="section-category">バックテスト</div>
-            <h2 class="section-heading">forge backtest</h2>
-            <p>戦略のバックテスト実行・履歴確認・分析を行います。結果は SQLite DB に自動保存されます。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge backtest run &lt;SYMBOL&gt;</code></td><td>バックテストを実行</td></tr>
-                <tr><td><code>forge backtest wft &lt;SYMBOL&gt;</code></td><td>ウォークフォワードテストを実行</td></tr>
-                <tr><td><code>forge backtest list</code></td><td>保存済みバックテスト結果を一覧表示</td></tr>
-                <tr><td><code>forge backtest report &lt;ID&gt;</code></td><td>バックテスト結果の詳細を表示</td></tr>
-                <tr><td><code>forge backtest compare</code></td><td>複数の戦略結果を並べて比較</td></tr>
-                <tr><td><code>forge backtest chart &lt;SYMBOL&gt;</code></td><td>インタラクティブ HTML チャートを生成</td></tr>
-                <tr><td><code>forge backtest diagnose &lt;SYMBOL&gt;</code></td><td>パフォーマンス問題を自動診断</td></tr>
-                <tr><td><code>forge backtest monte-carlo &lt;SYMBOL&gt;</code></td><td>モンテカルロシミュレーションを実行</td></tr>
-                <tr><td><code>forge backtest portfolio</code></td><td>ポートフォリオバックテストを実行</td></tr>
-                <tr><td><code>forge backtest batch</code></td><td>複数戦略を並列バックテスト</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># 基本的なバックテスト
-forge backtest run USDJPY --strategy usdjpy_ema_v1
-
-# 期間指定
-forge backtest run USDJPY --strategy usdjpy_ema_v1 \
-  --start 2021-01-01 --end 2024-12-31
-
-# JSON 形式で出力
-forge backtest run USDJPY --strategy usdjpy_ema_v1 --json
-
-# ウォークフォワードテスト（5 フォールド）
-forge backtest wft USDJPY --strategy usdjpy_ema_v1 --folds 5
-
-# 結果一覧（Sharpe 降順）
-forge backtest list --sort sharpe --limit 20
-
-# 特定戦略の結果のみ
-forge backtest list --strategy usdjpy_ema_v1
-
-# インタラクティブチャートを生成してブラウザで開く
-forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- optimize -->
-          <section class="cmd-section" id="ja-optimize">
-            <div class="section-category">最適化</div>
-            <h2 class="section-heading">forge optimize</h2>
-            <p>Optuna を使ったベイズ最適化でパラメータを効率的に探索します。過学習リスクの評価や、最適化結果の戦略への適用もできます。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge optimize run &lt;SYMBOL&gt;</code></td><td>ベイズ最適化を実行</td></tr>
-                <tr><td><code>forge optimize apply &lt;RESULT&gt;</code></td><td>最適化結果を戦略に適用して新規保存</td></tr>
-                <tr><td><code>forge optimize walk-forward &lt;SYMBOL&gt;</code></td><td>ウォークフォワード最適化を実行</td></tr>
-                <tr><td><code>forge optimize sensitivity &lt;SYMBOL&gt;</code></td><td>パラメータ感度分析（過学習リスク評価）</td></tr>
-                <tr><td><code>forge optimize history</code></td><td>過去の最適化結果をスコアボード表示</td></tr>
-                <tr><td><code>forge optimize portfolio</code></td><td>ポートフォリオ最適配分を最適化</td></tr>
-                <tr><td><code>forge optimize cross-symbol</code></td><td>複数銘柄への汎化性を最適化</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># Sharpe Ratio を指標に 200 トライアル、4 並列で最適化
-forge optimize run USDJPY --strategy usdjpy_ema_v1 \
-  --metric sharpe_ratio --trials 200 -j 4 --save
-
-# 最適化履歴を確認
-forge optimize history --strategy usdjpy_ema_v1 --sort score
-
-# 最適化結果を新しい戦略として保存
-forge optimize apply data/results/usdjpy_ema_v1_opt.json \
-  --to-strategy usdjpy_ema_v1_optimized
-
-# 感度分析で過学習リスクを評価
-forge optimize sensitivity USDJPY --strategy usdjpy_ema_v1_optimized</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- pine -->
-          <section class="cmd-section" id="ja-pine">
-            <div class="section-category">Pine Script</div>
-            <h2 class="section-heading">forge pine</h2>
-            <p>戦略定義から TradingView 用の Pine Script v6 を自動生成します。HMM などの機械学習インジケータにも対応しています。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge pine generate --strategy &lt;ID&gt;</code></td><td>Pine Script を生成してファイルに出力</td></tr>
-                <tr><td><code>forge pine preview --strategy &lt;ID&gt;</code></td><td>生成される Pine Script を標準出力でプレビュー</td></tr>
-                <tr><td><code>forge pine import &lt;FILE&gt;</code></td><td>.pine ファイルを戦略定義として取り込み</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">使用例</h3>
-            <pre><code># Pine Script を生成（output/pinescript/ に保存）
-forge pine generate --strategy usdjpy_ema_v1_optimized
-
-# HMM モデルの学習済みパラメータを埋め込んで生成
-forge pine generate --strategy cl_hmm_bb_rsi_v1 --with-training-data
-
-# 内容をプレビュー（ファイル出力なし）
-forge pine preview --strategy usdjpy_ema_v1_optimized
-
-# 既存 .pine ファイルをインポート
-forge pine import output/pinescript/usdjpy_ema_v1.pine --id usdjpy_ema_imported</code></pre>
-
-            <div class="callout">
-              生成ファイルの保存先は <code>forge.yaml</code> の <code>pinescript.output_path</code> で設定します。デフォルトは <code>output/pinescript/</code> です。
-            </div>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- dashboard & license -->
-          <section class="cmd-section" id="ja-dashboard">
-            <div class="section-category">Web UI</div>
-            <h2 class="section-heading">forge dashboard</h2>
-            <p>Streamlit ベースの Web UI を起動します。バックテスト結果の可視化、戦略ランキング、アイデア管理を一画面で確認できます。</p>
-            <pre><code>forge dashboard
-forge dashboard --port 8501 --no-open</code></pre>
-          </section>
-
-          <section class="cmd-section" id="ja-license" style="margin-top:2rem;">
-            <div class="section-category">ライセンス</div>
-            <h2 class="section-heading">forge license</h2>
-            <p>LemonSqueezy のライセンスキーを認証します。認証情報は <code>~/.forge/license.json</code> にキャッシュされます。</p>
-
-            <table class="option-table">
-              <thead><tr><th>コマンド</th><th>説明</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge license activate &lt;KEY&gt;</code></td><td>ライセンスキーを認証</td></tr>
-                <tr><td><code>forge license status</code></td><td>現在のライセンス状態を表示</td></tr>
-                <tr><td><code>forge license deactivate</code></td><td>このデバイスのライセンスを無効化</td></tr>
-              </tbody>
-            </table>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- workflow -->
-          <section class="cmd-section" id="ja-workflow">
-            <div class="section-category">ガイド</div>
-            <h2 class="section-heading">エンドツーエンド 戦略開発ワークフロー</h2>
-            <p>ヒストリカルデータの取得から自動発注まで、典型的な開発フローを示します。Claude Code などのコーディングエージェントと組み合わせると、各ステップの自動化やパラメータ探索を高速化できます。</p>
-
-            <div class="callout">
-              以下のコマンドはすべて <code>alpha-strategies/</code> ディレクトリから <code>FORGE_CONFIG=forge.yaml uv run</code> 付きで実行することを想定しています。
-            </div>
-
-            <ul class="step-list">
-              <li>
-                <div>
-                  <strong>データ取得</strong>
-                  対象シンボルのヒストリカルデータをローカルに保存します。
-                  <pre><code>forge data fetch USDJPY</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>戦略テンプレート作成</strong>
-                  テンプレートから戦略 JSON の雛形を生成し、パラメータを編集します。
-                  <pre><code>forge strategy create --template ema_crossover \
-  --id usdjpy_ema_v1 \
-  --out data/strategies/usdjpy_ema_v1.json
-
-# 生成されたファイルをエディタで編集し、パラメータを調整
-forge strategy save data/strategies/usdjpy_ema_v1.json</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>バックテスト実行</strong>
-                  定義した戦略のパフォーマンスを過去データで検証します。
-                  <pre><code>forge backtest run USDJPY --strategy usdjpy_ema_v1
-
-# インタラクティブチャートで視覚的に確認
-forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>パラメータ最適化</strong>
-                  Optuna のベイズ最適化で最適なパラメータを探索します。
-                  <pre><code>forge optimize run USDJPY --strategy usdjpy_ema_v1 \
-  --metric sharpe_ratio --trials 300 -j 4 --save
-
-# 結果を新しい戦略として保存
-forge optimize apply data/results/usdjpy_ema_v1_opt.json \
-  --to-strategy usdjpy_ema_v1_optimized</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>ウォークフォワード検証</strong>
-                  過学習を検出するために、訓練期間とテスト期間を分けた検証を行います。
-                  <pre><code>forge backtest wft USDJPY --strategy usdjpy_ema_v1_optimized \
-  --folds 5
-
-# 感度分析でパラメータの堅牢性を確認
-forge optimize sensitivity USDJPY \
-  --strategy usdjpy_ema_v1_optimized</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Pine Script 生成</strong>
-                  TradingView 用のアラートスクリプトを自動生成します。
-                  <pre><code>forge pine generate --strategy usdjpy_ema_v1_optimized</code></pre>
-                  出力先: <code>output/pinescript/usdjpy_ema_v1_optimized.pine</code>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- tradingview -->
-          <section class="cmd-section" id="ja-tradingview">
-            <div class="section-category">ガイド</div>
-            <h2 class="section-heading">TradingView への Pine Script 反映</h2>
-            <p><code>forge pine generate</code> で生成した <code>.pine</code> ファイルを TradingView に貼り付けてアラートを設定します。</p>
-
-            <ul class="step-list">
-              <li>
-                <div>
-                  <strong>Pine Script を開く</strong>
-                  TradingView でチャートを開き、画面下部の「Pine エディタ」タブをクリックします。
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>スクリプトを貼り付ける</strong>
-                  生成した <code>.pine</code> ファイルの内容をエディタに貼り付け、「スクリプトを追加」（▶ ボタン）をクリックします。
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>アラートを設定する</strong>
-                  チャート右上のベルアイコン（アラート）→「アラートを追加」をクリック。
-                  <ul style="margin-top:0.4rem; padding-left:1.2rem; font-size:0.88rem; color:var(--text2);">
-                    <li>条件: 追加したスクリプト名を選択</li>
-                    <li>「Webhook URL」にチェックを入れ、alpha-strike のエンドポイントを入力</li>
-                    <li>「メッセージ」に後述の JSON ペイロードを入力</li>
-                  </ul>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>アラートメッセージのヒント</strong>
-                  Pine Script 内でシグナル変数（例: <code>longSignal</code>）を定義しておくと、アラートの条件設定が簡単になります。
-                  <pre><code>// Pine Script 内でのアラート定義例
-longSignal = ta.crossover(ema_fast, ema_slow)
-shortSignal = ta.crossunder(ema_fast, ema_slow)
-alertcondition(longSignal, title="Long Entry", message="long")</code></pre>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- alpha-strike -->
-          <section class="cmd-section" id="ja-strike">
-            <div class="section-category">ガイド</div>
-            <h2 class="section-heading">TradingView と alpha-strike の連携</h2>
-            <p>alpha-strike は TradingView のアラートを Webhook で受け取り、OANDA・moomoo 証券に自動発注します。</p>
-
-            <h3 class="sub-heading">1. 環境変数の設定</h3>
-            <p><code>alpha-strike/.env</code> を作成して以下を設定します。</p>
-            <pre><code># 必須
-WEBHOOK_PASSPHRASE=your-secret-passphrase   # 任意の秘密文字列
-
-# OANDA 使用時
-OANDA_API_KEY=your-personal-access-token
-OANDA_ACCOUNT_ID=your-account-id
-OANDA_ENV=PRACTICE    # 本番は LIVE
-
-# moomoo 使用時
-MOOMOO_HOST=127.0.0.1
-MOOMOO_PORT=11111
-MOOMOO_TRD_ENV=SIMULATE   # 本番は REAL</code></pre>
-
-            <h3 class="sub-heading">2. Webhook URL</h3>
-            <div class="callout">
-              TradingView のアラート Webhook URL に以下を設定します:<br/>
-              <code>http://&lt;your-server&gt;:8080/webhook</code>
-            </div>
-
-            <h3 class="sub-heading">3. ペイロード仕様</h3>
-            <p>TradingView のアラートメッセージに JSON を記述します。</p>
-            <pre><code>{
-  "passphrase": "your-secret-passphrase",
-  "broker": "oanda",
-  "asset_class": "FX",
-  "action": "buy",
-  "ticker": "USDJPY",
-  "quantity": 1000
-}</code></pre>
-
-            <table class="payload-table">
-              <thead><tr><th>フィールド</th><th>説明</th><th>値の例</th></tr></thead>
-              <tbody>
-                <tr><td><code>passphrase</code><br/><span class="req">必須</span></td><td>.env の WEBHOOK_PASSPHRASE と一致させること</td><td>"my-secret"</td></tr>
-                <tr><td><code>broker</code><br/><span class="req">必須</span></td><td>発注先の証券会社</td><td>"oanda" / "moomoo"</td></tr>
-                <tr><td><code>asset_class</code><br/><span class="req">必須</span></td><td>アセットクラス</td><td>"FX" / "COMMODITY" / "US" / "INDEX"</td></tr>
-                <tr><td><code>action</code><br/><span class="req">必須</span></td><td>注文方向</td><td>"buy" / "sell"</td></tr>
-                <tr><td><code>ticker</code><br/><span class="req">必須</span></td><td>銘柄コード（TradingView のシンボル名）</td><td>"USDJPY" / "XAUUSD"</td></tr>
-                <tr><td><code>quantity</code><br/><span class="req">必須</span></td><td>注文数量（0 より大きい正の数）</td><td>1000 / 0.1</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">4. ティッカーと OANDA instrument の対応</h3>
-            <table class="option-table">
-              <thead><tr><th>asset_class</th><th>ticker 例</th><th>OANDA instrument</th></tr></thead>
-              <tbody>
-                <tr><td>FX</td><td>USDJPY</td><td>USD_JPY</td></tr>
-                <tr><td>COMMODITY</td><td>XAUUSD</td><td>XAU_USD</td></tr>
-                <tr><td>INDEX</td><td>NAS100</td><td>NAS100_USD</td></tr>
-                <tr><td>US</td><td>AAPL</td><td>AAPL_USD</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">5. 動作確認</h3>
-            <pre><code># ヘルスチェック
-curl http://localhost:8080/health
-# → {"status":"ok"}
-
-# テスト発注（PRACTICE / SIMULATE 環境で確認）
-curl -X POST http://localhost:8080/webhook \
-  -H "Content-Type: application/json" \
-  -d '{"passphrase":"your-secret","broker":"oanda","asset_class":"FX","action":"buy","ticker":"USDJPY","quantity":1000}'</code></pre>
-          </section>
-
-        </div>
+      <h1 class="page-title">forge コマンドの早見表</h1>
+      <p class="page-subtitle">主要 6 コマンドのカードと全コマンドカタログ。詳細パラメータと出力例は公式ドキュメントへ。</p>
+
+      <div class="callout" style="margin-bottom: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          全 76 サブコマンドの詳細パラメータ、出力例、エラーコードは
+          <strong>公式ドキュメント</strong>を参照してください。
+        </p>
+        <a href="/ja/docs/cli-reference/" class="btn-primary">
+          CLI リファレンスを開く →
+        </a>
       </div>
-    </div><!-- /lang-ja -->
 
+      <h2 class="section-heading">主要コマンド</h2>
+      <div class="cmd-card-grid">
+        <a class="cmd-card" href="/ja/docs/cli-reference/backtest/#forge-backtest-run">
+          <div class="cmd-card-name">forge backtest run</div>
+          <div class="cmd-card-desc">単一銘柄に戦略を適用してバックテストを実行する。</div>
+          <pre class="cmd-card-usage"><code>forge backtest run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--strategy</span>
+            <span class="cmd-card-option">--start</span>
+            <span class="cmd-card-option">--json</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
 
-    <!-- ==================== English version ==================== -->
+        <a class="cmd-card" href="/ja/docs/cli-reference/optimize/#forge-optimize-run">
+          <div class="cmd-card-name">forge optimize run</div>
+          <div class="cmd-card-desc">Optuna によるパラメータ最適化（TPE）。多目的最適化にも対応。</div>
+          <pre class="cmd-card-usage"><code>forge optimize run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--metric</span>
+            <span class="cmd-card-option">--trials</span>
+            <span class="cmd-card-option">--apply</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/optimize/#forge-optimize-walk-forward">
+          <div class="cmd-card-name">forge optimize walk-forward</div>
+          <div class="cmd-card-desc">時系列をウィンドウ分割し IS 最適化 → OOS 評価で過学習耐性を測定。</div>
+          <pre class="cmd-card-usage"><code>forge optimize walk-forward SYMBOL --strategy ID --windows N</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--windows</span>
+            <span class="cmd-card-option">--metric</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/data/#forge-data-fetch">
+          <div class="cmd-card-name">forge data fetch</div>
+          <div class="cmd-card-desc">OHLCV をプロバイダーから取得し Parquet で保存。</div>
+          <pre class="cmd-card-usage"><code>forge data fetch SYMBOL --period 5y --interval 1d</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--period</span>
+            <span class="cmd-card-option">--interval</span>
+            <span class="cmd-card-option">--watchlist</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/strategy/#forge-strategy-save">
+          <div class="cmd-card-name">forge strategy save</div>
+          <div class="cmd-card-desc">戦略 JSON をレジストリに登録（任意で Journal に記録）。</div>
+          <pre class="cmd-card-usage"><code>forge strategy save FILE_PATH</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--force</span>
+          </div>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+
+        <a class="cmd-card" href="/ja/docs/cli-reference/journal/#forge-journal-show">
+          <div class="cmd-card-name">forge journal show</div>
+          <div class="cmd-card-desc">戦略の全履歴（スナップショット・Runs・タグ・ライブサマリ）を表示。</div>
+          <pre class="cmd-card-usage"><code>forge journal show STRATEGY_ID</code></pre>
+          <div class="cmd-card-link">cli-reference で詳細 →</div>
+        </a>
+      </div>
+
+      <h2 class="section-heading">全コマンドカタログ</h2>
+      <table class="cmd-table">
+        <thead>
+          <tr><th>グループ</th><th>説明</th><th>サブコマンド数</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/backtest/"><code>forge backtest</code></a></td>
+            <td>バックテスト実行・スキャン・カスタム実験</td>
+            <td>11</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/optimize/"><code>forge optimize</code></a></td>
+            <td>パラメータ最適化（grid / bayes / wfa）</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td>
+            <td>戦略 JSON の保存・検証・適用</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/data/"><code>forge data</code></a></td>
+            <td>ヒストリカルデータ取得・更新</td>
+            <td>4</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/journal/"><code>forge journal</code></a></td>
+            <td>取引ジャーナル・トレード分析</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/live/"><code>forge live</code></a></td>
+            <td>ライブトレーディング・ブローカー連携</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/ja/docs/cli-reference/other/">その他コマンド</a></td>
+            <td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> 他</td>
+            <td>10 グループ</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout" style="margin-top: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          各グループの完全なサブコマンドリスト、オプション一覧、戻り値、サンプル出力は
+          ドキュメントの CLI リファレンスを参照してください。
+        </p>
+        <a href="/ja/docs/cli-reference/" class="btn-primary">
+          CLI リファレンスを開く →
+        </a>
+      </div>
+
+      <div class="callout" style="margin-top: 1rem;">
+        <p>サポートが必要な場合は <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a> までお問い合わせください。</p>
+      </div>
+    </div>
+
+    <!-- ==================== English ==================== -->
     <div class="lang-content lang-en">
       <div class="page-label">Documentation</div>
-      <h1 class="page-title">Documentation</h1>
-      <p class="page-subtitle">Command reference, strategy development workflow, and TradingView integration guide.</p>
-
-      <div class="doc-layout" style="margin-top: 2rem;">
-        <nav class="cmd-nav">
-          <ul class="cmd-nav-list">
-            <li class="nav-group">Data</li>
-            <li><a href="#en-data">data</a></li>
-            <li class="nav-group">Strategy</li>
-            <li><a href="#en-strategy">strategy</a></li>
-            <li class="nav-group">Backtest</li>
-            <li><a href="#en-backtest">backtest</a></li>
-            <li class="nav-group">Optimize</li>
-            <li><a href="#en-optimize">optimize</a></li>
-            <li class="nav-group">Pine Script</li>
-            <li><a href="#en-pine">pine</a></li>
-            <li class="nav-group">Other</li>
-            <li><a href="#en-dashboard">dashboard</a></li>
-            <li><a href="#en-license">license</a></li>
-            <li class="nav-group">Guides</li>
-            <li><a href="#en-workflow">Workflow</a></li>
-            <li><a href="#en-tradingview">TradingView</a></li>
-            <li><a href="#en-strike">alpha-strike</a></li>
-          </ul>
-        </nav>
-
-        <div>
-
-          <!-- data -->
-          <section class="cmd-section" id="en-data">
-            <div class="section-category">Data Management</div>
-            <h2 class="section-heading">forge data</h2>
-            <p>Fetch, update, and manage historical market data. Data is stored as Parquet files under <code>alpha-strategies/data/historical/</code>.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge data fetch &lt;SYMBOL&gt;</code></td><td>Fetch and save historical data for a symbol</td></tr>
-                <tr><td><code>forge data update</code></td><td>Incrementally update all saved data to today</td></tr>
-                <tr><td><code>forge data update --symbol &lt;SYMBOL&gt;</code></td><td>Update a specific symbol only</td></tr>
-                <tr><td><code>forge data list</code></td><td>List all saved datasets</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># Initial fetch
-forge data fetch USDJPY
-forge data fetch CL=F
-forge data fetch SPY QQQ NAS100
-
-# Incremental update (all symbols)
-forge data update
-
-# Update a single symbol
-forge data update --symbol USDJPY
-
-# Check what's saved
-forge data list</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- strategy -->
-          <section class="cmd-section" id="en-strategy">
-            <div class="section-category">Strategy Management</div>
-            <h2 class="section-heading">forge strategy</h2>
-            <p>Create, register, and inspect strategy JSON definitions. Strategies must be registered before use in backtests or optimization.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge strategy list</code></td><td>List all registered strategies</td></tr>
-                <tr><td><code>forge strategy create</code></td><td>Generate a strategy JSON from a template</td></tr>
-                <tr><td><code>forge strategy save &lt;FILE&gt;</code></td><td>Register a strategy from a JSON file</td></tr>
-                <tr><td><code>forge strategy show &lt;ID&gt;</code></td><td>Print the strategy definition (JSON)</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># Create from template
-forge strategy create --template ema_crossover --id usdjpy_ema_v1 \
-  --out data/strategies/usdjpy_ema_v1.json
-
-# Register after editing the JSON
-forge strategy save data/strategies/usdjpy_ema_v1.json
-
-# List registered strategies
-forge strategy list
-
-# Inspect a strategy definition
-forge strategy show usdjpy_ema_v1</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- backtest -->
-          <section class="cmd-section" id="en-backtest">
-            <div class="section-category">Backtesting</div>
-            <h2 class="section-heading">forge backtest</h2>
-            <p>Run backtests, view history, and analyse results. All results are automatically saved to SQLite.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge backtest run &lt;SYMBOL&gt;</code></td><td>Run a backtest</td></tr>
-                <tr><td><code>forge backtest wft &lt;SYMBOL&gt;</code></td><td>Run a walk-forward test</td></tr>
-                <tr><td><code>forge backtest list</code></td><td>List saved backtest results</td></tr>
-                <tr><td><code>forge backtest report &lt;ID&gt;</code></td><td>Show detailed result for a run</td></tr>
-                <tr><td><code>forge backtest compare</code></td><td>Compare multiple strategy results side by side</td></tr>
-                <tr><td><code>forge backtest chart &lt;SYMBOL&gt;</code></td><td>Generate an interactive HTML chart</td></tr>
-                <tr><td><code>forge backtest diagnose &lt;SYMBOL&gt;</code></td><td>Auto-diagnose performance issues</td></tr>
-                <tr><td><code>forge backtest monte-carlo &lt;SYMBOL&gt;</code></td><td>Run Monte Carlo simulation</td></tr>
-                <tr><td><code>forge backtest portfolio</code></td><td>Run a portfolio backtest</td></tr>
-                <tr><td><code>forge backtest batch</code></td><td>Parallel backtest across multiple strategies</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># Basic backtest
-forge backtest run USDJPY --strategy usdjpy_ema_v1
-
-# With date range
-forge backtest run USDJPY --strategy usdjpy_ema_v1 \
-  --start 2021-01-01 --end 2024-12-31
-
-# JSON output
-forge backtest run USDJPY --strategy usdjpy_ema_v1 --json
-
-# Walk-forward test (5 folds)
-forge backtest wft USDJPY --strategy usdjpy_ema_v1 --folds 5
-
-# List results sorted by Sharpe
-forge backtest list --sort sharpe --limit 20
-
-# Open interactive chart in browser
-forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- optimize -->
-          <section class="cmd-section" id="en-optimize">
-            <div class="section-category">Optimization</div>
-            <h2 class="section-heading">forge optimize</h2>
-            <p>Bayesian parameter search with Optuna. Includes overfitting risk evaluation, walk-forward optimization, and one-click apply.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge optimize run &lt;SYMBOL&gt;</code></td><td>Run Bayesian optimization</td></tr>
-                <tr><td><code>forge optimize apply &lt;RESULT&gt;</code></td><td>Apply results to a new strategy</td></tr>
-                <tr><td><code>forge optimize walk-forward &lt;SYMBOL&gt;</code></td><td>Walk-forward optimization</td></tr>
-                <tr><td><code>forge optimize sensitivity &lt;SYMBOL&gt;</code></td><td>Parameter sensitivity analysis (overfitting check)</td></tr>
-                <tr><td><code>forge optimize history</code></td><td>Scoreboard of past optimization runs</td></tr>
-                <tr><td><code>forge optimize portfolio</code></td><td>Optimize portfolio allocation weights</td></tr>
-                <tr><td><code>forge optimize cross-symbol</code></td><td>Optimize across multiple symbols for generalization</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># 300 trials, 4 workers, maximize Sharpe
-forge optimize run USDJPY --strategy usdjpy_ema_v1 \
-  --metric sharpe_ratio --trials 300 -j 4 --save
-
-# View optimization history
-forge optimize history --strategy usdjpy_ema_v1 --sort score
-
-# Apply best result as a new strategy
-forge optimize apply data/results/usdjpy_ema_v1_opt.json \
-  --to-strategy usdjpy_ema_v1_optimized
-
-# Check parameter robustness
-forge optimize sensitivity USDJPY --strategy usdjpy_ema_v1_optimized</code></pre>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- pine -->
-          <section class="cmd-section" id="en-pine">
-            <div class="section-category">Pine Script</div>
-            <h2 class="section-heading">forge pine</h2>
-            <p>Auto-generate TradingView Pine Script v6 from a strategy definition. Supports machine-learning indicators such as HMM by embedding trained parameters.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge pine generate --strategy &lt;ID&gt;</code></td><td>Generate Pine Script and write to file</td></tr>
-                <tr><td><code>forge pine preview --strategy &lt;ID&gt;</code></td><td>Preview Pine Script in stdout (no file written)</td></tr>
-                <tr><td><code>forge pine import &lt;FILE&gt;</code></td><td>Parse a .pine file and import as a strategy</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">Examples</h3>
-            <pre><code># Generate Pine Script (saved to output/pinescript/)
-forge pine generate --strategy usdjpy_ema_v1_optimized
-
-# Embed trained HMM parameters
-forge pine generate --strategy cl_hmm_bb_rsi_v1 --with-training-data
-
-# Preview without writing to disk
-forge pine preview --strategy usdjpy_ema_v1_optimized
-
-# Import existing .pine file as a strategy
-forge pine import output/pinescript/usdjpy_ema_v1.pine --id usdjpy_ema_imported</code></pre>
-
-            <div class="callout">
-              The output path is configured via <code>pinescript.output_path</code> in <code>forge.yaml</code>. Default: <code>output/pinescript/</code>.
-            </div>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- dashboard & license -->
-          <section class="cmd-section" id="en-dashboard">
-            <div class="section-category">Web UI</div>
-            <h2 class="section-heading">forge dashboard</h2>
-            <p>Launch the Streamlit-based Web UI for backtest visualisation, strategy rankings, and idea tracking.</p>
-            <pre><code>forge dashboard
-forge dashboard --port 8501 --no-open</code></pre>
-          </section>
-
-          <section class="cmd-section" id="en-license" style="margin-top:2rem;">
-            <div class="section-category">License</div>
-            <h2 class="section-heading">forge license</h2>
-            <p>Activate and manage your LemonSqueezy license. Activation data is cached in <code>~/.forge/license.json</code>.</p>
-
-            <table class="option-table">
-              <thead><tr><th>Command</th><th>Description</th></tr></thead>
-              <tbody>
-                <tr><td><code>forge license activate &lt;KEY&gt;</code></td><td>Activate a license key on this device</td></tr>
-                <tr><td><code>forge license status</code></td><td>Show current license status</td></tr>
-                <tr><td><code>forge license deactivate</code></td><td>Deactivate this device</td></tr>
-              </tbody>
-            </table>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- workflow -->
-          <section class="cmd-section" id="en-workflow">
-            <div class="section-category">Guide</div>
-            <h2 class="section-heading">End-to-End Strategy Development Workflow</h2>
-            <p>A typical flow from raw data to live execution. This pairs naturally with a coding agent (e.g. Claude Code) for automated parameter exploration and strategy generation.</p>
-
-            <div class="callout">
-              All commands below assume you are running from <code>alpha-strategies/</code> with <code>FORGE_CONFIG=forge.yaml uv run</code> prepended.
-            </div>
-
-            <ul class="step-list">
-              <li>
-                <div>
-                  <strong>Fetch historical data</strong>
-                  <pre><code>forge data fetch USDJPY</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Create a strategy from a template</strong>
-                  Generate a JSON scaffold, edit parameters, then register it.
-                  <pre><code>forge strategy create --template ema_crossover \
-  --id usdjpy_ema_v1 \
-  --out data/strategies/usdjpy_ema_v1.json
-
-# Edit the JSON, then register
-forge strategy save data/strategies/usdjpy_ema_v1.json</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Run a backtest</strong>
-                  <pre><code>forge backtest run USDJPY --strategy usdjpy_ema_v1
-
-# Visual equity curve
-forge backtest chart USDJPY --strategy usdjpy_ema_v1</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Optimize parameters</strong>
-                  Bayesian search with Optuna, then apply the best result.
-                  <pre><code>forge optimize run USDJPY --strategy usdjpy_ema_v1 \
-  --metric sharpe_ratio --trials 300 -j 4 --save
-
-forge optimize apply data/results/usdjpy_ema_v1_opt.json \
-  --to-strategy usdjpy_ema_v1_optimized</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Walk-forward validation</strong>
-                  Detect overfitting with out-of-sample testing.
-                  <pre><code>forge backtest wft USDJPY --strategy usdjpy_ema_v1_optimized \
-  --folds 5
-
-forge optimize sensitivity USDJPY \
-  --strategy usdjpy_ema_v1_optimized</code></pre>
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Generate Pine Script</strong>
-                  Export a TradingView alert script from the optimized strategy.
-                  <pre><code>forge pine generate --strategy usdjpy_ema_v1_optimized</code></pre>
-                  Output: <code>output/pinescript/usdjpy_ema_v1_optimized.pine</code>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- tradingview -->
-          <section class="cmd-section" id="en-tradingview">
-            <div class="section-category">Guide</div>
-            <h2 class="section-heading">Deploying Pine Script to TradingView</h2>
-            <p>Paste the generated <code>.pine</code> file into TradingView and set up an alert to trigger alpha-strike.</p>
-
-            <ul class="step-list">
-              <li>
-                <div>
-                  <strong>Open the Pine Editor</strong>
-                  Open a chart in TradingView and click the "Pine Editor" tab at the bottom.
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Paste the script</strong>
-                  Copy the contents of the generated <code>.pine</code> file and paste it into the editor. Click "Add to chart" (▶).
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Create an alert</strong>
-                  Click the bell icon (Alerts) → "Create alert". Set the condition to your script, enable "Webhook URL", and paste the alpha-strike endpoint.
-                </div>
-              </li>
-              <li>
-                <div>
-                  <strong>Tip: in-script alert conditions</strong>
-                  Define <code>alertcondition</code> in Pine Script for cleaner alert setup.
-                  <pre><code>longSignal = ta.crossover(ema_fast, ema_slow)
-alertcondition(longSignal, title="Long Entry", message="long")</code></pre>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <hr class="section-divider" />
-
-          <!-- alpha-strike -->
-          <section class="cmd-section" id="en-strike">
-            <div class="section-category">Guide</div>
-            <h2 class="section-heading">Connecting TradingView to alpha-strike</h2>
-            <p>alpha-strike receives TradingView webhook alerts and forwards orders to OANDA or moomoo.</p>
-
-            <h3 class="sub-heading">1. Configure environment variables</h3>
-            <p>Create <code>alpha-strike/.env</code> from the provided example:</p>
-            <pre><code># Required
-WEBHOOK_PASSPHRASE=your-secret-passphrase
-
-# OANDA
-OANDA_API_KEY=your-personal-access-token
-OANDA_ACCOUNT_ID=your-account-id
-OANDA_ENV=PRACTICE    # or LIVE
-
-# moomoo
-MOOMOO_HOST=127.0.0.1
-MOOMOO_PORT=11111
-MOOMOO_TRD_ENV=SIMULATE   # or REAL</code></pre>
-
-            <h3 class="sub-heading">2. Webhook URL</h3>
-            <div class="callout">
-              Set the TradingView alert Webhook URL to:<br/>
-              <code>http://&lt;your-server&gt;:8080/webhook</code>
-            </div>
-
-            <h3 class="sub-heading">3. Payload format</h3>
-            <pre><code>{
-  "passphrase": "your-secret-passphrase",
-  "broker": "oanda",
-  "asset_class": "FX",
-  "action": "buy",
-  "ticker": "USDJPY",
-  "quantity": 1000
-}</code></pre>
-
-            <table class="payload-table">
-              <thead><tr><th>Field</th><th>Description</th><th>Example</th></tr></thead>
-              <tbody>
-                <tr><td><code>passphrase</code><br/><span class="req">required</span></td><td>Must match WEBHOOK_PASSPHRASE in .env</td><td>"my-secret"</td></tr>
-                <tr><td><code>broker</code><br/><span class="req">required</span></td><td>Target broker</td><td>"oanda" / "moomoo"</td></tr>
-                <tr><td><code>asset_class</code><br/><span class="req">required</span></td><td>Asset class</td><td>"FX" / "COMMODITY" / "US" / "INDEX"</td></tr>
-                <tr><td><code>action</code><br/><span class="req">required</span></td><td>Order direction</td><td>"buy" / "sell"</td></tr>
-                <tr><td><code>ticker</code><br/><span class="req">required</span></td><td>Symbol (TradingView notation)</td><td>"USDJPY" / "XAUUSD"</td></tr>
-                <tr><td><code>quantity</code><br/><span class="req">required</span></td><td>Order size (positive number)</td><td>1000 / 0.1</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">4. Ticker to OANDA instrument mapping</h3>
-            <table class="option-table">
-              <thead><tr><th>asset_class</th><th>ticker</th><th>OANDA instrument</th></tr></thead>
-              <tbody>
-                <tr><td>FX</td><td>USDJPY</td><td>USD_JPY</td></tr>
-                <tr><td>COMMODITY</td><td>XAUUSD</td><td>XAU_USD</td></tr>
-                <tr><td>INDEX</td><td>NAS100</td><td>NAS100_USD</td></tr>
-                <tr><td>US</td><td>AAPL</td><td>AAPL_USD</td></tr>
-              </tbody>
-            </table>
-
-            <h3 class="sub-heading">5. Verify connectivity</h3>
-            <pre><code># Health check
-curl http://localhost:8080/health
-# → {"status":"ok"}
-
-# Test order (use PRACTICE / SIMULATE environment)
-curl -X POST http://localhost:8080/webhook \
-  -H "Content-Type: application/json" \
-  -d '{"passphrase":"your-secret","broker":"oanda","asset_class":"FX","action":"buy","ticker":"USDJPY","quantity":1000}'</code></pre>
-          </section>
-
-        </div>
+      <h1 class="page-title">forge Command Quick Reference</h1>
+      <p class="page-subtitle">Cards for the six core commands plus a full command catalog. Detailed parameters and output examples live in the official docs.</p>
+
+      <div class="callout" style="margin-bottom: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          For detailed parameters, output examples, and error codes for all 76 subcommands,
+          see the <strong>official documentation</strong>.
+        </p>
+        <a href="/en/docs/cli-reference/" class="btn-primary">
+          Open CLI Reference →
+        </a>
       </div>
-    </div><!-- /lang-en -->
+
+      <h2 class="section-heading">Top Commands</h2>
+      <div class="cmd-card-grid">
+        <a class="cmd-card" href="/en/docs/cli-reference/backtest/#forge-backtest-run">
+          <div class="cmd-card-name">forge backtest run</div>
+          <div class="cmd-card-desc">Run a backtest applying a strategy to a single symbol.</div>
+          <pre class="cmd-card-usage"><code>forge backtest run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--strategy</span>
+            <span class="cmd-card-option">--start</span>
+            <span class="cmd-card-option">--json</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/optimize/#forge-optimize-run">
+          <div class="cmd-card-name">forge optimize run</div>
+          <div class="cmd-card-desc">Parameter optimization with Optuna (TPE). Multi-objective also supported.</div>
+          <pre class="cmd-card-usage"><code>forge optimize run SYMBOL --strategy ID</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--metric</span>
+            <span class="cmd-card-option">--trials</span>
+            <span class="cmd-card-option">--apply</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/optimize/#forge-optimize-walk-forward">
+          <div class="cmd-card-name">forge optimize walk-forward</div>
+          <div class="cmd-card-desc">Split time series into windows; IS optimization → OOS evaluation for overfitting resistance.</div>
+          <pre class="cmd-card-usage"><code>forge optimize walk-forward SYMBOL --strategy ID --windows N</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--windows</span>
+            <span class="cmd-card-option">--metric</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/data/#forge-data-fetch">
+          <div class="cmd-card-name">forge data fetch</div>
+          <div class="cmd-card-desc">Fetch OHLCV from a provider and store as Parquet.</div>
+          <pre class="cmd-card-usage"><code>forge data fetch SYMBOL --period 5y --interval 1d</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--period</span>
+            <span class="cmd-card-option">--interval</span>
+            <span class="cmd-card-option">--watchlist</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/strategy/#forge-strategy-save">
+          <div class="cmd-card-name">forge strategy save</div>
+          <div class="cmd-card-desc">Register a strategy JSON to the registry (optionally recorded in the Journal).</div>
+          <pre class="cmd-card-usage"><code>forge strategy save FILE_PATH</code></pre>
+          <div class="cmd-card-options">
+            <span class="cmd-card-option">--force</span>
+          </div>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+
+        <a class="cmd-card" href="/en/docs/cli-reference/journal/#forge-journal-show">
+          <div class="cmd-card-name">forge journal show</div>
+          <div class="cmd-card-desc">Show the full history of a strategy (snapshots, runs, tags, live summary).</div>
+          <pre class="cmd-card-usage"><code>forge journal show STRATEGY_ID</code></pre>
+          <div class="cmd-card-link">See cli-reference →</div>
+        </a>
+      </div>
+
+      <h2 class="section-heading">All Command Groups</h2>
+      <table class="cmd-table">
+        <thead>
+          <tr><th>Group</th><th>Description</th><th>Subcommands</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="/en/docs/cli-reference/backtest/"><code>forge backtest</code></a></td>
+            <td>Backtest execution, scanning, custom experiments</td>
+            <td>11</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/optimize/"><code>forge optimize</code></a></td>
+            <td>Parameter optimization (grid / bayes / wfa)</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td>
+            <td>Strategy JSON save / validate / apply</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/data/"><code>forge data</code></a></td>
+            <td>Historical data fetch / update</td>
+            <td>4</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/journal/"><code>forge journal</code></a></td>
+            <td>Trading journal and trade analysis</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/live/"><code>forge live</code></a></td>
+            <td>Live trading and broker integration</td>
+            <td>9</td>
+          </tr>
+          <tr>
+            <td><a href="/en/docs/cli-reference/other/">Other commands</a></td>
+            <td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> and more</td>
+            <td>10 groups</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout" style="margin-top: 2rem;">
+        <p style="margin-bottom: 0.75rem;">
+          For complete subcommand listings, options, return values, and sample output for each group,
+          see the CLI Reference in the official docs.
+        </p>
+        <a href="/en/docs/cli-reference/" class="btn-primary">
+          Open CLI Reference →
+        </a>
+      </div>
+
+      <div class="callout" style="margin-top: 1rem;">
+        <p>If you need help, contact <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a>.</p>
+      </div>
+    </div>
 
   </div>
 

--- a/templates/docs.html.j2
+++ b/templates/docs.html.j2
@@ -10,7 +10,10 @@
   <link rel="alternate" hreflang="ja" href="{{ hreflang_ja }}" />
   <link rel="alternate" hreflang="en" href="{{ hreflang_en }}" />
   <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ canonical_url }}" />
+  <meta property="og:title" content="{{ og_title }}" />
+  <meta property="og:description" content="{{ og_description }}" />
   <meta property="og:image" content="{{ og_image }}" />
   <meta property="og:locale" content="{{ og_locale }}" />
   <meta property="og:site_name" content="Alforge Labs" />


### PR DESCRIPTION
## Summary

- `templates/docs.html.j2` を 1012 行から約 400 行へ簡素化し、ヒーロー + 主要 6 コマンドのカードグリッド + 全 7 グループのカタログ表に再構成
- ヒーロー直下とカタログ表後の 2 箇所に MkDocs 公式 cli-reference への誘導 callout を追加
- 削除: 左サイドバー目次、`forge {data,strategy,backtest,optimize,pine,dashboard,license}` の 7 セクション、ワークフロー / TradingView / alpha-strike 連携の 3 ガイドセクション
- カードクリックで `/{ja,en}/docs/cli-reference/{group}/#forge-{group}-{sub}` のサブコマンドアンカーへ直接遷移
- 旧テンプレから引き継いだ OGP メタタグ欠落（`og:type` / `og:title` / `og:description`）を併せて修正

## 設計ドキュメント

`docs/superpowers/specs/2026-04-30-alforge-labs-issue-65-docs-html-slim-design.md`

## 実装計画

`docs/superpowers/plans/2026-04-30-alforge-labs-issue-65-docs-html-slim.md`

## Test plan

- [x] `uv run python build.py` が正常終了し `{ja,en}/docs.html` のみが再生成される
- [x] `grep -c '<a class="cmd-card"' ja/docs.html` が `12` を返す（ja+en 各 6 カード）
- [x] `grep -c 'btn-primary' ja/docs.html` が `4` を返す（上下 callout × ja/en）
- [x] MkDocs cli-reference の各サブコマンドアンカー（`#forge-{group}-{sub}`）× 12 件が実在
- [x] `cmd-nav-list`, 旧本文の「エンドツーエンド」「TradingView」「alpha-strike」がいずれも本文に残っていない
- [x] JSON-LD と hreflang が維持されている
- [x] OGP 7 種類（`og:type` / `og:url` / `og:title` / `og:description` / `og:image` / `og:locale` / `og:site_name`）が両ファイルに反映
- [ ] 公開後ブラウザでヒーロー / カードグリッド / カタログ表 / 各リンクの動作を確認

## SEO 影響評価

- `seo.yaml` の docs ページコピーは無変更
- `sitemap.xml` の docs エントリ priority `0.9` / changefreq `weekly` 維持
- JSON-LD（BreadcrumbList）は build.py で動的生成、構造変更なし
- hreflang リンク（ja / en / x-default）維持

## フォローアップ（別 issue で対応推奨）

- 削除した 3 ガイドセクション（ワークフロー / TradingView / alpha-strike 連携）の MkDocs 移植
- `seo.yaml` の docs.{ja,en} description / keywords / og_description から旧コンテンツ（"TradingView 連携" 等）への言及を更新
- React/React-DOM の production build 切り替え（既存 issue #79）
- HTML テンプレートの lang-content 並列構造の見直し（既存 issue #78）

Closes #65