### PR TITLE
fix: platform-tabs を <button> 化してキーボード/SR 操作に対応 (#80)

### DIFF
--- a/en/install.html
+++ b/en/install.html
@@ -78,17 +78,17 @@
       </div>
 
       <h2 class="section-heading">Quick Install</h2>
-      <div class="platform-tabs">
-        <div class="platform-tab active" onclick="switchTab('en', 'mac', event)">macOS / Linux</div>
-        <div class="platform-tab" onclick="switchTab('en', 'win', event)">Windows</div>
+      <div class="platform-tabs" role="tablist">
+        <button type="button" class="platform-tab active" role="tab" aria-selected="true" aria-controls="tab-en-mac" onclick="switchTab('en', 'mac', event)">macOS / Linux</button>
+        <button type="button" class="platform-tab" role="tab" aria-selected="false" aria-controls="tab-en-win" onclick="switchTab('en', 'win', event)">Windows</button>
       </div>
 
-      <div id="tab-en-mac" class="platform-content active">
+      <div id="tab-en-mac" class="platform-content active" role="tabpanel">
         <p>Run the following in your terminal. The installer downloads the latest binary into <code>/usr/local/bin</code>.</p>
         <pre><code>curl -sSL https://alforge-labs.github.io/install.sh | bash</code></pre>
       </div>
 
-      <div id="tab-en-win" class="platform-content">
+      <div id="tab-en-win" class="platform-content" role="tabpanel">
         <p>Run this in PowerShell (no admin needed). Installs into <code>%USERPROFILE%\.forge\bin</code> and updates PATH.</p>
         <pre><code>irm https://alforge-labs.github.io/install.ps1 | iex</code></pre>
       </div>
@@ -149,9 +149,13 @@
   <script>
     function switchTab(lang, id, event) {
       var scope = document.querySelector('.lang-' + lang);
-      scope.querySelectorAll('.platform-tab').forEach(function(el) { el.classList.remove('active'); });
+      scope.querySelectorAll('.platform-tab').forEach(function(el) {
+        el.classList.remove('active');
+        el.setAttribute('aria-selected', 'false');
+      });
       scope.querySelectorAll('.platform-content').forEach(function(el) { el.classList.remove('active'); });
       event.currentTarget.classList.add('active');
+      event.currentTarget.setAttribute('aria-selected', 'true');
       document.getElementById('tab-' + lang + '-' + id).classList.add('active');
     }
   </script>

--- a/ja/install.html
+++ b/ja/install.html
@@ -78,17 +78,17 @@
       </div>
 
       <h2 class="section-heading">クイックインストール</h2>
-      <div class="platform-tabs">
-        <div class="platform-tab active" onclick="switchTab('ja', 'mac', event)">macOS / Linux</div>
-        <div class="platform-tab" onclick="switchTab('ja', 'win', event)">Windows</div>
+      <div class="platform-tabs" role="tablist">
+        <button type="button" class="platform-tab active" role="tab" aria-selected="true" aria-controls="tab-ja-mac" onclick="switchTab('ja', 'mac', event)">macOS / Linux</button>
+        <button type="button" class="platform-tab" role="tab" aria-selected="false" aria-controls="tab-ja-win" onclick="switchTab('ja', 'win', event)">Windows</button>
       </div>
 
-      <div id="tab-ja-mac" class="platform-content active">
+      <div id="tab-ja-mac" class="platform-content active" role="tabpanel">
         <p>ターミナルで実行します。インストーラーが最新バイナリをダウンロードし、<code>/usr/local/bin</code> に配置します。</p>
         <pre><code>curl -sSL https://alforge-labs.github.io/install.sh | bash</code></pre>
       </div>
 
-      <div id="tab-ja-win" class="platform-content">
+      <div id="tab-ja-win" class="platform-content" role="tabpanel">
         <p>PowerShell（管理者権限不要）で実行します。バイナリを <code>%USERPROFILE%\.forge\bin</code> にインストールし、PATH を自動設定します。</p>
         <pre><code>irm https://alforge-labs.github.io/install.ps1 | iex</code></pre>
       </div>
@@ -149,9 +149,13 @@
   <script>
     function switchTab(lang, id, event) {
       var scope = document.querySelector('.lang-' + lang);
-      scope.querySelectorAll('.platform-tab').forEach(function(el) { el.classList.remove('active'); });
+      scope.querySelectorAll('.platform-tab').forEach(function(el) {
+        el.classList.remove('active');
+        el.setAttribute('aria-selected', 'false');
+      });
       scope.querySelectorAll('.platform-content').forEach(function(el) { el.classList.remove('active'); });
       event.currentTarget.classList.add('active');
+      event.currentTarget.setAttribute('aria-selected', 'true');
       document.getElementById('tab-' + lang + '-' + id).classList.add('active');
     }
   </script>

--- a/page.css
+++ b/page.css
@@ -247,6 +247,7 @@ pre code { color: var(--text); font-size: 0.8rem; }
   padding: 0.4rem 1rem; border-radius: var(--r);
   background: var(--surface); border: 1px solid var(--border);
   font-family: var(--mono); font-size: 0.75rem; color: var(--text2);
+  line-height: inherit;
   cursor: pointer; transition: border-color 0.15s, color 0.15s;
 }
 .platform-tab.active, .platform-tab:hover {

--- a/templates/install.html.j2
+++ b/templates/install.html.j2
@@ -61,17 +61,17 @@
       </div>
 
       <h2 class="section-heading">クイックインストール</h2>
-      <div class="platform-tabs">
-        <div class="platform-tab active" onclick="switchTab('ja', 'mac', event)">macOS / Linux</div>
-        <div class="platform-tab" onclick="switchTab('ja', 'win', event)">Windows</div>
+      <div class="platform-tabs" role="tablist">
+        <button type="button" class="platform-tab active" role="tab" aria-selected="true" aria-controls="tab-ja-mac" onclick="switchTab('ja', 'mac', event)">macOS / Linux</button>
+        <button type="button" class="platform-tab" role="tab" aria-selected="false" aria-controls="tab-ja-win" onclick="switchTab('ja', 'win', event)">Windows</button>
       </div>
 
-      <div id="tab-ja-mac" class="platform-content active">
+      <div id="tab-ja-mac" class="platform-content active" role="tabpanel">
         <p>ターミナルで実行します。インストーラーが最新バイナリをダウンロードし、<code>/usr/local/bin</code> に配置します。</p>
         <pre><code>curl -sSL https://alforge-labs.github.io/install.sh | bash</code></pre>
       </div>
 
-      <div id="tab-ja-win" class="platform-content">
+      <div id="tab-ja-win" class="platform-content" role="tabpanel">
         <p>PowerShell（管理者権限不要）で実行します。バイナリを <code>%USERPROFILE%\.forge\bin</code> にインストールし、PATH を自動設定します。</p>
         <pre><code>irm https://alforge-labs.github.io/install.ps1 | iex</code></pre>
       </div>
@@ -119,17 +119,17 @@
       </div>
 
       <h2 class="section-heading">Quick Install</h2>
-      <div class="platform-tabs">
-        <div class="platform-tab active" onclick="switchTab('en', 'mac', event)">macOS / Linux</div>
-        <div class="platform-tab" onclick="switchTab('en', 'win', event)">Windows</div>
+      <div class="platform-tabs" role="tablist">
+        <button type="button" class="platform-tab active" role="tab" aria-selected="true" aria-controls="tab-en-mac" onclick="switchTab('en', 'mac', event)">macOS / Linux</button>
+        <button type="button" class="platform-tab" role="tab" aria-selected="false" aria-controls="tab-en-win" onclick="switchTab('en', 'win', event)">Windows</button>
       </div>
 
-      <div id="tab-en-mac" class="platform-content active">
+      <div id="tab-en-mac" class="platform-content active" role="tabpanel">
         <p>Run the following in your terminal. The installer downloads the latest binary into <code>/usr/local/bin</code>.</p>
         <pre><code>curl -sSL https://alforge-labs.github.io/install.sh | bash</code></pre>
       </div>
 
-      <div id="tab-en-win" class="platform-content">
+      <div id="tab-en-win" class="platform-content" role="tabpanel">
         <p>Run this in PowerShell (no admin needed). Installs into <code>%USERPROFILE%\.forge\bin</code> and updates PATH.</p>
         <pre><code>irm https://alforge-labs.github.io/install.ps1 | iex</code></pre>
       </div>
@@ -196,9 +196,13 @@
   <script>
     function switchTab(lang, id, event) {
       var scope = document.querySelector('.lang-' + lang);
-      scope.querySelectorAll('.platform-tab').forEach(function(el) { el.classList.remove('active'); });
+      scope.querySelectorAll('.platform-tab').forEach(function(el) {
+        el.classList.remove('active');
+        el.setAttribute('aria-selected', 'false');
+      });
       scope.querySelectorAll('.platform-content').forEach(function(el) { el.classList.remove('active'); });
       event.currentTarget.classList.add('active');
+      event.currentTarget.setAttribute('aria-selected', 'true');
       document.getElementById('tab-' + lang + '-' + id).classList.add('active');
     }
   </script>


### PR DESCRIPTION
## Summary
- `templates/install.html.j2` のクイックインストールタブを `<div onclick>` から `<button type=\"button\">` に変更し、WCAG 2.1 Level A の Keyboard Accessible 違反を解消
- `role=\"tablist\"` / `role=\"tab\"` / `role=\"tabpanel\"` / `aria-selected` / `aria-controls` を付与し、`switchTab()` で `aria-selected` を同期更新
- `.platform-tab` に `line-height: inherit` を追加して button のユーザーエージェント既定スタイルをリセット
- ja/en の `install.html` を再生成

## Test plan
- [ ] `https://alforgelabs.com/ja/install.html` を開き Tab キーで platform-tab にフォーカスでき、Enter / Space でタブ切替できること
- [ ] スクリーンリーダー（VoiceOver / NVDA など）が「ボタン」として読み上げること
- [ ] `.platform-tab` / `.platform-tab.active` の見た目が変化していないこと（既存スタイル維持）
- [ ] en 版でも同様に動作すること

Closes #80