### PR TITLE
revert: MkDocs リンクの ↗ 矢印統一を取り消し

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -225,7 +225,9 @@
     }
     .nav-center a:hover { color: var(--text); }
     .nav-center a.active { color: var(--accent); }
-    .docs-link::after { content: ' ↗'; font-size: 0.6rem; vertical-align: super; opacity: 0.8; }
+    .nav-center a.nav-mkdocs-link { color: var(--accent); }
+    .nav-center a.nav-mkdocs-link::after { content: '↗'; font-size: 0.6rem; vertical-align: super; margin-left: 1px; opacity: 0.8; }
+    .nav-center a.nav-mkdocs-link:hover { color: var(--text); }
 
     .nav-right { display: flex; align-items: center; justify-content: flex-end; gap: 0.5rem; min-width: 0; }
 

--- a/en/install.html
+++ b/en/install.html
@@ -96,7 +96,7 @@
           see the <strong>official documentation</strong>.
         </p>
         <a href="/en/docs/getting-started/" class="btn-primary">
-          Open Documentation ↗
+          Open Documentation →
         </a>
       </div>
 
@@ -136,7 +136,7 @@
           troubleshooting matrix, see the documentation.
         </p>
         <a href="/en/docs/getting-started/" class="btn-primary">
-          Open Documentation ↗
+          Open Documentation →
         </a>
       </div>
 
@@ -145,7 +145,7 @@
 
       <div class="callout" style="margin-bottom: 2rem;">
         <p style="margin-bottom: 0.75rem;">For detailed parameters, output examples, and error codes for all 76 subcommands, see the <strong>official documentation</strong>.</p>
-        <a href="/en/docs/cli-reference/" class="btn-primary">Open CLI Reference ↗</a>
+        <a href="/en/docs/cli-reference/" class="btn-primary">Open CLI Reference →</a>
       </div>
 
       <h3 class="sub-heading">Top Commands</h3>
@@ -209,7 +209,7 @@
 
       <div class="callout" style="margin-top: 2rem;">
         <p style="margin-bottom: 0.75rem;">For complete subcommand listings, options, return values, and sample output for each group, see the CLI Reference in the official docs.</p>
-        <a href="/en/docs/cli-reference/" class="btn-primary">Open CLI Reference ↗</a>
+        <a href="/en/docs/cli-reference/" class="btn-primary">Open CLI Reference →</a>
       </div>
 
       <div class="callout" style="margin-top: 1rem;">
@@ -226,7 +226,7 @@
         
         <a href="index.html">Home</a>
         <a href="install.html">Install</a>
-        <a href="/en/docs/" class="docs-link">Docs</a>
+        <a href="/en/docs/">Docs</a>
         <a href="terms.html">Terms</a>
         <a href="privacy.html">Privacy</a>
         

--- a/en/privacy.html
+++ b/en/privacy.html
@@ -123,7 +123,7 @@
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="lang-en"><div class="footer-links"><a href="index.html">Home</a><a href="install.html">Install</a><a href="/en/docs/" class="docs-link">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a></div></div>
+    <div class="lang-en"><div class="footer-links"><a href="index.html">Home</a><a href="install.html">Install</a><a href="/en/docs/">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a></div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>

--- a/en/terms.html
+++ b/en/terms.html
@@ -141,7 +141,7 @@
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="lang-en"><div class="footer-links"><a href="index.html">Home</a><a href="install.html">Install</a><a href="/en/docs/" class="docs-link">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a></div></div>
+    <div class="lang-en"><div class="footer-links"><a href="index.html">Home</a><a href="install.html">Install</a><a href="/en/docs/">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a></div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>

--- a/en/tutorial-strategy.html
+++ b/en/tutorial-strategy.html
@@ -527,7 +527,7 @@ forge data fetch SPY QQQ --period 5y</code></pre>
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="lang-en"><div class="footer-links"><a href="index.html">Home</a><a href="install.html">Install</a><a href="/en/docs/" class="docs-link">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a></div></div>
+    <div class="lang-en"><div class="footer-links"><a href="index.html">Home</a><a href="install.html">Install</a><a href="/en/docs/">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a></div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>

--- a/homepage-components.jsx
+++ b/homepage-components.jsx
@@ -101,7 +101,7 @@ function FreeStart({ t, lang }) {
             ))}
             {c.outExamplesCta && (
               <a href={`/${lang}/docs/guides/output-examples/`} className="free-start-link free-start-examples-link">
-                {c.outExamplesCta} ↗
+                {c.outExamplesCta} →
               </a>
             )}
           </div>
@@ -519,7 +519,7 @@ function TrustSafety({ t }) {
           ))}
         </div>
         <a className="trust-safety-link" href={c.docsHref}>
-          {c.docsLabel} ↗
+          {c.docsLabel} →
         </a>
       </div>
     </section>

--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -317,7 +317,7 @@ window.COPY = {
           title: 'TradingViewユーザー',
           desc: 'Pine Scriptでアイデアを試作し、AlphaForgeでバックテスト・最適化を本格化。Pine Script再エクスポートまで一気通貫。',
           link: '/ja/docs/usecases/tradingview/',
-          linkLabel: '詳しく見る ↗',
+          linkLabel: '詳しく見る →',
         },
         {
           icon: '🐍',
@@ -325,7 +325,7 @@ window.COPY = {
           title: 'Python開発者',
           desc: 'JSON宣言型の戦略管理、CLIの構造化出力、Optunaベースの最適化。Pythonエコシステムとシームレスに連携。',
           link: '/ja/docs/usecases/python-dev/',
-          linkLabel: '詳しく見る ↗',
+          linkLabel: '詳しく見る →',
         },
         {
           icon: '🔬',
@@ -333,7 +333,7 @@ window.COPY = {
           title: 'クオンツ・研究者',
           desc: 'ウォークフォワード検証・ベイズ最適化・再現性保証。統計的な厳密性を求める研究者向けの定量評価環境。',
           link: '/ja/docs/usecases/quants/',
-          linkLabel: '詳しく見る ↗',
+          linkLabel: '詳しく見る →',
         },
         {
           icon: '🤖',
@@ -341,7 +341,7 @@ window.COPY = {
           title: '自動売買検討者',
           desc: 'バックテスト→最適化→Pine Script生成→TradingViewアラート→Alpha Strike自動発注まで一貫した環境。',
           link: '/ja/docs/usecases/auto-trading/',
-          linkLabel: '詳しく見る ↗',
+          linkLabel: '詳しく見る →',
         },
         {
           icon: '✨',
@@ -349,7 +349,7 @@ window.COPY = {
           title: 'AIエージェント利用者',
           desc: 'Claude Codeなど AIエージェントと組み合わせて戦略探索を自動化。夜間に自律探索を回す非同期ワークフロー。',
           link: '/ja/docs/usecases/ai-agents/',
-          linkLabel: '詳しく見る ↗',
+          linkLabel: '詳しく見る →',
         },
       ],
     },
@@ -698,7 +698,7 @@ window.COPY = {
           title: 'TradingView Users',
           desc: 'Prototype in Pine Script and bring the real backtesting and optimization to AlphaForge. Export Pine Script back when done.',
           link: '/en/docs/usecases/tradingview/',
-          linkLabel: 'Learn more ↗',
+          linkLabel: 'Learn more →',
         },
         {
           icon: '🐍',
@@ -706,7 +706,7 @@ window.COPY = {
           title: 'Python Developers',
           desc: 'JSON-declarative strategy management, structured CLI output, and Optuna-based optimization — seamlessly integrated with the Python ecosystem.',
           link: '/en/docs/usecases/python-dev/',
-          linkLabel: 'Learn more ↗',
+          linkLabel: 'Learn more →',
         },
         {
           icon: '🔬',
@@ -714,7 +714,7 @@ window.COPY = {
           title: 'Quants & Researchers',
           desc: 'Walk-forward validation, Bayesian optimization, and reproducibility guarantees. A quantitative evaluation environment for researchers who demand statistical rigor.',
           link: '/en/docs/usecases/quants/',
-          linkLabel: 'Learn more ↗',
+          linkLabel: 'Learn more →',
         },
         {
           icon: '🤖',
@@ -722,7 +722,7 @@ window.COPY = {
           title: 'Automated Trading',
           desc: 'A complete pipeline: backtest → optimize → generate Pine Script → TradingView alert → Alpha Strike auto-execution.',
           link: '/en/docs/usecases/auto-trading/',
-          linkLabel: 'Learn more ↗',
+          linkLabel: 'Learn more →',
         },
         {
           icon: '✨',
@@ -730,7 +730,7 @@ window.COPY = {
           title: 'AI Agent Users',
           desc: 'Combine with Claude Code or other AI agents to automate strategy exploration. Run autonomous overnight discovery loops without human intervention.',
           link: '/en/docs/usecases/ai-agents/',
-          linkLabel: 'Learn more ↗',
+          linkLabel: 'Learn more →',
         },
       ],
     },

--- a/ja/index.html
+++ b/ja/index.html
@@ -225,7 +225,9 @@
     }
     .nav-center a:hover { color: var(--text); }
     .nav-center a.active { color: var(--accent); }
-    .docs-link::after { content: ' ↗'; font-size: 0.6rem; vertical-align: super; opacity: 0.8; }
+    .nav-center a.nav-mkdocs-link { color: var(--accent); }
+    .nav-center a.nav-mkdocs-link::after { content: '↗'; font-size: 0.6rem; vertical-align: super; margin-left: 1px; opacity: 0.8; }
+    .nav-center a.nav-mkdocs-link:hover { color: var(--text); }
 
     .nav-right { display: flex; align-items: center; justify-content: flex-end; gap: 0.5rem; min-width: 0; }
 

--- a/ja/install.html
+++ b/ja/install.html
@@ -96,7 +96,7 @@
           <strong>公式ドキュメント</strong>を参照してください。
         </p>
         <a href="/ja/docs/getting-started/" class="btn-primary">
-          ドキュメントを開く ↗
+          ドキュメントを開く →
         </a>
       </div>
 
@@ -136,7 +136,7 @@
           ドキュメントを参照してください。
         </p>
         <a href="/ja/docs/getting-started/" class="btn-primary">
-          ドキュメントを開く ↗
+          ドキュメントを開く →
         </a>
       </div>
 
@@ -145,7 +145,7 @@
 
       <div class="callout" style="margin-bottom: 2rem;">
         <p style="margin-bottom: 0.75rem;">全 76 サブコマンドの詳細パラメータ、出力例、エラーコードは<strong>公式ドキュメント</strong>を参照してください。</p>
-        <a href="/ja/docs/cli-reference/" class="btn-primary">CLI リファレンスを開く ↗</a>
+        <a href="/ja/docs/cli-reference/" class="btn-primary">CLI リファレンスを開く →</a>
       </div>
 
       <h3 class="sub-heading">主要コマンド</h3>
@@ -209,7 +209,7 @@
 
       <div class="callout" style="margin-top: 2rem;">
         <p style="margin-bottom: 0.75rem;">各グループの完全なサブコマンドリスト、オプション一覧、戻り値、サンプル出力はドキュメントの CLI リファレンスを参照してください。</p>
-        <a href="/ja/docs/cli-reference/" class="btn-primary">CLI リファレンスを開く ↗</a>
+        <a href="/ja/docs/cli-reference/" class="btn-primary">CLI リファレンスを開く →</a>
       </div>
 
       <div class="callout" style="margin-top: 1rem;">
@@ -226,7 +226,7 @@
         
         <a href="index.html">ホーム</a>
         <a href="install.html">インストール</a>
-        <a href="/ja/docs/" class="docs-link">ドキュメント</a>
+        <a href="/ja/docs/">ドキュメント</a>
         <a href="terms.html">利用規約</a>
         <a href="privacy.html">プライバシー</a>
         

--- a/ja/privacy.html
+++ b/ja/privacy.html
@@ -123,7 +123,7 @@
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="lang-ja"><div class="footer-links"><a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="/ja/docs/" class="docs-link">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a></div></div>
+    <div class="lang-ja"><div class="footer-links"><a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="/ja/docs/">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a></div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>

--- a/ja/terms.html
+++ b/ja/terms.html
@@ -142,7 +142,7 @@
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="lang-ja"><div class="footer-links"><a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="/ja/docs/" class="docs-link">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a></div></div>
+    <div class="lang-ja"><div class="footer-links"><a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="/ja/docs/">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a></div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>

--- a/ja/tutorial-strategy.html
+++ b/ja/tutorial-strategy.html
@@ -550,7 +550,7 @@ Avg Sharpe: 1.10  |  Avg CAGR: 13.9%  |  WF Efficiency: 89%</code></pre>
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="lang-ja"><div class="footer-links"><a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="/ja/docs/" class="docs-link">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a></div></div>
+    <div class="lang-ja"><div class="footer-links"><a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="/ja/docs/">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a></div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>

--- a/page.css
+++ b/page.css
@@ -89,7 +89,9 @@ body {
 }
 .nav-center a:hover { color: var(--text); text-decoration: none; }
 .nav-center a.active { color: var(--accent); }
-.docs-link::after { content: ' ↗'; font-size: 0.6rem; vertical-align: super; opacity: 0.8; }
+.nav-center a.nav-mkdocs-link { color: var(--accent); }
+.nav-center a.nav-mkdocs-link::after { content: '↗'; font-size: 0.6rem; vertical-align: super; margin-left: 1px; opacity: 0.8; }
+.nav-center a.nav-mkdocs-link:hover { color: var(--text); }
 
 .nav-right { display: flex; align-items: center; justify-content: flex-end; gap: 0.5rem; min-width: 0; }
 

--- a/site-header.jsx
+++ b/site-header.jsx
@@ -68,12 +68,12 @@ function SiteHeader({ dark, setDark, lang = 'ja', setLang, active = '', showLang
       <ul className="nav-center">
         {HEADER_LINKS.map(link => (
           <li key={link.key}>
-            <a href={link.href} className={[active === link.key ? 'active' : '', link.key === 'mkdocs' ? 'docs-link' : ''].filter(Boolean).join(' ')}>{c[link.key]}</a>
+            <a href={link.href} className={[active === link.key ? 'active' : '', link.key === 'mkdocs' ? 'nav-mkdocs-link' : ''].filter(Boolean).join(' ')}>{c[link.key]}</a>
           </li>
         ))}
       </ul>
       <div className="nav-right">
-        <a className="nav-page-link docs-link" href="docs/">{c.mkdocs}</a>
+        <a className="nav-page-link" href="docs/">{c.mkdocs}</a>
         {showLanguage && (
           <button className="lang-btn" onClick={toggleLang}>
             {lang === 'ja' ? 'EN' : 'JA'}

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -145,7 +145,9 @@
     }
     .nav-center a:hover { color: var(--text); }
     .nav-center a.active { color: var(--accent); }
-    .docs-link::after { content: ' ↗'; font-size: 0.6rem; vertical-align: super; opacity: 0.8; }
+    .nav-center a.nav-mkdocs-link { color: var(--accent); }
+    .nav-center a.nav-mkdocs-link::after { content: '↗'; font-size: 0.6rem; vertical-align: super; margin-left: 1px; opacity: 0.8; }
+    .nav-center a.nav-mkdocs-link:hover { color: var(--text); }
 
     .nav-right { display: flex; align-items: center; justify-content: flex-end; gap: 0.5rem; min-width: 0; }
 

--- a/templates/install.html.j2
+++ b/templates/install.html.j2
@@ -44,7 +44,7 @@
           <strong>公式ドキュメント</strong>を参照してください。
         </p>
         <a href="/ja/docs/getting-started/" class="btn-primary">
-          ドキュメントを開く ↗
+          ドキュメントを開く →
         </a>
       </div>
 
@@ -84,7 +84,7 @@
           ドキュメントを参照してください。
         </p>
         <a href="/ja/docs/getting-started/" class="btn-primary">
-          ドキュメントを開く ↗
+          ドキュメントを開く →
         </a>
       </div>
 
@@ -93,7 +93,7 @@
 
       <div class="callout" style="margin-bottom: 2rem;">
         <p style="margin-bottom: 0.75rem;">全 76 サブコマンドの詳細パラメータ、出力例、エラーコードは<strong>公式ドキュメント</strong>を参照してください。</p>
-        <a href="/ja/docs/cli-reference/" class="btn-primary">CLI リファレンスを開く ↗</a>
+        <a href="/ja/docs/cli-reference/" class="btn-primary">CLI リファレンスを開く →</a>
       </div>
 
       <h3 class="sub-heading">主要コマンド</h3>
@@ -157,7 +157,7 @@
 
       <div class="callout" style="margin-top: 2rem;">
         <p style="margin-bottom: 0.75rem;">各グループの完全なサブコマンドリスト、オプション一覧、戻り値、サンプル出力はドキュメントの CLI リファレンスを参照してください。</p>
-        <a href="/ja/docs/cli-reference/" class="btn-primary">CLI リファレンスを開く ↗</a>
+        <a href="/ja/docs/cli-reference/" class="btn-primary">CLI リファレンスを開く →</a>
       </div>
 
       <div class="callout" style="margin-top: 1rem;">
@@ -174,7 +174,7 @@
           see the <strong>official documentation</strong>.
         </p>
         <a href="/en/docs/getting-started/" class="btn-primary">
-          Open Documentation ↗
+          Open Documentation →
         </a>
       </div>
 
@@ -214,7 +214,7 @@
           troubleshooting matrix, see the documentation.
         </p>
         <a href="/en/docs/getting-started/" class="btn-primary">
-          Open Documentation ↗
+          Open Documentation →
         </a>
       </div>
 
@@ -223,7 +223,7 @@
 
       <div class="callout" style="margin-bottom: 2rem;">
         <p style="margin-bottom: 0.75rem;">For detailed parameters, output examples, and error codes for all 76 subcommands, see the <strong>official documentation</strong>.</p>
-        <a href="/en/docs/cli-reference/" class="btn-primary">Open CLI Reference ↗</a>
+        <a href="/en/docs/cli-reference/" class="btn-primary">Open CLI Reference →</a>
       </div>
 
       <h3 class="sub-heading">Top Commands</h3>
@@ -287,7 +287,7 @@
 
       <div class="callout" style="margin-top: 2rem;">
         <p style="margin-bottom: 0.75rem;">For complete subcommand listings, options, return values, and sample output for each group, see the CLI Reference in the official docs.</p>
-        <a href="/en/docs/cli-reference/" class="btn-primary">Open CLI Reference ↗</a>
+        <a href="/en/docs/cli-reference/" class="btn-primary">Open CLI Reference →</a>
       </div>
 
       <div class="callout" style="margin-top: 1rem;">
@@ -304,13 +304,13 @@
         {% if lang == 'ja' %}
         <a href="index.html">ホーム</a>
         <a href="install.html">インストール</a>
-        <a href="/ja/docs/" class="docs-link">ドキュメント</a>
+        <a href="/ja/docs/">ドキュメント</a>
         <a href="terms.html">利用規約</a>
         <a href="privacy.html">プライバシー</a>
         {% else %}
         <a href="index.html">Home</a>
         <a href="install.html">Install</a>
-        <a href="/en/docs/" class="docs-link">Docs</a>
+        <a href="/en/docs/">Docs</a>
         <a href="terms.html">Terms</a>
         <a href="privacy.html">Privacy</a>
         {% endif %}

--- a/templates/privacy.html.j2
+++ b/templates/privacy.html.j2
@@ -115,7 +115,7 @@
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="lang-{{ lang }}"><div class="footer-links">{% if lang == 'ja' %}<a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="/ja/docs/" class="docs-link">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a>{% else %}<a href="index.html">Home</a><a href="install.html">Install</a><a href="/en/docs/" class="docs-link">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a>{% endif %}</div></div>
+    <div class="lang-{{ lang }}"><div class="footer-links">{% if lang == 'ja' %}<a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="/ja/docs/">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a>{% else %}<a href="index.html">Home</a><a href="install.html">Install</a><a href="/en/docs/">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a>{% endif %}</div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>

--- a/templates/terms.html.j2
+++ b/templates/terms.html.j2
@@ -152,7 +152,7 @@
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="lang-{{ lang }}"><div class="footer-links">{% if lang == 'ja' %}<a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="/ja/docs/" class="docs-link">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a>{% else %}<a href="index.html">Home</a><a href="install.html">Install</a><a href="/en/docs/" class="docs-link">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a>{% endif %}</div></div>
+    <div class="lang-{{ lang }}"><div class="footer-links">{% if lang == 'ja' %}<a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="/ja/docs/">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a>{% else %}<a href="index.html">Home</a><a href="install.html">Install</a><a href="/en/docs/">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a>{% endif %}</div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>

--- a/templates/tutorial-strategy.html.j2
+++ b/templates/tutorial-strategy.html.j2
@@ -871,7 +871,7 @@ forge data fetch SPY QQQ --period 5y</code></pre>
 
   <footer>
     <div class="footer-logo">alforge<span class="dot">.</span>labs</div>
-    <div class="lang-{{ lang }}"><div class="footer-links">{% if lang == 'ja' %}<a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="/ja/docs/" class="docs-link">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a>{% else %}<a href="index.html">Home</a><a href="install.html">Install</a><a href="/en/docs/" class="docs-link">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a>{% endif %}</div></div>
+    <div class="lang-{{ lang }}"><div class="footer-links">{% if lang == 'ja' %}<a href="index.html">ホーム</a><a href="install.html">インストール</a><a href="/ja/docs/">ドキュメント</a><a href="terms.html">利用規約</a><a href="privacy.html">プライバシー</a>{% else %}<a href="index.html">Home</a><a href="install.html">Install</a><a href="/en/docs/">Docs</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a>{% endif %}</div></div>
   </footer>
 
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary

- #126（MkDocs リンクへの ↗ 矢印統一）を revert
- 見た目がうるさくなったとのフィードバックを受け元の状態に戻す

## 変更内容

`git revert 256135f` による自動 revert。影響ファイルは以下のとおり。

- `page.css` / `templates/index.html.j2` — `.docs-link::after` ルールを削除
- `site-header.jsx` — `docs-link` → `nav-mkdocs-link` に戻し、nav-page-link からも削除
- `homepage-copy.jsx` — `linkLabel` の `↗` を `→` に戻す
- `homepage-components.jsx` — `↗` を `→` に戻す（2箇所）
- `templates/install.html.j2` — CTA ボタンの `↗` を `→` に戻す・フッターの `docs-link` クラスを削除
- `templates/terms.html.j2` / `privacy.html.j2` / `tutorial-strategy.html.j2` — フッターの `docs-link` クラスを削除