### PR TITLE
fix: _config.yml から *.jsx の除外設定を削除（JSX 404 修正）

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 exclude:
   - docs/superpowers/
   - "*.py"
-  - "*.jsx"
   - node_modules/
   - .superpowers/


### PR DESCRIPTION
## 問題

`_config.yml` の `exclude` に `"*.jsx"` が含まれていたため、Jekyll が `homepage-copy.jsx` / `homepage-components.jsx` / `homepage-app.jsx` / `site-header.jsx` をデプロイ時に除外していた。その結果、`https://alforgelabs.com/ja/` でこれらのファイルが 404 になり、ランディングページが正常に表示されなかった。

## 修正

`_config.yml` の `exclude` リストから `"*.jsx"` を削除。

## Test plan

- [ ] `https://alforgelabs.com/homepage-copy.jsx` が 200 で返ることを確認
- [ ] `https://alforgelabs.com/ja/` でコンソールエラーが出ないことを確認