### PR TITLE
chore: .gitignore に node_modules などの除外設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
 .DS_Store
+
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-error.log*
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+
+# IDE
+.vscode/
+.idea/


### PR DESCRIPTION
## Summary
- `node_modules/` の記載がなく、`npm install` 時に誤ってトラッキングされるリスクがあった
- Node.js・Python・IDE の除外パターンを追加

## Test plan
- [ ] `node_modules/` が `git status` に表示されないことを確認