### PR TITLE
fix: Free プランのデータ期間制限テキストを 2023/12/31 に確定

### DIFF
--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -37,7 +37,7 @@ window.COPY = {
         { num: '03', title: '結果を見る', desc: '指標、損益曲線、制限内の最適化結果を確認します。' },
       ],
       limits: [
-        'データは2023年まで',
+        'データは2023年12月31日まで',
         '最適化50回',
         'Pine Script生成なし',
       ],
@@ -54,12 +54,12 @@ window.COPY = {
       freePlan: {
         title: 'Free プランで始める',
         badge: 'Free',
-        desc: 'バックテスト・ベイズ最適化・ウォークフォワード分析を無料で試せます。\n〜2023年のデータ・最適化50回上限・Pine Script 生成なし。',
+        desc: 'バックテスト・ベイズ最適化・ウォークフォワード分析を無料で試せます。\n2023年12月31日までのデータ・最適化50回上限・Pine Script 生成なし。',
         pills: [
           { label: '✓ バックテスト',       type: 'ok' },
           { label: '✓ ウォークフォワード', type: 'ok' },
           { label: '最適化 50回上限',      type: 'limit' },
-          { label: 'データ 〜2023年',      type: 'limit' },
+          { label: 'データ 〜2023/12/31',   type: 'limit' },
           { label: 'Pine Script 生成',     type: 'no' },
         ],
         ctaLabel: '$0 で登録',
@@ -131,8 +131,8 @@ window.COPY = {
         colPaid: '有料プラン（Lifetime / Annual / Monthly）',
         rows: [
           { feature: 'macOS / Linux / Windows 対応',    free: 'ok',    paid: 'ok' },
-          { feature: 'バックテスト（シミュレーション）', free: 'limit', freeNote: '〜2023年のデータのみ', paid: 'ok', paidNote: '✓ 最新データ含む' },
-          { feature: 'ウォークフォワード分析',           free: 'limit', freeNote: '〜2023年のデータのみ', paid: 'ok', paidNote: '✓ 最新データ含む' },
+          { feature: 'バックテスト（シミュレーション）', free: 'limit', freeNote: '2023/12/31までのデータのみ', paid: 'ok', paidNote: '✓ 最新データ含む' },
+          { feature: 'ウォークフォワード分析',           free: 'limit', freeNote: '2023/12/31までのデータのみ', paid: 'ok', paidNote: '✓ 最新データ含む' },
           { feature: 'ベイズ最適化（Optuna）',           free: 'limit', freeNote: '最大 50 回 / 実行',   paid: 'ok', paidNote: '✓ 回数無制限' },
           { feature: '最新ヒストリカルデータ取得',        free: 'no',    paid: 'ok' },
           { feature: 'Pine Script v6 自動生成',          free: 'no',    paid: 'ok' },
@@ -406,7 +406,7 @@ window.COPY = {
         { num: '03', title: 'Review results', desc: 'Inspect metrics, the equity curve, and optimization results within Free limits.' },
       ],
       limits: [
-        'Data through 2023',
+        'Data through Dec 31, 2023',
         '50 optimization trials',
         'No Pine Script export',
       ],
@@ -423,12 +423,12 @@ window.COPY = {
       freePlan: {
         title: 'Start with Free',
         badge: 'Free',
-        desc: 'Try backtesting, Bayesian optimization, and walk-forward analysis at no cost.\nHistorical data up to 2023 · 50 optimization trials per run · No Pine Script export.',
+        desc: 'Try backtesting, Bayesian optimization, and walk-forward analysis at no cost.\nHistorical data up to Dec 31, 2023 · 50 optimization trials per run · No Pine Script export.',
         pills: [
           { label: '✓ Backtest',           type: 'ok' },
           { label: '✓ Walk-Forward',       type: 'ok' },
           { label: 'Optimization 50 trials max', type: 'limit' },
-          { label: 'Data up to 2023',      type: 'limit' },
+          { label: 'Data up to Dec 31, 2023', type: 'limit' },
           { label: 'Pine Script export',   type: 'no' },
         ],
         ctaLabel: 'Register for $0',
@@ -500,8 +500,8 @@ window.COPY = {
         colPaid: 'Paid Plans (Lifetime / Annual / Monthly)',
         rows: [
           { feature: 'macOS / Linux / Windows',          free: 'ok',    paid: 'ok' },
-          { feature: 'Backtest (simulation)',             free: 'limit', freeNote: 'Historical data up to 2023', paid: 'ok', paidNote: '✓ Latest data included' },
-          { feature: 'Walk-forward analysis',            free: 'limit', freeNote: 'Historical data up to 2023', paid: 'ok', paidNote: '✓ Latest data included' },
+          { feature: 'Backtest (simulation)',             free: 'limit', freeNote: 'Historical data up to Dec 31, 2023', paid: 'ok', paidNote: '✓ Latest data included' },
+          { feature: 'Walk-forward analysis',            free: 'limit', freeNote: 'Historical data up to Dec 31, 2023', paid: 'ok', paidNote: '✓ Latest data included' },
           { feature: 'Bayesian optimization (Optuna)',   free: 'limit', freeNote: 'Up to 50 trials per run',   paid: 'ok', paidNote: '✓ Unlimited' },
           { feature: 'Latest historical data download',  free: 'no',    paid: 'ok' },
           { feature: 'Pine Script v6 auto-generation',   free: 'no',    paid: 'ok' },


### PR DESCRIPTION
## Summary

- alpha-forge #229・#230 の実装で確定したカットオフ日（**2023-12-31**）を Landing Page の日英コピーに反映
- `homepage-copy.jsx` の暫定表記「〜2023年」「up to 2023」を正確な日付に更新（日英合計 10 箇所）

## 変更内容

**日本語 (ja)**
- `freeStart.limits`: `データは2023年まで` → `データは2023年12月31日まで`
- `freePlan.desc`: `〜2023年のデータ` → `2023年12月31日までのデータ`
- `freePlan.pills`: `データ 〜2023年` → `データ 〜2023/12/31`
- `comparison.rows` × 2: `〜2023年のデータのみ` → `2023/12/31までのデータのみ`

**英語 (en)**
- `freeStart.limits`: `Data through 2023` → `Data through Dec 31, 2023`
- `freePlan.desc`: `Historical data up to 2023` → `Historical data up to Dec 31, 2023`
- `freePlan.pills`: `Data up to 2023` → `Data up to Dec 31, 2023`
- `comparison.rows` × 2: `Historical data up to 2023` → `Historical data up to Dec 31, 2023`

## Test plan

- [x] `uv run python build.py` でビルドが通ること
- [x] `homepage-copy.jsx` の全10箇所で「2023」表記が確定日付に更新されていること
- [ ] ブラウザで ja/en ランディングページを開き、Pricing セクションの表記を目視確認

Closes #93