### PR TITLE
seo: hreflang x-default をページ別の英語版に変更 (#81)

### DIFF
--- a/build.py
+++ b/build.py
@@ -100,6 +100,7 @@ def make_ctx(site: dict, page: str, lang: str, data: dict) -> dict:
         "canonical_url": f"{base}/{lang}/{page_file}",
         "hreflang_ja": f"{base}/ja/{page_file}",
         "hreflang_en": f"{base}/en/{page_file}",
+        "hreflang_x_default": f"{base}/en/{page_file}",
         "og_image": site["og_image"],
         "twitter_site": site["twitter_site"],
         "json_ld": build_json_ld(json_ld_type, base, lang, page),
@@ -152,6 +153,7 @@ def generate_sitemap(base_url: str) -> None:
                 f"    <loc>{loc}</loc>\n"
                 f'    <xhtml:link rel="alternate" hreflang="ja" href="{alt_ja}"/>\n'
                 f'    <xhtml:link rel="alternate" hreflang="en" href="{alt_en}"/>\n'
+                f'    <xhtml:link rel="alternate" hreflang="x-default" href="{alt_en}"/>\n'
                 f"    <changefreq>{freq}</changefreq>\n"
                 f"    <priority>{priority}</priority>\n"
                 f"  </url>"

--- a/en/docs.html
+++ b/en/docs.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://alforgelabs.com/en/docs.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/docs.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/docs.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/docs.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/en/docs.html" />
   <meta property="og:title" content="AlphaForge CLI Documentation" />

--- a/en/index.html
+++ b/en/index.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://alforgelabs.com/en/index.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/index.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/index.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/index.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/en/index.html" />
   <meta property="og:title" content="Alforge Labs — Backtesting CLI Framework" />

--- a/en/install.html
+++ b/en/install.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://alforgelabs.com/en/install.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/install.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/install.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/install.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/en/install.html" />
   <meta property="og:title" content="AlphaForge CLI Installation Guide" />

--- a/en/privacy.html
+++ b/en/privacy.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://alforgelabs.com/en/privacy.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/privacy.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/privacy.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/privacy.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/en/privacy.html" />
   <meta property="og:title" content="Privacy Policy — Alforge Labs" />

--- a/en/terms.html
+++ b/en/terms.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://alforgelabs.com/en/terms.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/terms.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/terms.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/terms.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/en/terms.html" />
   <meta property="og:title" content="Terms of Service & Risk Disclaimer — Alforge Labs" />

--- a/en/tutorial-strategy.html
+++ b/en/tutorial-strategy.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://alforgelabs.com/en/tutorial-strategy.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/tutorial-strategy.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/tutorial-strategy.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/tutorial-strategy.html" />
   <meta property="og:url" content="https://alforgelabs.com/en/tutorial-strategy.html" />
   <meta property="og:image" content="https://alforgelabs.com/assets/og-image.png" />
   <meta property="og:locale" content="en_US" />

--- a/ja/docs.html
+++ b/ja/docs.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://alforgelabs.com/ja/docs.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/docs.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/docs.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/docs.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/ja/docs.html" />
   <meta property="og:title" content="AlphaForge CLI ドキュメント" />

--- a/ja/index.html
+++ b/ja/index.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://alforgelabs.com/ja/index.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/index.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/index.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/index.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/ja/index.html" />
   <meta property="og:title" content="Alforge Labs — バックテスト CLI フレームワーク" />

--- a/ja/install.html
+++ b/ja/install.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://alforgelabs.com/ja/install.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/install.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/install.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/install.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/ja/install.html" />
   <meta property="og:title" content="AlphaForge CLI インストールガイド" />

--- a/ja/privacy.html
+++ b/ja/privacy.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://alforgelabs.com/ja/privacy.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/privacy.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/privacy.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/privacy.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/ja/privacy.html" />
   <meta property="og:title" content="プライバシーポリシー — Alforge Labs" />

--- a/ja/terms.html
+++ b/ja/terms.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://alforgelabs.com/ja/terms.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/terms.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/terms.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/terms.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/ja/terms.html" />
   <meta property="og:title" content="利用規約・リスク免責事項 — Alforge Labs" />

--- a/ja/tutorial-strategy.html
+++ b/ja/tutorial-strategy.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://alforgelabs.com/ja/tutorial-strategy.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/tutorial-strategy.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/tutorial-strategy.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/tutorial-strategy.html" />
   <meta property="og:url" content="https://alforgelabs.com/ja/tutorial-strategy.html" />
   <meta property="og:image" content="https://alforgelabs.com/assets/og-image.png" />
   <meta property="og:locale" content="ja_JP" />

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,6 +5,7 @@
     <loc>https://alforgelabs.com/ja/index.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/index.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/index.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/index.html"/>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -12,6 +13,7 @@
     <loc>https://alforgelabs.com/en/index.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/index.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/index.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/index.html"/>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -19,6 +21,7 @@
     <loc>https://alforgelabs.com/ja/install.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/install.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/install.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/install.html"/>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -26,6 +29,7 @@
     <loc>https://alforgelabs.com/en/install.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/install.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/install.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/install.html"/>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -33,6 +37,7 @@
     <loc>https://alforgelabs.com/ja/docs.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/docs.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/docs.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/docs.html"/>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -40,6 +45,7 @@
     <loc>https://alforgelabs.com/en/docs.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/docs.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/docs.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/docs.html"/>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -47,6 +53,7 @@
     <loc>https://alforgelabs.com/ja/tutorial-strategy.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/tutorial-strategy.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/tutorial-strategy.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/tutorial-strategy.html"/>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -54,6 +61,7 @@
     <loc>https://alforgelabs.com/en/tutorial-strategy.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/tutorial-strategy.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/tutorial-strategy.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/tutorial-strategy.html"/>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -61,6 +69,7 @@
     <loc>https://alforgelabs.com/ja/privacy.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/privacy.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/privacy.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/privacy.html"/>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
@@ -68,6 +77,7 @@
     <loc>https://alforgelabs.com/en/privacy.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/privacy.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/privacy.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/privacy.html"/>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
@@ -75,6 +85,7 @@
     <loc>https://alforgelabs.com/ja/terms.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/terms.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/terms.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/terms.html"/>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
@@ -82,6 +93,7 @@
     <loc>https://alforgelabs.com/en/terms.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/terms.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/terms.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/terms.html"/>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/templates/docs.html.j2
+++ b/templates/docs.html.j2
@@ -9,7 +9,7 @@
   <link rel="canonical" href="{{ canonical_url }}" />
   <link rel="alternate" hreflang="ja" href="{{ hreflang_ja }}" />
   <link rel="alternate" hreflang="en" href="{{ hreflang_en }}" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="{{ hreflang_x_default }}" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ canonical_url }}" />
   <meta property="og:title" content="{{ og_title }}" />

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -9,7 +9,7 @@
   <link rel="canonical" href="{{ canonical_url }}" />
   <link rel="alternate" hreflang="ja" href="{{ hreflang_ja }}" />
   <link rel="alternate" hreflang="en" href="{{ hreflang_en }}" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="{{ hreflang_x_default }}" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ canonical_url }}" />
   <meta property="og:title" content="{{ og_title }}" />

--- a/templates/install.html.j2
+++ b/templates/install.html.j2
@@ -9,7 +9,7 @@
   <link rel="canonical" href="{{ canonical_url }}" />
   <link rel="alternate" hreflang="ja" href="{{ hreflang_ja }}" />
   <link rel="alternate" hreflang="en" href="{{ hreflang_en }}" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="{{ hreflang_x_default }}" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ canonical_url }}" />
   <meta property="og:title" content="{{ og_title }}" />

--- a/templates/privacy.html.j2
+++ b/templates/privacy.html.j2
@@ -9,7 +9,7 @@
   <link rel="canonical" href="{{ canonical_url }}" />
   <link rel="alternate" hreflang="ja" href="{{ hreflang_ja }}" />
   <link rel="alternate" hreflang="en" href="{{ hreflang_en }}" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="{{ hreflang_x_default }}" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ canonical_url }}" />
   <meta property="og:title" content="{{ og_title }}" />

--- a/templates/terms.html.j2
+++ b/templates/terms.html.j2
@@ -9,7 +9,7 @@
   <link rel="canonical" href="{{ canonical_url }}" />
   <link rel="alternate" hreflang="ja" href="{{ hreflang_ja }}" />
   <link rel="alternate" hreflang="en" href="{{ hreflang_en }}" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="{{ hreflang_x_default }}" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ canonical_url }}" />
   <meta property="og:title" content="{{ og_title }}" />

--- a/templates/tutorial-strategy.html.j2
+++ b/templates/tutorial-strategy.html.j2
@@ -9,7 +9,7 @@
   <link rel="canonical" href="{{ canonical_url }}" />
   <link rel="alternate" hreflang="ja" href="{{ hreflang_ja }}" />
   <link rel="alternate" hreflang="en" href="{{ hreflang_en }}" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/" />
+  <link rel="alternate" hreflang="x-default" href="{{ hreflang_x_default }}" />
   <meta property="og:url" content="{{ canonical_url }}" />
   <meta property="og:image" content="{{ og_image }}" />
   <meta property="og:locale" content="{{ og_locale }}" />


### PR DESCRIPTION
## Summary
- `hreflang=\"x-default\"` がサイトルート `https://alforgelabs.com/` を指していたのを、各ページの英語版 URL に変更
- [Google の推奨](https://developers.google.com/search/docs/specialty/international/localized-versions)どおり「そのページのデフォルト言語バージョン」を指す形に修正
- `build.py` の `make_ctx()` に `hreflang_x_default = base/en/<page_file>` を追加し、6 テンプレートの x-default href を `{{ hreflang_x_default }}` に置換
- 整合性のため `sitemap.xml` の各 `<url>` にも `xhtml:link rel=\"alternate\" hreflang=\"x-default\"` を追加
- ja/en の全 12 HTML と sitemap.xml を再生成

## Test plan
- [ ] `ja/install.html` の `<link rel=\"alternate\" hreflang=\"x-default\">` が `https://alforgelabs.com/en/install.html` を指すこと
- [ ] 同じことが `ja/{index,docs,terms,privacy,tutorial-strategy}.html` および `en/*.html` で成立すること
- [ ] `sitemap.xml` の各 `<url>` に hreflang ja / en / x-default の 3 つの xhtml:link が並ぶこと
- [ ] 既存の `hreflang=\"ja\"` / `hreflang=\"en\"` リンクが維持されていること
- [ ] Google Search Console の URL 検査で hreflang エラーが出ないこと（マージ後のクロール待ち）

Closes #81