### PR TITLE
ランディングページに継続利用価値セクションを追加

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -867,6 +867,94 @@
     }
     @media (max-width: 900px) { .usecases-grid { grid-template-columns: 1fr 1fr; } }
     @media (max-width: 600px) { .usecases-grid { grid-template-columns: 1fr; } }
+
+    /* ── 継続利用価値 ── */
+    .long-term-value {
+      padding: 6rem 0;
+      border-bottom: 1px solid var(--border);
+      background:
+        linear-gradient(180deg, transparent 0%, var(--accent-bg) 52%, transparent 100%);
+    }
+    .long-term-header {
+      max-width: 720px;
+      margin-bottom: 2.5rem;
+    }
+    .long-term-subtitle {
+      margin-top: 0.9rem;
+      color: var(--text2);
+      font-size: 0.95rem;
+      line-height: 1.8;
+    }
+    .long-term-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 1px;
+      background: var(--border);
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      overflow: hidden;
+    }
+    .long-term-card {
+      min-height: 280px;
+      padding: 1.8rem;
+      background: var(--surface);
+      display: flex;
+      flex-direction: column;
+      gap: 0.85rem;
+      position: relative;
+      overflow: hidden;
+      transition: background 0.2s, border-color 0.2s;
+    }
+    .long-term-card::before {
+      content: '';
+      position: absolute;
+      inset: 0 0 auto;
+      height: 2px;
+      background: var(--accent);
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+    .long-term-card:hover {
+      background: var(--surface-h);
+    }
+    .long-term-card:hover::before {
+      opacity: 1;
+    }
+    .long-term-index {
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      color: var(--text3);
+      letter-spacing: 0.08em;
+    }
+    .long-term-eyebrow {
+      width: fit-content;
+      margin-top: 0.5rem;
+      padding: 0.22rem 0.6rem;
+      border: 1px solid var(--accent-glow);
+      border-radius: 100px;
+      background: var(--accent-bg);
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 0.64rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .long-term-title {
+      color: var(--text);
+      font-size: 1.05rem;
+      font-weight: 600;
+      line-height: 1.35;
+    }
+    .long-term-desc {
+      color: var(--text2);
+      font-size: 0.88rem;
+      line-height: 1.75;
+    }
+    @media (max-width: 900px) { .long-term-grid { grid-template-columns: 1fr; } }
+    @media (max-width: 600px) {
+      .long-term-value { padding: 4.5rem 0; }
+      .long-term-card { min-height: auto; padding: 1.5rem; }
+    }
   </style>
 </head>
 <body data-theme="dark">

--- a/homepage-app.jsx
+++ b/homepage-app.jsx
@@ -252,6 +252,7 @@ function App() {
       <Products t={t} />
       <SystemFlow t={t} dark={dark} lang={lang} />
       <UseCases t={t} />
+      <LongTermValue t={t} />
       <PerformanceChart t={t} dark={dark} />
       <Pricing t={t} />
       <Roadmap t={t} />

--- a/homepage-components.jsx
+++ b/homepage-components.jsx
@@ -328,6 +328,32 @@ function UseCases({ t }) {
   );
 }
 
+/* ── 継続利用価値 ── */
+function LongTermValue({ t }) {
+  const c = t.longTermValue;
+  return (
+    <section className="long-term-value reveal" id="long-term-value">
+      <div className="container">
+        <div className="long-term-header">
+          <div className="sec-label">{c.label}</div>
+          <h2 className="sec-title">{c.title}</h2>
+          <p className="long-term-subtitle">{c.subtitle}</p>
+        </div>
+        <div className="long-term-grid">
+          {c.items.map((item, i) => (
+            <article key={i} className="long-term-card">
+              <div className="long-term-index">{String(i + 1).padStart(2, '0')}</div>
+              <div className="long-term-eyebrow">{item.eyebrow}</div>
+              <h3 className="long-term-title">{item.title}</h3>
+              <p className="long-term-desc">{item.desc}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 /* ── SYSTEM FLOW ── */
 function SystemFlow({ t, dark, lang }) {
   const c = t.systemFlow;
@@ -348,4 +374,4 @@ function SystemFlow({ t, dark, lang }) {
 }
 
 /* ── EXPORT ── */
-Object.assign(window, { NavBar, Hero, Products, PerformanceChart, Pricing, UseCases, SystemFlow });
+Object.assign(window, { NavBar, Hero, Products, PerformanceChart, Pricing, UseCases, SystemFlow, LongTermValue });

--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -256,6 +256,28 @@ window.COPY = {
         },
       ],
     },
+    longTermValue: {
+      label: '継続利用価値',
+      title: '戦略は、作って終わりではない',
+      subtitle: 'マーケット、研究、実装アイデアは変わり続けます。alpha-forge は一度きりの検証ツールではなく、戦略を見直し続けるための開発ループです。',
+      items: [
+        {
+          eyebrow: 'Regime Shift',
+          title: '市場レジームは変わる',
+          desc: '一度よい結果を出した投資戦略でも、ボラティリティ・金利・流動性・参加者行動の変化で将来も機能し続けるとは限りません。定期的な再検証が必要です。',
+        },
+        {
+          eyebrow: 'Strategy Intake',
+          title: '新しいアイデアは増え続ける',
+          desc: 'SSRN などの研究や TradingView の Pine Script コミュニティでは、新しい手法・指標・リスク管理アイデアが継続的に公開されています。検証候補を取り込める状態を保つことが重要です。',
+        },
+        {
+          eyebrow: 'Validation Loop',
+          title: '検証ループを回せる',
+          desc: 'alpha-forge はバックテスト、ベイズ最適化、ウォークフォワード検証、Pine Script 生成を同じ流れで扱えます。発見した仮説を、再現可能な検証サイクルへ落とし込めます。',
+        },
+      ],
+    },
     follow: {
       label: 'アップデート',
       title: '開発をリアルタイムで追う',
@@ -486,6 +508,28 @@ window.COPY = {
           title: 'Forex Strategies',
           desc: 'Run Bayesian optimization across high-dimensional parameter spaces for major pairs like USDJPY and EURUSD. Find optimal solutions more efficiently than grid search while preventing curve-fitting.',
           tags: ['FX Strategy', 'Bayesian Optimization', 'Currency Pairs', 'USDJPY / EURUSD'],
+        },
+      ],
+    },
+    longTermValue: {
+      label: 'Long-Term Value',
+      title: 'Strategies are never finished',
+      subtitle: 'Markets, research, and implementation ideas keep changing. alpha-forge is not a one-off backtest tool; it is a development loop for continuously revisiting your strategy assumptions.',
+      items: [
+        {
+          eyebrow: 'Regime Shift',
+          title: 'Market regimes change',
+          desc: 'A strategy that looks strong once may degrade as volatility, rates, liquidity, and participant behavior shift. Long-lived systems need periodic revalidation instead of one-time confidence.',
+        },
+        {
+          eyebrow: 'Strategy Intake',
+          title: 'New ideas keep arriving',
+          desc: 'Research platforms such as SSRN and the TradingView Pine Script community continue to surface new methods, indicators, and risk-management ideas. Keeping an intake path open helps turn them into testable candidates.',
+        },
+        {
+          eyebrow: 'Validation Loop',
+          title: 'Keep the validation loop moving',
+          desc: 'alpha-forge keeps backtesting, Bayesian optimization, walk-forward validation, and Pine Script generation in one flow. New hypotheses can move into reproducible validation without rebuilding the workflow each time.',
         },
       ],
     },

--- a/ja/index.html
+++ b/ja/index.html
@@ -867,6 +867,94 @@
     }
     @media (max-width: 900px) { .usecases-grid { grid-template-columns: 1fr 1fr; } }
     @media (max-width: 600px) { .usecases-grid { grid-template-columns: 1fr; } }
+
+    /* ── 継続利用価値 ── */
+    .long-term-value {
+      padding: 6rem 0;
+      border-bottom: 1px solid var(--border);
+      background:
+        linear-gradient(180deg, transparent 0%, var(--accent-bg) 52%, transparent 100%);
+    }
+    .long-term-header {
+      max-width: 720px;
+      margin-bottom: 2.5rem;
+    }
+    .long-term-subtitle {
+      margin-top: 0.9rem;
+      color: var(--text2);
+      font-size: 0.95rem;
+      line-height: 1.8;
+    }
+    .long-term-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 1px;
+      background: var(--border);
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      overflow: hidden;
+    }
+    .long-term-card {
+      min-height: 280px;
+      padding: 1.8rem;
+      background: var(--surface);
+      display: flex;
+      flex-direction: column;
+      gap: 0.85rem;
+      position: relative;
+      overflow: hidden;
+      transition: background 0.2s, border-color 0.2s;
+    }
+    .long-term-card::before {
+      content: '';
+      position: absolute;
+      inset: 0 0 auto;
+      height: 2px;
+      background: var(--accent);
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+    .long-term-card:hover {
+      background: var(--surface-h);
+    }
+    .long-term-card:hover::before {
+      opacity: 1;
+    }
+    .long-term-index {
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      color: var(--text3);
+      letter-spacing: 0.08em;
+    }
+    .long-term-eyebrow {
+      width: fit-content;
+      margin-top: 0.5rem;
+      padding: 0.22rem 0.6rem;
+      border: 1px solid var(--accent-glow);
+      border-radius: 100px;
+      background: var(--accent-bg);
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 0.64rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .long-term-title {
+      color: var(--text);
+      font-size: 1.05rem;
+      font-weight: 600;
+      line-height: 1.35;
+    }
+    .long-term-desc {
+      color: var(--text2);
+      font-size: 0.88rem;
+      line-height: 1.75;
+    }
+    @media (max-width: 900px) { .long-term-grid { grid-template-columns: 1fr; } }
+    @media (max-width: 600px) {
+      .long-term-value { padding: 4.5rem 0; }
+      .long-term-card { min-height: auto; padding: 1.5rem; }
+    }
   </style>
 </head>
 <body data-theme="dark">

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -830,6 +830,94 @@
     }
     @media (max-width: 900px) { .usecases-grid { grid-template-columns: 1fr 1fr; } }
     @media (max-width: 600px) { .usecases-grid { grid-template-columns: 1fr; } }
+
+    /* ── 継続利用価値 ── */
+    .long-term-value {
+      padding: 6rem 0;
+      border-bottom: 1px solid var(--border);
+      background:
+        linear-gradient(180deg, transparent 0%, var(--accent-bg) 52%, transparent 100%);
+    }
+    .long-term-header {
+      max-width: 720px;
+      margin-bottom: 2.5rem;
+    }
+    .long-term-subtitle {
+      margin-top: 0.9rem;
+      color: var(--text2);
+      font-size: 0.95rem;
+      line-height: 1.8;
+    }
+    .long-term-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 1px;
+      background: var(--border);
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      overflow: hidden;
+    }
+    .long-term-card {
+      min-height: 280px;
+      padding: 1.8rem;
+      background: var(--surface);
+      display: flex;
+      flex-direction: column;
+      gap: 0.85rem;
+      position: relative;
+      overflow: hidden;
+      transition: background 0.2s, border-color 0.2s;
+    }
+    .long-term-card::before {
+      content: '';
+      position: absolute;
+      inset: 0 0 auto;
+      height: 2px;
+      background: var(--accent);
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+    .long-term-card:hover {
+      background: var(--surface-h);
+    }
+    .long-term-card:hover::before {
+      opacity: 1;
+    }
+    .long-term-index {
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      color: var(--text3);
+      letter-spacing: 0.08em;
+    }
+    .long-term-eyebrow {
+      width: fit-content;
+      margin-top: 0.5rem;
+      padding: 0.22rem 0.6rem;
+      border: 1px solid var(--accent-glow);
+      border-radius: 100px;
+      background: var(--accent-bg);
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 0.64rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .long-term-title {
+      color: var(--text);
+      font-size: 1.05rem;
+      font-weight: 600;
+      line-height: 1.35;
+    }
+    .long-term-desc {
+      color: var(--text2);
+      font-size: 0.88rem;
+      line-height: 1.75;
+    }
+    @media (max-width: 900px) { .long-term-grid { grid-template-columns: 1fr; } }
+    @media (max-width: 600px) {
+      .long-term-value { padding: 4.5rem 0; }
+      .long-term-card { min-height: auto; padding: 1.5rem; }
+    }
   </style>
 </head>
 <body data-theme="dark">

--- a/tests/test_homepage_long_term_value.py
+++ b/tests/test_homepage_long_term_value.py
@@ -1,0 +1,57 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+class HomepageLongTermValueTest(unittest.TestCase):
+    def test_long_term_value_copy_exists_in_both_languages(self):
+        copy = read("homepage-copy.jsx")
+
+        self.assertIn("longTermValue", copy)
+        self.assertIn("戦略は、作って終わりではない", copy)
+        self.assertIn("Strategies are never finished", copy)
+        self.assertIn("市場レジームは変わる", copy)
+        self.assertIn("New ideas keep arriving", copy)
+        self.assertIn("検証ループを回せる", copy)
+        self.assertIn("Keep the validation loop moving", copy)
+
+    def test_long_term_value_component_is_rendered_between_usecases_and_performance(self):
+        components = read("homepage-components.jsx")
+        app = read("homepage-app.jsx")
+
+        self.assertIn("function LongTermValue", components)
+        self.assertIn('className="long-term-value reveal"', components)
+        self.assertIn(
+            "Object.assign(window, { NavBar, Hero, Products, PerformanceChart, Pricing, UseCases, SystemFlow, LongTermValue });",
+            components,
+        )
+
+        usecases_pos = app.index("<UseCases t={t} />")
+        long_term_pos = app.index("<LongTermValue t={t} />")
+        performance_pos = app.index("<PerformanceChart t={t} dark={dark} />")
+        self.assertLess(usecases_pos, long_term_pos)
+        self.assertLess(long_term_pos, performance_pos)
+
+    def test_long_term_value_styles_and_generated_pages_are_present(self):
+        template = read("templates/index.html.j2")
+        ja_html = read("ja/index.html")
+        en_html = read("en/index.html")
+
+        self.assertIn(".long-term-value", template)
+        self.assertIn(".long-term-grid", template)
+        self.assertRegex(template, r"@media \(max-width: 900px\).*?\.long-term-grid", re.S)
+        self.assertIn(".long-term-value", ja_html)
+        self.assertIn(".long-term-value", en_html)
+        self.assertIn('src="../homepage-copy.jsx"', ja_html)
+        self.assertIn('src="../homepage-copy.jsx"', en_html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
- ランディングページに alpha-forge を長く使い続ける理由を示す継続利用価値セクションを追加
- 市場レジーム変化、新しい戦略アイデアの継続的な増加、検証ループの重要性を日英コピーで整理
- テンプレート CSS と生成済み ja/en トップページを更新し、回帰テストを追加

## 確認
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m unittest tests.test_homepage_long_term_value -v`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python build.py`
- ローカル HTTP で `/ja/` と `/en/` が 200 OK

Closes #75