### PR TITLE
docs: docs.html にプラン制限バッジを追加（ja/en）

### DIFF
--- a/en/docs.html
+++ b/en/docs.html
@@ -108,6 +108,17 @@
       font-family: var(--mono);
     }
     .cmd-card:hover .cmd-card-link { color: var(--accent); }
+
+    /* ── PLAN BADGES ── */
+    .cmd-card-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.5rem; margin-bottom: 0.4rem; }
+    .cmd-card-header .cmd-card-name { margin-bottom: 0; }
+    .plan-badge {
+      display: inline-block; font-family: var(--sans); font-size: 0.65rem; font-weight: 600;
+      padding: 0.15rem 0.45rem; border-radius: 3px; white-space: nowrap; flex-shrink: 0;
+      line-height: 1.4;
+    }
+    .plan-badge-paid  { background: rgba(255,90,90,0.15); color: #ff6b6b; border: 1px solid rgba(255,90,90,0.35); }
+    .plan-badge-limit { background: rgba(255,185,0,0.12); color: #e6a800; border: 1px solid rgba(255,185,0,0.30); }
   </style>
   <script>
     (function() {
@@ -143,10 +154,22 @@
         </a>
       </div>
 
+      <div class="callout" style="margin-bottom: 2rem; border-color: rgba(255,185,0,0.35);">
+        <p style="font-weight:600; margin-bottom:0.5rem;">🔒 Plan Restrictions</p>
+        <p style="margin-bottom:0.5rem;">
+          The <strong>Free plan</strong> limits evaluation to data ≤ 2023-12-31 and optimization to 50 trials.
+          <code>forge pine generate / preview</code> requires a <strong>paid plan</strong>.
+        </p>
+        <a href="/en/index.html#pricing" class="btn-primary" style="font-size:0.8rem;">Compare plans →</a>
+      </div>
+
       <h2 class="section-heading">Top Commands</h2>
       <div class="cmd-card-grid">
         <a class="cmd-card" href="/en/docs/cli-reference/backtest/#forge-backtest-run">
-          <div class="cmd-card-name">forge backtest run</div>
+          <div class="cmd-card-header">
+            <div class="cmd-card-name">forge backtest run</div>
+            <span class="plan-badge plan-badge-limit">Free: limited</span>
+          </div>
           <div class="cmd-card-desc">Run a backtest applying a strategy to a single symbol.</div>
           <pre class="cmd-card-usage"><code>forge backtest run SYMBOL --strategy ID</code></pre>
           <div class="cmd-card-options">
@@ -158,7 +181,10 @@
         </a>
 
         <a class="cmd-card" href="/en/docs/cli-reference/optimize/#forge-optimize-run">
-          <div class="cmd-card-name">forge optimize run</div>
+          <div class="cmd-card-header">
+            <div class="cmd-card-name">forge optimize run</div>
+            <span class="plan-badge plan-badge-limit">Free: 50 trials</span>
+          </div>
           <div class="cmd-card-desc">Parameter optimization with Optuna (TPE). Multi-objective also supported.</div>
           <pre class="cmd-card-usage"><code>forge optimize run SYMBOL --strategy ID</code></pre>
           <div class="cmd-card-options">
@@ -170,7 +196,10 @@
         </a>
 
         <a class="cmd-card" href="/en/docs/cli-reference/optimize/#forge-optimize-walk-forward">
-          <div class="cmd-card-name">forge optimize walk-forward</div>
+          <div class="cmd-card-header">
+            <div class="cmd-card-name">forge optimize walk-forward</div>
+            <span class="plan-badge plan-badge-limit">Free: limited</span>
+          </div>
           <div class="cmd-card-desc">Split time series into windows; IS optimization → OOS evaluation for overfitting resistance.</div>
           <pre class="cmd-card-usage"><code>forge optimize walk-forward SYMBOL --strategy ID --windows N</code></pre>
           <div class="cmd-card-options">
@@ -181,7 +210,10 @@
         </a>
 
         <a class="cmd-card" href="/en/docs/cli-reference/data/#forge-data-fetch">
-          <div class="cmd-card-name">forge data fetch</div>
+          <div class="cmd-card-header">
+            <div class="cmd-card-name">forge data fetch</div>
+            <span class="plan-badge plan-badge-limit">Free: limited</span>
+          </div>
           <div class="cmd-card-desc">Fetch OHLCV from a provider and store as Parquet.</div>
           <pre class="cmd-card-usage"><code>forge data fetch SYMBOL --period 5y --interval 1d</code></pre>
           <div class="cmd-card-options">
@@ -213,43 +245,50 @@
       <h2 class="section-heading">All Command Groups</h2>
       <table class="cmd-table">
         <thead>
-          <tr><th>Group</th><th>Description</th><th>Subcommands</th></tr>
+          <tr><th>Group</th><th>Description</th><th>Subcommands</th><th>Plan restriction</th></tr>
         </thead>
         <tbody>
           <tr>
             <td><a href="/en/docs/cli-reference/backtest/"><code>forge backtest</code></a></td>
             <td>Backtest execution, scanning, custom experiments</td>
             <td>11</td>
+            <td><span class="plan-badge plan-badge-limit">Free: limited</span></td>
           </tr>
           <tr>
             <td><a href="/en/docs/cli-reference/optimize/"><code>forge optimize</code></a></td>
             <td>Parameter optimization (grid / bayes / wfa)</td>
             <td>9</td>
+            <td><span class="plan-badge plan-badge-limit">Free: 50 trials</span></td>
           </tr>
           <tr>
             <td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td>
             <td>Strategy JSON save / validate / apply</td>
             <td>7</td>
+            <td>—</td>
           </tr>
           <tr>
             <td><a href="/en/docs/cli-reference/data/"><code>forge data</code></a></td>
             <td>Historical data fetch / update</td>
             <td>4</td>
+            <td><span class="plan-badge plan-badge-limit">Free: limited</span></td>
           </tr>
           <tr>
             <td><a href="/en/docs/cli-reference/journal/"><code>forge journal</code></a></td>
             <td>Trading journal and trade analysis</td>
             <td>7</td>
+            <td>—</td>
           </tr>
           <tr>
             <td><a href="/en/docs/cli-reference/live/"><code>forge live</code></a></td>
             <td>Live trading and broker integration</td>
             <td>9</td>
+            <td>—</td>
           </tr>
           <tr>
             <td><a href="/en/docs/cli-reference/other/">Other commands</a></td>
             <td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> and more</td>
             <td>10 groups</td>
+            <td><span class="plan-badge plan-badge-paid">pine: paid only</span></td>
           </tr>
         </tbody>
       </table>

--- a/ja/docs.html
+++ b/ja/docs.html
@@ -108,6 +108,17 @@
       font-family: var(--mono);
     }
     .cmd-card:hover .cmd-card-link { color: var(--accent); }
+
+    /* ── PLAN BADGES ── */
+    .cmd-card-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.5rem; margin-bottom: 0.4rem; }
+    .cmd-card-header .cmd-card-name { margin-bottom: 0; }
+    .plan-badge {
+      display: inline-block; font-family: var(--sans); font-size: 0.65rem; font-weight: 600;
+      padding: 0.15rem 0.45rem; border-radius: 3px; white-space: nowrap; flex-shrink: 0;
+      line-height: 1.4;
+    }
+    .plan-badge-paid  { background: rgba(255,90,90,0.15); color: #ff6b6b; border: 1px solid rgba(255,90,90,0.35); }
+    .plan-badge-limit { background: rgba(255,185,0,0.12); color: #e6a800; border: 1px solid rgba(255,185,0,0.30); }
   </style>
   <script>
     (function() {
@@ -143,10 +154,22 @@
         </a>
       </div>
 
+      <div class="callout" style="margin-bottom: 2rem; border-color: rgba(255,185,0,0.35);">
+        <p style="font-weight:600; margin-bottom:0.5rem;">🔒 プラン制限について</p>
+        <p style="margin-bottom:0.5rem;">
+          <strong>Free プラン</strong>は 2023-12-31 以前のデータのみ評価可能・最適化は 50 試行まで。
+          <code>forge pine generate / preview</code> は<strong>有料プランのみ</strong>利用できます。
+        </p>
+        <a href="/ja/index.html#pricing" class="btn-primary" style="font-size:0.8rem;">プランを比較する →</a>
+      </div>
+
       <h2 class="section-heading">主要コマンド</h2>
       <div class="cmd-card-grid">
         <a class="cmd-card" href="/ja/docs/cli-reference/backtest/#forge-backtest-run">
-          <div class="cmd-card-name">forge backtest run</div>
+          <div class="cmd-card-header">
+            <div class="cmd-card-name">forge backtest run</div>
+            <span class="plan-badge plan-badge-limit">Free: 制限あり</span>
+          </div>
           <div class="cmd-card-desc">単一銘柄に戦略を適用してバックテストを実行する。</div>
           <pre class="cmd-card-usage"><code>forge backtest run SYMBOL --strategy ID</code></pre>
           <div class="cmd-card-options">
@@ -158,7 +181,10 @@
         </a>
 
         <a class="cmd-card" href="/ja/docs/cli-reference/optimize/#forge-optimize-run">
-          <div class="cmd-card-name">forge optimize run</div>
+          <div class="cmd-card-header">
+            <div class="cmd-card-name">forge optimize run</div>
+            <span class="plan-badge plan-badge-limit">Free: 50試行まで</span>
+          </div>
           <div class="cmd-card-desc">Optuna によるパラメータ最適化（TPE）。多目的最適化にも対応。</div>
           <pre class="cmd-card-usage"><code>forge optimize run SYMBOL --strategy ID</code></pre>
           <div class="cmd-card-options">
@@ -170,7 +196,10 @@
         </a>
 
         <a class="cmd-card" href="/ja/docs/cli-reference/optimize/#forge-optimize-walk-forward">
-          <div class="cmd-card-name">forge optimize walk-forward</div>
+          <div class="cmd-card-header">
+            <div class="cmd-card-name">forge optimize walk-forward</div>
+            <span class="plan-badge plan-badge-limit">Free: 制限あり</span>
+          </div>
           <div class="cmd-card-desc">時系列をウィンドウ分割し IS 最適化 → OOS 評価で過学習耐性を測定。</div>
           <pre class="cmd-card-usage"><code>forge optimize walk-forward SYMBOL --strategy ID --windows N</code></pre>
           <div class="cmd-card-options">
@@ -181,7 +210,10 @@
         </a>
 
         <a class="cmd-card" href="/ja/docs/cli-reference/data/#forge-data-fetch">
-          <div class="cmd-card-name">forge data fetch</div>
+          <div class="cmd-card-header">
+            <div class="cmd-card-name">forge data fetch</div>
+            <span class="plan-badge plan-badge-limit">Free: 制限あり</span>
+          </div>
           <div class="cmd-card-desc">OHLCV をプロバイダーから取得し Parquet で保存。</div>
           <pre class="cmd-card-usage"><code>forge data fetch SYMBOL --period 5y --interval 1d</code></pre>
           <div class="cmd-card-options">
@@ -213,43 +245,50 @@
       <h2 class="section-heading">全コマンドカタログ</h2>
       <table class="cmd-table">
         <thead>
-          <tr><th>グループ</th><th>説明</th><th>サブコマンド数</th></tr>
+          <tr><th>グループ</th><th>説明</th><th>サブコマンド数</th><th>プラン制限</th></tr>
         </thead>
         <tbody>
           <tr>
             <td><a href="/ja/docs/cli-reference/backtest/"><code>forge backtest</code></a></td>
             <td>バックテスト実行・スキャン・カスタム実験</td>
             <td>11</td>
+            <td><span class="plan-badge plan-badge-limit">Free: 制限あり</span></td>
           </tr>
           <tr>
             <td><a href="/ja/docs/cli-reference/optimize/"><code>forge optimize</code></a></td>
             <td>パラメータ最適化（grid / bayes / wfa）</td>
             <td>9</td>
+            <td><span class="plan-badge plan-badge-limit">Free: 50試行まで</span></td>
           </tr>
           <tr>
             <td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td>
             <td>戦略 JSON の保存・検証・適用</td>
             <td>7</td>
+            <td>—</td>
           </tr>
           <tr>
             <td><a href="/ja/docs/cli-reference/data/"><code>forge data</code></a></td>
             <td>ヒストリカルデータ取得・更新</td>
             <td>4</td>
+            <td><span class="plan-badge plan-badge-limit">Free: 制限あり</span></td>
           </tr>
           <tr>
             <td><a href="/ja/docs/cli-reference/journal/"><code>forge journal</code></a></td>
             <td>取引ジャーナル・トレード分析</td>
             <td>7</td>
+            <td>—</td>
           </tr>
           <tr>
             <td><a href="/ja/docs/cli-reference/live/"><code>forge live</code></a></td>
             <td>ライブトレーディング・ブローカー連携</td>
             <td>9</td>
+            <td>—</td>
           </tr>
           <tr>
             <td><a href="/ja/docs/cli-reference/other/">その他コマンド</a></td>
             <td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> 他</td>
             <td>10 グループ</td>
+            <td><span class="plan-badge plan-badge-paid">pine: 有料のみ</span></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## Summary

- `ja/docs.html` と `en/docs.html` のコマンド早見表に、Free / Paid プランの制限を事前に可視化するバッジとバナーを追加
- ユーザーがコマンドを実行してから制限に気づく UX を改善

## 変更内容

### 追加要素

| 要素 | 内容 |
|------|------|
| **プラン制限バナー** | コマンドカード直上に黄枠の callout を挿入。Free プランの制限概要（データ日付キャップ・最適化50試行・pine ハードブロック）と料金ページリンクを記載 |
| **コマンドカードバッジ** | `forge backtest run` / `forge optimize *` / `forge data fetch` に黄色バッジ、`forge strategy save` / `forge journal show` はバッジなし |
| **カタログ表「プラン制限」列** | 全コマンドグループ行に制限情報を追加。`その他（pine）` 行には赤バッジで「pine: 有料のみ」を表示 |
| **CSS** | `.plan-badge-limit`（黄）/ `.plan-badge-paid`（赤）の2クラスを `<style>` に追加 |

### 制限の根拠（entitlements.py / freemium-limits.md より）

- `forge data fetch / update` — Free は 2023-12-31 でデータをキャップ
- `forge backtest run` / `forge optimize *` — 評価データも同様にキャップ + optimize は 50 試行まで
- `forge pine generate / preview` — Free プランでは終了コード 1 でハードブロック

## Test plan

- [ ] `ja/docs.html` をブラウザで開き、プラン制限バナー・バッジ・カタログ表が正しく表示されること
- [ ] ライトテーマ切り替え後もバッジが視認しやすいこと
- [ ] `en/docs.html` で英語バッジが同様に表示されること
- [ ] モバイル幅（375px）でテーブルが横スクロールすること