### PR TITLE
fix: ナビの「ドキュメント」リンクの常時アクセントカラー強調を除去

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -225,9 +225,7 @@
     }
     .nav-center a:hover { color: var(--text); }
     .nav-center a.active { color: var(--accent); }
-    .nav-center a.nav-mkdocs-link { color: var(--accent); }
     .nav-center a.nav-mkdocs-link::after { content: '↗'; font-size: 0.6rem; vertical-align: super; margin-left: 1px; opacity: 0.8; }
-    .nav-center a.nav-mkdocs-link:hover { color: var(--text); }
 
     .nav-right { display: flex; align-items: center; justify-content: flex-end; gap: 0.5rem; min-width: 0; }
 

--- a/ja/index.html
+++ b/ja/index.html
@@ -225,9 +225,7 @@
     }
     .nav-center a:hover { color: var(--text); }
     .nav-center a.active { color: var(--accent); }
-    .nav-center a.nav-mkdocs-link { color: var(--accent); }
     .nav-center a.nav-mkdocs-link::after { content: '↗'; font-size: 0.6rem; vertical-align: super; margin-left: 1px; opacity: 0.8; }
-    .nav-center a.nav-mkdocs-link:hover { color: var(--text); }
 
     .nav-right { display: flex; align-items: center; justify-content: flex-end; gap: 0.5rem; min-width: 0; }
 

--- a/page.css
+++ b/page.css
@@ -89,9 +89,7 @@ body {
 }
 .nav-center a:hover { color: var(--text); text-decoration: none; }
 .nav-center a.active { color: var(--accent); }
-.nav-center a.nav-mkdocs-link { color: var(--accent); }
 .nav-center a.nav-mkdocs-link::after { content: '↗'; font-size: 0.6rem; vertical-align: super; margin-left: 1px; opacity: 0.8; }
-.nav-center a.nav-mkdocs-link:hover { color: var(--text); }
 
 .nav-right { display: flex; align-items: center; justify-content: flex-end; gap: 0.5rem; min-width: 0; }
 

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -145,9 +145,7 @@
     }
     .nav-center a:hover { color: var(--text); }
     .nav-center a.active { color: var(--accent); }
-    .nav-center a.nav-mkdocs-link { color: var(--accent); }
     .nav-center a.nav-mkdocs-link::after { content: '↗'; font-size: 0.6rem; vertical-align: super; margin-left: 1px; opacity: 0.8; }
-    .nav-center a.nav-mkdocs-link:hover { color: var(--text); }
 
     .nav-right { display: flex; align-items: center; justify-content: flex-end; gap: 0.5rem; min-width: 0; }
 


### PR DESCRIPTION
## Summary

- ナビヘッダーの「ドキュメント」リンクに常時かかっていたアクセントカラーを除去
- チュートリアル・インストールページ閲覧時に「ドキュメント」がアクティブページに見えて紛らわしい問題を修正
- `↗` インジケーターは維持し、他のナビリンクと同じ通常色（`var(--text2)`）で表示

## 変更内容

- `page.css`: `.nav-mkdocs-link { color: var(--accent); }` と `:hover { color: var(--text); }` を削除
- `templates/index.html.j2`: 同上（インライン CSS）

## Test plan

- [ ] LP・インストール・チュートリアル各ページで「ドキュメント」が他のナビリンクと同じ色で表示されること
- [ ] 「ドキュメント」リンクに `↗` が引き続き表示されること
- [ ] MkDocs ページではアクティブリンクが正しくアクセントカラーで表示されること