### PR TITLE
feat: Freemium プランをランディングページに追加

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -533,6 +533,71 @@
       margin-top: 1.75rem; font-family: var(--mono); font-size: 0.7rem;
       color: var(--text3); max-width: 1040px;
     }
+
+    /* ── FREE BANNER ── */
+    .free-banner {
+      margin-top: 2rem;
+      border: 1px dashed rgba(0,228,154,0.35);
+      border-radius: var(--r);
+      background: rgba(0,228,154,0.03);
+      padding: 1.1rem 1.4rem;
+      display: flex; align-items: center; gap: 1.2rem; flex-wrap: wrap;
+    }
+    .free-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
+    .free-banner-body { flex: 1; min-width: 200px; }
+    .free-banner-title {
+      font-size: 0.95rem; font-weight: 600;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .free-badge {
+      font-family: var(--mono); font-size: 0.6rem; letter-spacing: 0.08em;
+      text-transform: uppercase;
+      background: rgba(0,228,154,0.12); color: var(--accent);
+      border: 1px solid rgba(0,228,154,0.25); border-radius: 4px; padding: 1px 6px;
+    }
+    .free-banner-desc {
+      margin-top: 0.3rem; color: var(--text2);
+      font-size: 0.82rem; line-height: 1.5;
+    }
+    .free-banner-pills {
+      margin-top: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.4rem;
+    }
+    .free-pill {
+      font-size: 0.68rem; padding: 2px 8px; border-radius: 20px;
+      border: 1px solid var(--border); color: var(--text2);
+    }
+    .free-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
+    .free-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
+    .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
+    .free-banner-cta { flex-shrink: 0; min-width: 140px; }
+    .free-banner-cta .btn-secondary {
+      width: 100%; justify-content: center; flex-direction: column; gap: 2px;
+    }
+
+    /* ── COMPARISON TABLE ── */
+    .pricing-comparison {
+      margin-top: 2rem;
+    }
+    .comparison-label {
+      font-family: var(--mono); font-size: 0.62rem; letter-spacing: 0.1em;
+      text-transform: uppercase; color: var(--text3); margin-bottom: 0.75rem;
+    }
+    .comparison-table {
+      width: 100%; border-collapse: collapse; font-size: 0.82rem;
+    }
+    .comparison-table thead tr { border-bottom: 1px solid var(--border); }
+    .comparison-th-feature { padding: 0.5rem 0.75rem; text-align: left; font-weight: 600; font-size: 0.78rem; width: 48%; }
+    .comparison-th-free    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
+    .comparison-th-paid    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
+    .comparison-td-feature { padding: 0.5rem 0.75rem; color: var(--text2); border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-free    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-paid    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-table tbody tr:last-child td { border-bottom: none; }
+    .comparison-table tbody tr:nth-child(even) td { background: rgba(255,255,255,0.015); }
+    .cmp-ok    { color: var(--accent); }
+    .cmp-limit { color: var(--amber); font-size: 0.75rem; }
+    .cmp-no    { color: var(--text3); }
+
     .pricing-card:hover .btn-secondary,
     .pricing-card:focus-within .btn-secondary {
       background: var(--accent);
@@ -766,6 +831,11 @@
     @media (max-width: 768px) {
       .products-grid { grid-template-columns: 1fr; }
       .pricing-grid { grid-template-columns: 1fr; }
+      .free-banner { flex-direction: column; align-items: flex-start; }
+      .free-banner-cta { width: 100%; }
+      .free-banner-cta .btn-secondary { width: 100%; }
+      .comparison-th-paid { display: none; }
+      .comparison-td-paid { display: none; }
       .nav-page-link { padding: 0 0.55rem; }
       .lang-btn { padding: 0 0.55rem; }
       .follow-btn-nav {

--- a/homepage-components.jsx
+++ b/homepage-components.jsx
@@ -247,6 +247,73 @@ function PerformanceChart({ t, dark }) {
   );
 }
 
+/* ── FREE BANNER ── */
+function FreeBanner({ plan, comingSummer }) {
+  const pillClass = { ok: 'free-pill-ok', limit: 'free-pill-limit', no: 'free-pill-no' };
+  return (
+    <div className="free-banner">
+      <div className="free-banner-icon">⚙</div>
+      <div className="free-banner-body">
+        <div className="free-banner-title">
+          {plan.title}
+          <span className="free-badge">{plan.badge}</span>
+        </div>
+        <p className="free-banner-desc" style={{ whiteSpace: 'pre-line' }}>{plan.desc}</p>
+        <div className="free-banner-pills">
+          {plan.pills.map((p, i) => (
+            <span key={i} className={`free-pill ${pillClass[p.type]}`}>{p.label}</span>
+          ))}
+        </div>
+      </div>
+      <div className="free-banner-cta">
+        <a
+          href="#roadmap"
+          className="btn-secondary"
+          style={{ justifyContent: 'center', flexDirection: 'column', gap: '2px' }}
+        >
+          <s>{plan.ctaLabel}</s>
+          <span style={{ fontSize: '0.82em', fontWeight: 400 }}>{comingSummer}</span>
+        </a>
+      </div>
+    </div>
+  );
+}
+
+/* ── COMPARISON TABLE ── */
+function ComparisonTable({ data }) {
+  return (
+    <div className="pricing-comparison">
+      <div className="comparison-label">{data.label}</div>
+      <table className="comparison-table">
+        <thead>
+          <tr>
+            <th className="comparison-th-feature"></th>
+            <th className="comparison-th-free">{data.colFree}</th>
+            <th className="comparison-th-paid">{data.colPaid}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.rows.map((row, i) => (
+            <tr key={i}>
+              <td className="comparison-td-feature">{row.feature}</td>
+              <td className="comparison-td-free">
+                {row.free === 'ok'    && <span className="cmp-ok">✓</span>}
+                {row.free === 'limit' && <span className="cmp-limit">{row.freeNote}</span>}
+                {row.free === 'no'    && <span className="cmp-no">—</span>}
+              </td>
+              <td className="comparison-td-paid">
+                {row.paid === 'ok' && (
+                  <span className="cmp-ok">{row.paidNote || '✓'}</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 /* ── PRICING ── */
 function Pricing({ t }) {
   const c = t.pricing;
@@ -256,7 +323,8 @@ function Pricing({ t }) {
         <div className="sec-label">{c.label}</div>
         <h2 className="sec-title" style={{ whiteSpace: 'pre-line' }}>{c.title}</h2>
         <p style={{ marginTop: '0.6rem', color: 'var(--text2)', fontSize: '0.92rem' }}>{c.subtitle}</p>
-        <div className="pricing-grid" style={{ marginTop: '2.5rem' }}>
+        <FreeBanner plan={c.freePlan} comingSummer={c.freePlan.comingSummer} />
+        <div className="pricing-grid" style={{ marginTop: '1rem' }}>
           {c.plans.map((plan, i) => (
             <div key={i} className={`pricing-card${plan.featured ? ' featured' : ''}`}>
               <div className="pricing-card-top">
@@ -287,6 +355,7 @@ function Pricing({ t }) {
             </div>
           ))}
         </div>
+        <ComparisonTable data={c.comparison} />
         <p className="pricing-note">{c.note}</p>
       </div>
     </section>
@@ -374,4 +443,4 @@ function SystemFlow({ t, dark, lang }) {
 }
 
 /* ── EXPORT ── */
-Object.assign(window, { NavBar, Hero, Products, PerformanceChart, Pricing, UseCases, SystemFlow, LongTermValue });
+Object.assign(window, { NavBar, Hero, Products, PerformanceChart, FreeBanner, ComparisonTable, Pricing, UseCases, SystemFlow, LongTermValue });

--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -31,7 +31,21 @@ window.COPY = {
     pricing: {
       label: '料金',
       title: '使い方に合わせて\n選べるプラン',
-      subtitle: '買い切り・年額・月額から選べます。Lifetime は将来のバージョンアップ込みです。',
+      subtitle: '買い切り・年額・月額から選べます。無料でも主要機能をお試しいただけます。',
+      freePlan: {
+        title: 'Free プランで始める',
+        badge: 'Free',
+        desc: 'バックテスト・ベイズ最適化・ウォークフォワード分析を無料で試せます。\n〜2023年のデータ・最適化50回上限・Pine Script 生成なし。',
+        pills: [
+          { label: '✓ バックテスト',       type: 'ok' },
+          { label: '✓ ウォークフォワード', type: 'ok' },
+          { label: '最適化 50回上限',      type: 'limit' },
+          { label: 'データ 〜2023年',      type: 'limit' },
+          { label: 'Pine Script 生成',     type: 'no' },
+        ],
+        ctaLabel: '$0 で登録',
+        comingSummer: '今夏提供開始予定',
+      },
       plans: [
         {
           name: 'Lifetime',
@@ -64,7 +78,7 @@ window.COPY = {
             'ベイズ最適化（Optuna）',
             'ウォークフォワード分析',
             'Pine Script v6 自動生成',
-            '常に最新バージョン',
+            '将来バージョンのアップデート込み',
             '1台のマシンでアクティベート',
           ],
           url: 'https://whop.com/alforge-labs'
@@ -82,7 +96,7 @@ window.COPY = {
             'ベイズ最適化（Optuna）',
             'ウォークフォワード分析',
             'Pine Script v6 自動生成',
-            '常に最新バージョン',
+            '将来バージョンのアップデート込み',
             '1台のマシンでアクティベート',
           ],
           url: 'https://whop.com/alforge-labs'
@@ -90,7 +104,22 @@ window.COPY = {
       ],
       buyNow: '今すぐ購入',
       comingSummer: '今夏販売開始予定',
-      note: '購入後にライセンスキーが発行されます。インストール後に forge license activate <KEY> で有効化してください。',
+      note: '購入・登録後にライセンスキーが発行されます。インストール後に forge license activate <KEY> で有効化してください。',
+      comparison: {
+        label: 'プラン比較',
+        colFree: 'Free',
+        colPaid: '有料プラン（Lifetime / Annual / Monthly）',
+        rows: [
+          { feature: 'macOS / Linux / Windows 対応',    free: 'ok',    paid: 'ok' },
+          { feature: 'バックテスト（シミュレーション）', free: 'limit', freeNote: '〜2023年のデータのみ', paid: 'ok', paidNote: '✓ 最新データ含む' },
+          { feature: 'ウォークフォワード分析',           free: 'limit', freeNote: '〜2023年のデータのみ', paid: 'ok', paidNote: '✓ 最新データ含む' },
+          { feature: 'ベイズ最適化（Optuna）',           free: 'limit', freeNote: '最大 50 回 / 実行',   paid: 'ok', paidNote: '✓ 回数無制限' },
+          { feature: '最新ヒストリカルデータ取得',        free: 'no',    paid: 'ok' },
+          { feature: 'Pine Script v6 自動生成',          free: 'no',    paid: 'ok' },
+          { feature: '将来バージョンのアップデート',      free: 'ok',    paid: 'ok' },
+          { feature: '1台のマシンでアクティベート',       free: 'ok',    paid: 'ok' },
+        ],
+      },
     },
     products: {
       label: 'プロダクト',
@@ -322,7 +351,21 @@ window.COPY = {
     pricing: {
       label: 'Pricing',
       title: 'Choose the plan\nthat fits your workflow.',
-      subtitle: 'Pick lifetime, annual, or monthly access. Lifetime includes future version updates.',
+      subtitle: 'Pick lifetime, annual, or monthly access. Or start free and upgrade when you\'re ready.',
+      freePlan: {
+        title: 'Start with Free',
+        badge: 'Free',
+        desc: 'Try backtesting, Bayesian optimization, and walk-forward analysis at no cost.\nHistorical data up to 2023 · 50 optimization trials per run · No Pine Script export.',
+        pills: [
+          { label: '✓ Backtest',           type: 'ok' },
+          { label: '✓ Walk-Forward',       type: 'ok' },
+          { label: 'Optimization 50 trials max', type: 'limit' },
+          { label: 'Data up to 2023',      type: 'limit' },
+          { label: 'Pine Script export',   type: 'no' },
+        ],
+        ctaLabel: 'Register for $0',
+        comingSummer: 'Coming This Summer',
+      },
       plans: [
         {
           name: 'Lifetime',
@@ -355,7 +398,7 @@ window.COPY = {
             'Bayesian optimization (Optuna)',
             'Walk-forward analysis',
             'Pine Script v6 auto-generation',
-            'Always latest version',
+            'Future version updates included',
             'Activate on 1 machine',
           ],
           url: 'https://whop.com/alforge-labs'
@@ -373,7 +416,7 @@ window.COPY = {
             'Bayesian optimization (Optuna)',
             'Walk-forward analysis',
             'Pine Script v6 auto-generation',
-            'Always latest version',
+            'Future version updates included',
             'Activate on 1 machine',
           ],
           url: 'https://whop.com/alforge-labs'
@@ -381,7 +424,22 @@ window.COPY = {
       ],
       buyNow: 'Get Access',
       comingSummer: 'Coming This Summer',
-      note: 'A license key is issued after purchase. Activate with: forge license activate <KEY>',
+      note: 'A license key is issued after purchase or registration. Activate with: forge license activate <KEY>',
+      comparison: {
+        label: 'Plan Comparison',
+        colFree: 'Free',
+        colPaid: 'Paid Plans (Lifetime / Annual / Monthly)',
+        rows: [
+          { feature: 'macOS / Linux / Windows',          free: 'ok',    paid: 'ok' },
+          { feature: 'Backtest (simulation)',             free: 'limit', freeNote: 'Historical data up to 2023', paid: 'ok', paidNote: '✓ Latest data included' },
+          { feature: 'Walk-forward analysis',            free: 'limit', freeNote: 'Historical data up to 2023', paid: 'ok', paidNote: '✓ Latest data included' },
+          { feature: 'Bayesian optimization (Optuna)',   free: 'limit', freeNote: 'Up to 50 trials per run',   paid: 'ok', paidNote: '✓ Unlimited' },
+          { feature: 'Latest historical data download',  free: 'no',    paid: 'ok' },
+          { feature: 'Pine Script v6 auto-generation',   free: 'no',    paid: 'ok' },
+          { feature: 'Future version updates',           free: 'ok',    paid: 'ok' },
+          { feature: 'Activate on 1 machine',            free: 'ok',    paid: 'ok' },
+        ],
+      },
     },
     products: {
       label: 'Products',

--- a/ja/index.html
+++ b/ja/index.html
@@ -533,6 +533,71 @@
       margin-top: 1.75rem; font-family: var(--mono); font-size: 0.7rem;
       color: var(--text3); max-width: 1040px;
     }
+
+    /* ── FREE BANNER ── */
+    .free-banner {
+      margin-top: 2rem;
+      border: 1px dashed rgba(0,228,154,0.35);
+      border-radius: var(--r);
+      background: rgba(0,228,154,0.03);
+      padding: 1.1rem 1.4rem;
+      display: flex; align-items: center; gap: 1.2rem; flex-wrap: wrap;
+    }
+    .free-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
+    .free-banner-body { flex: 1; min-width: 200px; }
+    .free-banner-title {
+      font-size: 0.95rem; font-weight: 600;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .free-badge {
+      font-family: var(--mono); font-size: 0.6rem; letter-spacing: 0.08em;
+      text-transform: uppercase;
+      background: rgba(0,228,154,0.12); color: var(--accent);
+      border: 1px solid rgba(0,228,154,0.25); border-radius: 4px; padding: 1px 6px;
+    }
+    .free-banner-desc {
+      margin-top: 0.3rem; color: var(--text2);
+      font-size: 0.82rem; line-height: 1.5;
+    }
+    .free-banner-pills {
+      margin-top: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.4rem;
+    }
+    .free-pill {
+      font-size: 0.68rem; padding: 2px 8px; border-radius: 20px;
+      border: 1px solid var(--border); color: var(--text2);
+    }
+    .free-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
+    .free-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
+    .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
+    .free-banner-cta { flex-shrink: 0; min-width: 140px; }
+    .free-banner-cta .btn-secondary {
+      width: 100%; justify-content: center; flex-direction: column; gap: 2px;
+    }
+
+    /* ── COMPARISON TABLE ── */
+    .pricing-comparison {
+      margin-top: 2rem;
+    }
+    .comparison-label {
+      font-family: var(--mono); font-size: 0.62rem; letter-spacing: 0.1em;
+      text-transform: uppercase; color: var(--text3); margin-bottom: 0.75rem;
+    }
+    .comparison-table {
+      width: 100%; border-collapse: collapse; font-size: 0.82rem;
+    }
+    .comparison-table thead tr { border-bottom: 1px solid var(--border); }
+    .comparison-th-feature { padding: 0.5rem 0.75rem; text-align: left; font-weight: 600; font-size: 0.78rem; width: 48%; }
+    .comparison-th-free    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
+    .comparison-th-paid    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
+    .comparison-td-feature { padding: 0.5rem 0.75rem; color: var(--text2); border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-free    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-paid    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-table tbody tr:last-child td { border-bottom: none; }
+    .comparison-table tbody tr:nth-child(even) td { background: rgba(255,255,255,0.015); }
+    .cmp-ok    { color: var(--accent); }
+    .cmp-limit { color: var(--amber); font-size: 0.75rem; }
+    .cmp-no    { color: var(--text3); }
+
     .pricing-card:hover .btn-secondary,
     .pricing-card:focus-within .btn-secondary {
       background: var(--accent);
@@ -766,6 +831,11 @@
     @media (max-width: 768px) {
       .products-grid { grid-template-columns: 1fr; }
       .pricing-grid { grid-template-columns: 1fr; }
+      .free-banner { flex-direction: column; align-items: flex-start; }
+      .free-banner-cta { width: 100%; }
+      .free-banner-cta .btn-secondary { width: 100%; }
+      .comparison-th-paid { display: none; }
+      .comparison-td-paid { display: none; }
       .nav-page-link { padding: 0 0.55rem; }
       .lang-btn { padding: 0 0.55rem; }
       .follow-btn-nav {

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -496,6 +496,71 @@
       margin-top: 1.75rem; font-family: var(--mono); font-size: 0.7rem;
       color: var(--text3); max-width: 1040px;
     }
+
+    /* ── FREE BANNER ── */
+    .free-banner {
+      margin-top: 2rem;
+      border: 1px dashed rgba(0,228,154,0.35);
+      border-radius: var(--r);
+      background: rgba(0,228,154,0.03);
+      padding: 1.1rem 1.4rem;
+      display: flex; align-items: center; gap: 1.2rem; flex-wrap: wrap;
+    }
+    .free-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
+    .free-banner-body { flex: 1; min-width: 200px; }
+    .free-banner-title {
+      font-size: 0.95rem; font-weight: 600;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .free-badge {
+      font-family: var(--mono); font-size: 0.6rem; letter-spacing: 0.08em;
+      text-transform: uppercase;
+      background: rgba(0,228,154,0.12); color: var(--accent);
+      border: 1px solid rgba(0,228,154,0.25); border-radius: 4px; padding: 1px 6px;
+    }
+    .free-banner-desc {
+      margin-top: 0.3rem; color: var(--text2);
+      font-size: 0.82rem; line-height: 1.5;
+    }
+    .free-banner-pills {
+      margin-top: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.4rem;
+    }
+    .free-pill {
+      font-size: 0.68rem; padding: 2px 8px; border-radius: 20px;
+      border: 1px solid var(--border); color: var(--text2);
+    }
+    .free-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
+    .free-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
+    .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
+    .free-banner-cta { flex-shrink: 0; min-width: 140px; }
+    .free-banner-cta .btn-secondary {
+      width: 100%; justify-content: center; flex-direction: column; gap: 2px;
+    }
+
+    /* ── COMPARISON TABLE ── */
+    .pricing-comparison {
+      margin-top: 2rem;
+    }
+    .comparison-label {
+      font-family: var(--mono); font-size: 0.62rem; letter-spacing: 0.1em;
+      text-transform: uppercase; color: var(--text3); margin-bottom: 0.75rem;
+    }
+    .comparison-table {
+      width: 100%; border-collapse: collapse; font-size: 0.82rem;
+    }
+    .comparison-table thead tr { border-bottom: 1px solid var(--border); }
+    .comparison-th-feature { padding: 0.5rem 0.75rem; text-align: left; font-weight: 600; font-size: 0.78rem; width: 48%; }
+    .comparison-th-free    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
+    .comparison-th-paid    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
+    .comparison-td-feature { padding: 0.5rem 0.75rem; color: var(--text2); border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-free    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-paid    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-table tbody tr:last-child td { border-bottom: none; }
+    .comparison-table tbody tr:nth-child(even) td { background: rgba(255,255,255,0.015); }
+    .cmp-ok    { color: var(--accent); }
+    .cmp-limit { color: var(--amber); font-size: 0.75rem; }
+    .cmp-no    { color: var(--text3); }
+
     .pricing-card:hover .btn-secondary,
     .pricing-card:focus-within .btn-secondary {
       background: var(--accent);
@@ -729,6 +794,11 @@
     @media (max-width: 768px) {
       .products-grid { grid-template-columns: 1fr; }
       .pricing-grid { grid-template-columns: 1fr; }
+      .free-banner { flex-direction: column; align-items: flex-start; }
+      .free-banner-cta { width: 100%; }
+      .free-banner-cta .btn-secondary { width: 100%; }
+      .comparison-th-paid { display: none; }
+      .comparison-td-paid { display: none; }
       .nav-page-link { padding: 0 0.55rem; }
       .lang-btn { padding: 0 0.55rem; }
       .follow-btn-nav {


### PR DESCRIPTION
## Summary

- Pricing セクションに **Free プラン**（Freemium）の情報を追加
- 見込み客把握のため $0 登録フロー（ライセンスキー発行）を導入
- 有料プランへのアップグレード動機を明示

## Changes

- **Free バナー（B）**: 有料カード上に機能制限ピル付き横長バナーを追加
- **プラン比較テーブル（C）**: Free vs 有料プランの機能比較テーブルを追加
- Annual・Monthly の features に「将来バージョンのアップデート込み」を追記
- 「Whop」名称を UI から削除し汎用表現に統一
- subtitle・note テキストを Free プラン対応に更新

## 制限事項（別 Issue で対応予定）

- データ期間: 〜2023年のみ（Closes #229）
- 最適化上限: 50回（Closes #230）
- Pine Script 生成: 不可（Closes #231）
- Free プランは将来バージョンのアップデートあり、過去バージョン維持なし（Closes #232）
- リリース時期: 有料プランと同様 Summer 2026（Closes #233）

## Test plan

- [ ] en/index.html・ja/index.html で Free バナーが表示されること
- [ ] プラン比較テーブルが正しく表示されること
- [ ] 有料プランの features に「将来バージョンのアップデート込み」が表示されること
- [ ] 「Whop」の文字列が UI に露出していないこと