### PR TITLE
LPにFree開始導線を追加

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -366,6 +366,117 @@
       text-transform: uppercase; font-family: var(--mono);
     }
 
+    /* ── FREE START ── */
+    .free-start {
+      padding: 4.75rem 0;
+      border-bottom: 1px solid var(--border);
+      background:
+        linear-gradient(180deg, var(--bg) 0%, var(--accent-bg) 100%);
+    }
+    .free-start-shell {
+      display: grid;
+      grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
+      gap: 2rem;
+      align-items: stretch;
+    }
+    .free-start-copy {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      gap: 1rem;
+    }
+    .free-start-title {
+      color: var(--text);
+      font-size: clamp(1.6rem, 3.2vw, 2.35rem);
+      font-weight: 600;
+      line-height: 1.15;
+    }
+    .free-start-subtitle {
+      max-width: 620px;
+      color: var(--text2);
+      font-size: 0.95rem;
+      line-height: 1.8;
+    }
+    .free-start-limits {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+    }
+    .free-start-limit {
+      border: 1px solid var(--accent-glow);
+      border-radius: 100px;
+      background: var(--surface);
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 0.68rem;
+      padding: 0.25rem 0.65rem;
+    }
+    .free-start-actions {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.75rem;
+      margin-top: 0.35rem;
+    }
+    .free-start-link {
+      color: var(--text2);
+      font-size: 0.86rem;
+      text-decoration: none;
+      border-bottom: 1px solid var(--border-h);
+      padding-bottom: 0.1rem;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .free-start-link:hover {
+      color: var(--accent);
+      border-color: var(--accent);
+    }
+    .free-start-note {
+      max-width: 620px;
+      color: var(--text3);
+      font-family: var(--mono);
+      font-size: 0.7rem;
+      line-height: 1.7;
+    }
+    .free-start-steps {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 1px;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      background: var(--border);
+    }
+    .free-start-step {
+      min-height: 132px;
+      background: var(--surface);
+      padding: 1.35rem;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      column-gap: 1rem;
+      row-gap: 0.35rem;
+      align-content: start;
+      transition: background 0.2s;
+    }
+    .free-start-step:hover { background: var(--surface-h); }
+    .free-start-step-num {
+      grid-row: span 2;
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
+    }
+    .free-start-step-title {
+      color: var(--text);
+      font-size: 0.98rem;
+      font-weight: 600;
+      line-height: 1.35;
+    }
+    .free-start-step-desc {
+      color: var(--text2);
+      font-size: 0.84rem;
+      line-height: 1.65;
+    }
+
     /* ── PRODUCTS ── */
     .products { padding: 6rem 0; border-bottom: 1px solid var(--border); }
     .products-grid {
@@ -589,7 +700,14 @@
     .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
     .free-banner-cta { flex-shrink: 0; min-width: 140px; }
     .free-banner-cta .btn-secondary {
-      width: 100%; justify-content: center; flex-direction: column; gap: 2px;
+      width: 100%; justify-content: center;
+    }
+    .free-banner-status {
+      margin-top: 0.35rem;
+      color: var(--text3);
+      font-family: var(--mono);
+      font-size: 0.66rem;
+      text-align: center;
     }
 
     /* ── COMPARISON TABLE ── */
@@ -849,6 +967,16 @@
     @media (max-width: 768px) {
       .products-grid { grid-template-columns: 1fr; }
       .pricing-grid { grid-template-columns: 1fr; }
+      .free-start { padding: 4rem 0; }
+      .free-start-shell { grid-template-columns: 1fr; }
+      .free-start-actions { align-items: stretch; }
+      .free-start-actions .btn-primary,
+      .free-start-actions .btn-secondary {
+        width: 100%;
+        justify-content: center;
+        text-align: center;
+      }
+      .free-start-link { width: fit-content; }
       .free-banner { flex-direction: column; align-items: flex-start; }
       .free-banner-cta { width: 100%; }
       .free-banner-cta .btn-secondary { width: 100%; }

--- a/homepage-app.jsx
+++ b/homepage-app.jsx
@@ -248,13 +248,14 @@ function App() {
   return (
     <div className="app">
       <NavBar dark={dark} setDark={setDark} lang={lang} setLang={setLang} t={t} />
-      <Hero t={t} />
+      <Hero t={t} lang={lang} />
+      <FreeStart t={t} lang={lang} />
       <Products t={t} />
       <SystemFlow t={t} dark={dark} lang={lang} />
       <UseCases t={t} />
       <LongTermValue t={t} />
       <PerformanceChart t={t} dark={dark} />
-      <Pricing t={t} />
+      <Pricing t={t} lang={lang} />
       <Roadmap t={t} />
       <FAQ t={t} />
       <FollowCTA t={t} />

--- a/homepage-components.jsx
+++ b/homepage-components.jsx
@@ -30,7 +30,7 @@ function NavBar({ dark, setDark, lang, setLang }) {
 }
 
 /* ── HERO ── */
-function Hero({ t }) {
+function Hero({ t, lang }) {
   const c = t.hero;
   const stats = t.heroStats;
   return (
@@ -43,7 +43,7 @@ function Hero({ t }) {
         </h1>
         <p className="hero-desc">{c.desc}</p>
         <div className="hero-cta">
-          <a href="#pricing" className="btn-primary">
+          <a href={`/${lang}/install.html`} className="btn-primary">
             {c.cta1}
           </a>
           <a href="#pricing" className="btn-secondary">{c.cta2} →</a>
@@ -55,6 +55,51 @@ function Hero({ t }) {
               <span className="stat-lbl">{s.lbl}</span>
             </div>
           ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ── FREE START ── */
+function FreeStart({ t, lang }) {
+  const c = t.freeStart;
+  return (
+    <section className="free-start reveal" id="free-start">
+      <div className="container">
+        <div className="free-start-shell">
+          <div className="free-start-copy">
+            <div className="sec-label">{c.label}</div>
+            <h2 className="free-start-title">{c.title}</h2>
+            <p className="free-start-subtitle">{c.subtitle}</p>
+            <div className="free-start-limits">
+              {c.limits.map((limit) => (
+                <span key={limit} className="free-start-limit">{limit}</span>
+              ))}
+            </div>
+            <div className="free-start-actions">
+              <a href={`/${lang}/install.html`} className="btn-primary">{c.primaryCta}</a>
+              <a href="#pricing" className="btn-secondary">{c.secondaryCta} →</a>
+              <a
+                href="https://x.com/alforge_bot"
+                target="_blank"
+                rel="noopener"
+                className="free-start-link"
+              >
+                {c.updateCta}
+              </a>
+            </div>
+            <p className="free-start-note">{c.availability}</p>
+          </div>
+          <div className="free-start-steps">
+            {c.steps.map((step) => (
+              <article key={step.num} className="free-start-step">
+                <span className="free-start-step-num">{step.num}</span>
+                <h3 className="free-start-step-title">{step.title}</h3>
+                <p className="free-start-step-desc">{step.desc}</p>
+              </article>
+            ))}
+          </div>
         </div>
       </div>
     </section>
@@ -244,7 +289,7 @@ function PerformanceChart({ t, dark }) {
 }
 
 /* ── FREE BANNER ── */
-function FreeBanner({ plan, comingSummer }) {
+function FreeBanner({ plan, comingSummer, lang }) {
   const pillClass = { ok: 'free-pill-ok', limit: 'free-pill-limit', no: 'free-pill-no' };
   return (
     <div className="free-banner">
@@ -263,13 +308,13 @@ function FreeBanner({ plan, comingSummer }) {
       </div>
       <div className="free-banner-cta">
         <a
-          href="#roadmap"
+          href={`/${lang}/install.html`}
           className="btn-secondary"
-          style={{ justifyContent: 'center', flexDirection: 'column', gap: '2px' }}
+          style={{ justifyContent: 'center' }}
         >
-          <s>{plan.ctaLabel}</s>
-          <span style={{ fontSize: '0.82em', fontWeight: 400 }}>{comingSummer}</span>
+          {plan.ctaHint || plan.ctaLabel}
         </a>
+        <div className="free-banner-status">{comingSummer}</div>
       </div>
     </div>
   );
@@ -311,7 +356,7 @@ function ComparisonTable({ data }) {
 }
 
 /* ── PRICING ── */
-function Pricing({ t }) {
+function Pricing({ t, lang }) {
   const c = t.pricing;
   return (
     <section className="pricing reveal" id="pricing">
@@ -319,7 +364,7 @@ function Pricing({ t }) {
         <div className="sec-label">{c.label}</div>
         <h2 className="sec-title" style={{ whiteSpace: 'pre-line' }}>{c.title}</h2>
         <p style={{ marginTop: '0.6rem', color: 'var(--text2)', fontSize: '0.92rem' }}>{c.subtitle}</p>
-        <FreeBanner plan={c.freePlan} comingSummer={c.freePlan.comingSummer} />
+        <FreeBanner plan={c.freePlan} comingSummer={c.freePlan.comingSummer} lang={lang} />
         <div className="pricing-grid" style={{ marginTop: '1rem' }}>
           {c.plans.map((plan, i) => (
             <div key={i} className={`pricing-card${plan.featured ? ' featured' : ''}`}>
@@ -439,4 +484,4 @@ function SystemFlow({ t, dark, lang }) {
 }
 
 /* ── EXPORT ── */
-Object.assign(window, { NavBar, Hero, Products, useChartColors, EquityChartSVG, BenchmarkTable, PerformanceChart, FreeBanner, ComparisonTable, Pricing, UseCases, SystemFlow, LongTermValue });
+Object.assign(window, { NavBar, Hero, FreeStart, Products, useChartColors, EquityChartSVG, BenchmarkTable, PerformanceChart, FreeBanner, ComparisonTable, Pricing, UseCases, SystemFlow, LongTermValue });

--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -20,8 +20,27 @@ window.COPY = {
       h1a: 'ノイズから、',
       h1b: 'シグナルへ。',
       desc: 'バックテスト・ベイズ最適化・ウォークフォワード検証をひとつの CLI で完結。先物・株式・FX を問わず、統計的に再現可能な投資戦略を体系的に開発・証明する。',
-      cta1: '今すぐ入手 — $499',
+      cta1: '無料で試す',
       cta2: 'プランを見る',
+    },
+    freeStart: {
+      label: 'Free で開始',
+      title: '無料で検証を始める',
+      subtitle: 'Free プランでは、バックテスト・ウォークフォワード分析・ベイズ最適化をローカル環境で試せます。まずはサンプル戦略を動かし、AlphaForge の検証フローを確認してください。',
+      primaryCta: 'インストールへ進む',
+      secondaryCta: '料金比較を見る',
+      updateCta: '更新情報をXで追う',
+      availability: 'Free 登録・販売開始は今夏提供開始予定です。現時点ではインストール手順と提供範囲を確認できます。',
+      steps: [
+        { num: '01', title: 'インストール', desc: 'macOS / Linux / Windows の手順に沿って CLI を準備します。' },
+        { num: '02', title: 'サンプル戦略を実行', desc: '用意された戦略 JSON でバックテストと検証フローを試します。' },
+        { num: '03', title: '結果を見る', desc: '指標、損益曲線、制限内の最適化結果を確認します。' },
+      ],
+      limits: [
+        'データは2023年まで',
+        '最適化50回',
+        'Pine Script生成なし',
+      ],
     },
     heroStats: [
       { val: '3', accent: false, lbl: '開発中プロダクト' },
@@ -44,6 +63,7 @@ window.COPY = {
           { label: 'Pine Script 生成',     type: 'no' },
         ],
         ctaLabel: '$0 で登録',
+        ctaHint: 'インストール手順へ',
         comingSummer: '今夏提供開始予定',
       },
       plans: [
@@ -340,8 +360,27 @@ window.COPY = {
       h1a: 'From Noise',
       h1b: 'to Signal.',
       desc: 'Backtest, Bayesian optimization, and walk-forward validation — unified in a single CLI. Systematically develop and validate investment strategies with reproducible statistical edge across futures, equities, and FX.',
-      cta1: 'Get Access — $499',
+      cta1: 'Start Free',
       cta2: 'See Plans',
+    },
+    freeStart: {
+      label: 'Start Free',
+      title: 'Start validating for free',
+      subtitle: 'The Free plan lets you try backtesting, walk-forward analysis, and Bayesian optimization locally. Start with a sample strategy and see the AlphaForge validation flow before choosing a paid plan.',
+      primaryCta: 'Go to install',
+      secondaryCta: 'Compare plans',
+      updateCta: 'Follow updates on X',
+      availability: 'Free registration and paid plans are scheduled for this summer. For now, you can review the install flow and plan limits.',
+      steps: [
+        { num: '01', title: 'Install', desc: 'Set up the CLI on macOS, Linux, or Windows.' },
+        { num: '02', title: 'Run a sample strategy', desc: 'Try the validation flow with a ready-made strategy JSON.' },
+        { num: '03', title: 'Review results', desc: 'Inspect metrics, the equity curve, and optimization results within Free limits.' },
+      ],
+      limits: [
+        'Data through 2023',
+        '50 optimization trials',
+        'No Pine Script export',
+      ],
     },
     heroStats: [
       { val: '3', accent: false, lbl: 'Products in Dev' },
@@ -364,6 +403,7 @@ window.COPY = {
           { label: 'Pine Script export',   type: 'no' },
         ],
         ctaLabel: 'Register for $0',
+        ctaHint: 'View install steps',
         comingSummer: 'Coming This Summer',
       },
       plans: [

--- a/ja/index.html
+++ b/ja/index.html
@@ -366,6 +366,117 @@
       text-transform: uppercase; font-family: var(--mono);
     }
 
+    /* ── FREE START ── */
+    .free-start {
+      padding: 4.75rem 0;
+      border-bottom: 1px solid var(--border);
+      background:
+        linear-gradient(180deg, var(--bg) 0%, var(--accent-bg) 100%);
+    }
+    .free-start-shell {
+      display: grid;
+      grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
+      gap: 2rem;
+      align-items: stretch;
+    }
+    .free-start-copy {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      gap: 1rem;
+    }
+    .free-start-title {
+      color: var(--text);
+      font-size: clamp(1.6rem, 3.2vw, 2.35rem);
+      font-weight: 600;
+      line-height: 1.15;
+    }
+    .free-start-subtitle {
+      max-width: 620px;
+      color: var(--text2);
+      font-size: 0.95rem;
+      line-height: 1.8;
+    }
+    .free-start-limits {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+    }
+    .free-start-limit {
+      border: 1px solid var(--accent-glow);
+      border-radius: 100px;
+      background: var(--surface);
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 0.68rem;
+      padding: 0.25rem 0.65rem;
+    }
+    .free-start-actions {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.75rem;
+      margin-top: 0.35rem;
+    }
+    .free-start-link {
+      color: var(--text2);
+      font-size: 0.86rem;
+      text-decoration: none;
+      border-bottom: 1px solid var(--border-h);
+      padding-bottom: 0.1rem;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .free-start-link:hover {
+      color: var(--accent);
+      border-color: var(--accent);
+    }
+    .free-start-note {
+      max-width: 620px;
+      color: var(--text3);
+      font-family: var(--mono);
+      font-size: 0.7rem;
+      line-height: 1.7;
+    }
+    .free-start-steps {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 1px;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      background: var(--border);
+    }
+    .free-start-step {
+      min-height: 132px;
+      background: var(--surface);
+      padding: 1.35rem;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      column-gap: 1rem;
+      row-gap: 0.35rem;
+      align-content: start;
+      transition: background 0.2s;
+    }
+    .free-start-step:hover { background: var(--surface-h); }
+    .free-start-step-num {
+      grid-row: span 2;
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
+    }
+    .free-start-step-title {
+      color: var(--text);
+      font-size: 0.98rem;
+      font-weight: 600;
+      line-height: 1.35;
+    }
+    .free-start-step-desc {
+      color: var(--text2);
+      font-size: 0.84rem;
+      line-height: 1.65;
+    }
+
     /* ── PRODUCTS ── */
     .products { padding: 6rem 0; border-bottom: 1px solid var(--border); }
     .products-grid {
@@ -589,7 +700,14 @@
     .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
     .free-banner-cta { flex-shrink: 0; min-width: 140px; }
     .free-banner-cta .btn-secondary {
-      width: 100%; justify-content: center; flex-direction: column; gap: 2px;
+      width: 100%; justify-content: center;
+    }
+    .free-banner-status {
+      margin-top: 0.35rem;
+      color: var(--text3);
+      font-family: var(--mono);
+      font-size: 0.66rem;
+      text-align: center;
     }
 
     /* ── COMPARISON TABLE ── */
@@ -849,6 +967,16 @@
     @media (max-width: 768px) {
       .products-grid { grid-template-columns: 1fr; }
       .pricing-grid { grid-template-columns: 1fr; }
+      .free-start { padding: 4rem 0; }
+      .free-start-shell { grid-template-columns: 1fr; }
+      .free-start-actions { align-items: stretch; }
+      .free-start-actions .btn-primary,
+      .free-start-actions .btn-secondary {
+        width: 100%;
+        justify-content: center;
+        text-align: center;
+      }
+      .free-start-link { width: fit-content; }
       .free-banner { flex-direction: column; align-items: flex-start; }
       .free-banner-cta { width: 100%; }
       .free-banner-cta .btn-secondary { width: 100%; }

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -286,6 +286,117 @@
       text-transform: uppercase; font-family: var(--mono);
     }
 
+    /* ── FREE START ── */
+    .free-start {
+      padding: 4.75rem 0;
+      border-bottom: 1px solid var(--border);
+      background:
+        linear-gradient(180deg, var(--bg) 0%, var(--accent-bg) 100%);
+    }
+    .free-start-shell {
+      display: grid;
+      grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
+      gap: 2rem;
+      align-items: stretch;
+    }
+    .free-start-copy {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      gap: 1rem;
+    }
+    .free-start-title {
+      color: var(--text);
+      font-size: clamp(1.6rem, 3.2vw, 2.35rem);
+      font-weight: 600;
+      line-height: 1.15;
+    }
+    .free-start-subtitle {
+      max-width: 620px;
+      color: var(--text2);
+      font-size: 0.95rem;
+      line-height: 1.8;
+    }
+    .free-start-limits {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+    }
+    .free-start-limit {
+      border: 1px solid var(--accent-glow);
+      border-radius: 100px;
+      background: var(--surface);
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 0.68rem;
+      padding: 0.25rem 0.65rem;
+    }
+    .free-start-actions {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.75rem;
+      margin-top: 0.35rem;
+    }
+    .free-start-link {
+      color: var(--text2);
+      font-size: 0.86rem;
+      text-decoration: none;
+      border-bottom: 1px solid var(--border-h);
+      padding-bottom: 0.1rem;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .free-start-link:hover {
+      color: var(--accent);
+      border-color: var(--accent);
+    }
+    .free-start-note {
+      max-width: 620px;
+      color: var(--text3);
+      font-family: var(--mono);
+      font-size: 0.7rem;
+      line-height: 1.7;
+    }
+    .free-start-steps {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 1px;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      background: var(--border);
+    }
+    .free-start-step {
+      min-height: 132px;
+      background: var(--surface);
+      padding: 1.35rem;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      column-gap: 1rem;
+      row-gap: 0.35rem;
+      align-content: start;
+      transition: background 0.2s;
+    }
+    .free-start-step:hover { background: var(--surface-h); }
+    .free-start-step-num {
+      grid-row: span 2;
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
+    }
+    .free-start-step-title {
+      color: var(--text);
+      font-size: 0.98rem;
+      font-weight: 600;
+      line-height: 1.35;
+    }
+    .free-start-step-desc {
+      color: var(--text2);
+      font-size: 0.84rem;
+      line-height: 1.65;
+    }
+
     /* ── PRODUCTS ── */
     .products { padding: 6rem 0; border-bottom: 1px solid var(--border); }
     .products-grid {
@@ -509,7 +620,14 @@
     .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
     .free-banner-cta { flex-shrink: 0; min-width: 140px; }
     .free-banner-cta .btn-secondary {
-      width: 100%; justify-content: center; flex-direction: column; gap: 2px;
+      width: 100%; justify-content: center;
+    }
+    .free-banner-status {
+      margin-top: 0.35rem;
+      color: var(--text3);
+      font-family: var(--mono);
+      font-size: 0.66rem;
+      text-align: center;
     }
 
     /* ── COMPARISON TABLE ── */
@@ -769,6 +887,16 @@
     @media (max-width: 768px) {
       .products-grid { grid-template-columns: 1fr; }
       .pricing-grid { grid-template-columns: 1fr; }
+      .free-start { padding: 4rem 0; }
+      .free-start-shell { grid-template-columns: 1fr; }
+      .free-start-actions { align-items: stretch; }
+      .free-start-actions .btn-primary,
+      .free-start-actions .btn-secondary {
+        width: 100%;
+        justify-content: center;
+        text-align: center;
+      }
+      .free-start-link { width: fit-content; }
       .free-banner { flex-direction: column; align-items: flex-start; }
       .free-banner-cta { width: 100%; }
       .free-banner-cta .btn-secondary { width: 100%; }

--- a/tests/test_homepage_free_start.py
+++ b/tests/test_homepage_free_start.py
@@ -1,0 +1,54 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+class HomepageFreeStartTest(unittest.TestCase):
+    def test_free_start_copy_exists_in_both_languages(self):
+        copy = read("homepage-copy.jsx")
+
+        self.assertIn("freeStart", copy)
+        self.assertIn("無料で検証を始める", copy)
+        self.assertIn("Start validating for free", copy)
+        self.assertIn("データは2023年まで", copy)
+        self.assertIn("Data through 2023", copy)
+        self.assertIn("最適化50回", copy)
+        self.assertIn("50 optimization trials", copy)
+        self.assertIn("Pine Script生成なし", copy)
+        self.assertIn("No Pine Script export", copy)
+
+    def test_free_start_component_is_rendered_after_hero(self):
+        components = read("homepage-components.jsx")
+        app = read("homepage-app.jsx")
+
+        self.assertIn("function FreeStart", components)
+        self.assertIn('className="free-start reveal"', components)
+        self.assertIn("Object.assign(window, { NavBar, Hero, FreeStart", components)
+        self.assertIn('href={`/${lang}/install.html`}', components)
+        self.assertIn('href="#pricing"', components)
+
+        hero_pos = app.index("<Hero t={t} lang={lang} />")
+        free_start_pos = app.index("<FreeStart t={t} lang={lang} />")
+        products_pos = app.index("<Products t={t} />")
+        self.assertLess(hero_pos, free_start_pos)
+        self.assertLess(free_start_pos, products_pos)
+
+    def test_generated_pages_include_free_start_styles(self):
+        template = read("templates/index.html.j2")
+        ja_html = read("ja/index.html")
+        en_html = read("en/index.html")
+
+        self.assertIn(".free-start", template)
+        self.assertIn(".free-start-steps", template)
+        self.assertIn("free-start", ja_html)
+        self.assertIn("free-start", en_html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_homepage_long_term_value.py
+++ b/tests/test_homepage_long_term_value.py
@@ -29,7 +29,7 @@ class HomepageLongTermValueTest(unittest.TestCase):
         self.assertIn("function LongTermValue", components)
         self.assertIn('className="long-term-value reveal"', components)
         self.assertIn(
-            "Object.assign(window, { NavBar, Hero, Products, PerformanceChart, Pricing, UseCases, SystemFlow, LongTermValue });",
+            "Object.assign(window, { NavBar, Hero, FreeStart",
             components,
         )
 


### PR DESCRIPTION
## 概要
- Heroの主CTAをFree開始導線へ変更し、日英LPでインストールページへ誘導
- Hero直下にFreeでできること、制限、3ステップ導線を示すFreeStartセクションを追加
- 料金セクション内のFreeバナーを取り消し線CTAからインストール手順への補助導線に変更
- 生成済みja/enトップページと回帰テストを更新

## 確認
- `uv run python build.py`
- `uv run python -m unittest tests.test_homepage_free_start tests.test_homepage_long_term_value -v`
- `uv run python -m unittest discover -s tests -v`
- `uv run python -m compileall build.py tests`

Closes #99