### PR TITLE
seo: docs.{ja,en} のメタデータを現コンテンツに整合 (#84)

### DIFF
--- a/en/docs.html
+++ b/en/docs.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Documentation — Alforge Labs</title>
-  <meta name="description" content="AlphaForge CLI command reference, strategy development workflow, and TradingView integration guide. Full coverage of backtesting, optimization, and walk-forward validation." />
-  <meta name="keywords" content="AlphaForge, documentation, command reference, backtesting, strategy development, TradingView, CLI" />
+  <meta name="description" content="AlphaForge CLI official docs. Quick reference for the six core commands and a full catalog of 7 groups × 76 subcommands. Also covers the end-to-end strategy development workflow, TradingView integration, and backtesting / optimization / walk-forward validation." />
+  <meta name="keywords" content="AlphaForge, documentation, command reference, backtesting, optimization, strategy workflow, TradingView, CLI" />
   <link rel="canonical" href="https://alforgelabs.com/en/docs.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/docs.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/docs.html" />
@@ -13,14 +13,14 @@
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/en/docs.html" />
   <meta property="og:title" content="AlphaForge CLI Documentation" />
-  <meta property="og:description" content="Command reference, strategy workflow, and TradingView integration — the official AlphaForge docs." />
+  <meta property="og:description" content="A quick reference for the six core commands and a full command catalog. The end-to-end strategy workflow and TradingView integration guides live in the MkDocs-based official CLI reference." />
   <meta property="og:image" content="https://alforgelabs.com/assets/og-image.png" />
   <meta property="og:locale" content="en_US" />
   <meta property="og:site_name" content="Alforge Labs" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@alforge_bot" />
   <meta name="twitter:title" content="AlphaForge CLI Documentation" />
-  <meta name="twitter:description" content="Command reference, strategy workflow, and TradingView integration — the official AlphaForge docs." />
+  <meta name="twitter:description" content="A quick reference for the six core commands and a full command catalog. The end-to-end strategy workflow and TradingView integration guides live in the MkDocs-based official CLI reference." />
   <meta name="twitter:image" content="https://alforgelabs.com/assets/og-image.png" />
   <script type="application/ld+json">{
   "@context": "https://schema.org",

--- a/ja/docs.html
+++ b/ja/docs.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ドキュメント — Alforge Labs</title>
-  <meta name="description" content="AlphaForge CLI コマンドリファレンス、戦略開発ワークフロー、TradingView 連携ガイド。バックテスト・最適化・ウォークフォワード検証の全手順。" />
-  <meta name="keywords" content="AlphaForge, ドキュメント, コマンドリファレンス, バックテスト, 戦略開発, TradingView, CLI" />
+  <meta name="description" content="AlphaForge CLI 公式ドキュメント。主要 6 コマンドの早見表と全 7 グループ × 76 サブコマンドのカタログ。エンドツーエンド戦略開発ワークフロー、TradingView 連携ガイド、バックテスト・最適化・ウォークフォワード検証も網羅。" />
+  <meta name="keywords" content="AlphaForge, ドキュメント, コマンドリファレンス, バックテスト, 最適化, 戦略開発ワークフロー, TradingView, CLI" />
   <link rel="canonical" href="https://alforgelabs.com/ja/docs.html" />
   <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/docs.html" />
   <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/docs.html" />
@@ -13,14 +13,14 @@
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://alforgelabs.com/ja/docs.html" />
   <meta property="og:title" content="AlphaForge CLI ドキュメント" />
-  <meta property="og:description" content="コマンドリファレンスから戦略開発ワークフロー、TradingView 連携まで網羅した公式ドキュメント。" />
+  <meta property="og:description" content="主要 6 コマンドの早見表と全コマンドカタログ。エンドツーエンド戦略開発ワークフローと TradingView 連携ガイドは MkDocs ベースの公式 CLI リファレンスへ。" />
   <meta property="og:image" content="https://alforgelabs.com/assets/og-image.png" />
   <meta property="og:locale" content="ja_JP" />
   <meta property="og:site_name" content="Alforge Labs" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@alforge_bot" />
   <meta name="twitter:title" content="AlphaForge CLI ドキュメント" />
-  <meta name="twitter:description" content="コマンドリファレンスから戦略開発ワークフロー、TradingView 連携まで網羅した公式ドキュメント。" />
+  <meta name="twitter:description" content="主要 6 コマンドの早見表と全コマンドカタログ。エンドツーエンド戦略開発ワークフローと TradingView 連携ガイドは MkDocs ベースの公式 CLI リファレンスへ。" />
   <meta name="twitter:image" content="https://alforgelabs.com/assets/og-image.png" />
   <script type="application/ld+json">{
   "@context": "https://schema.org",

--- a/seo.yaml
+++ b/seo.yaml
@@ -39,17 +39,17 @@ pages:
   docs:
     ja:
       title: "ドキュメント — Alforge Labs"
-      description: "AlphaForge CLI コマンドリファレンス、戦略開発ワークフロー、TradingView 連携ガイド。バックテスト・最適化・ウォークフォワード検証の全手順。"
-      keywords: "AlphaForge, ドキュメント, コマンドリファレンス, バックテスト, 戦略開発, TradingView, CLI"
+      description: "AlphaForge CLI 公式ドキュメント。主要 6 コマンドの早見表と全 7 グループ × 76 サブコマンドのカタログ。エンドツーエンド戦略開発ワークフロー、TradingView 連携ガイド、バックテスト・最適化・ウォークフォワード検証も網羅。"
+      keywords: "AlphaForge, ドキュメント, コマンドリファレンス, バックテスト, 最適化, 戦略開発ワークフロー, TradingView, CLI"
       og_title: "AlphaForge CLI ドキュメント"
-      og_description: "コマンドリファレンスから戦略開発ワークフロー、TradingView 連携まで網羅した公式ドキュメント。"
+      og_description: "主要 6 コマンドの早見表と全コマンドカタログ。エンドツーエンド戦略開発ワークフローと TradingView 連携ガイドは MkDocs ベースの公式 CLI リファレンスへ。"
       json_ld_type: breadcrumb
     en:
       title: "Documentation — Alforge Labs"
-      description: "AlphaForge CLI command reference, strategy development workflow, and TradingView integration guide. Full coverage of backtesting, optimization, and walk-forward validation."
-      keywords: "AlphaForge, documentation, command reference, backtesting, strategy development, TradingView, CLI"
+      description: "AlphaForge CLI official docs. Quick reference for the six core commands and a full catalog of 7 groups × 76 subcommands. Also covers the end-to-end strategy development workflow, TradingView integration, and backtesting / optimization / walk-forward validation."
+      keywords: "AlphaForge, documentation, command reference, backtesting, optimization, strategy workflow, TradingView, CLI"
       og_title: "AlphaForge CLI Documentation"
-      og_description: "Command reference, strategy workflow, and TradingView integration — the official AlphaForge docs."
+      og_description: "A quick reference for the six core commands and a full command catalog. The end-to-end strategy workflow and TradingView integration guides live in the MkDocs-based official CLI reference."
       json_ld_type: breadcrumb
 
   tutorial-strategy:


### PR DESCRIPTION
## Summary
- PR #82 で `docs.html.j2` を簡素化した後、SEO メタデータが旧フレーミングのまま残っていた問題を修正
- PR #86（issue #83）で **エンドツーエンド戦略開発ワークフロー / TradingView Pine 連携 / TradingView × alpha-strike 連携** の 3 ガイドが MkDocs サイトに移植済みのため、`戦略開発ワークフロー` / `TradingView` のキーワードは保持
- ランディング本体（早見表 + カタログ）と MkDocs リンク先（ワークフロー + TradingView ガイド）の役割を文言レベルで分離

## 変更点（旧 → 新）
- **description**：「コマンドリファレンス」だけでなく「主要 6 コマンドの早見表と全 7 グループ × 76 サブコマンドのカタログ」をランディング本体として明示しつつ、MkDocs 側で扱うガイド群も網羅と記載
- **keywords**：`戦略開発` を `戦略開発ワークフロー` に揃え MkDocs ガイド名と一致。`最適化` / `optimization` を新規追加
- **og_description**：SNS シェア時のプレビューが「早見表＋カタログのランディング、詳細は MkDocs ガイドへ」と分かるフレーミングに

## 影響範囲
- 変更: `seo.yaml` + `ja/docs.html` + `en/docs.html` の 3 ファイルのみ
- 他 10 HTML（index / install / tutorial-strategy / privacy / terms × ja/en）に副作用なし
- `sitemap.xml` / `robots.txt` 変更なし

## Test plan
- [ ] `ja/docs.html` の `<meta name=\"description\">` / `<meta name=\"keywords\">` / `<meta property=\"og:description\">` / `<meta name=\"twitter:description\">` が新文言で出力されていること
- [ ] `en/docs.html` も同様
- [ ] 旧フレーミング（`戦略開発` 単独 / `ウォークフォワード検証の全手順`）が `seo.yaml` から消えていること
- [ ] OGP プレビュー（Twitter Card Validator 等）で `og_description` が新フレーミングで表示されること（マージ後のクロール待ち）

Closes #84