### PR TITLE
fix: Search Console 警告対応（docs.html を sitemap から除外＋index ページのクリーン URL 統一）

### DIFF
--- a/build.py
+++ b/build.py
@@ -18,6 +18,11 @@ PAGES = [
     "terms",
 ]
 
+# sitemap.xml から除外するページ（リダイレクト専用ページなど、独立した正規ページではないもの）。
+# docs.html は install.html#commands への単純リダイレクトのため、sitemap に登録すると
+# Google が「代替ページ（適切な canonical タグあり）」と判定してしまう。
+SITEMAP_EXCLUDED_PAGES = {"docs"}
+
 PAGE_FILE = {p: ("index.html" if p == "index" else f"{p}.html") for p in PAGES}
 
 CHANGEFREQ = {
@@ -147,6 +152,8 @@ def generate_sitemap(base_url: str, site: dict) -> None:
     lastmod_line = f"    <lastmod>{modified}</lastmod>\n" if modified else ""
     entries: list[str] = []
     for page in PAGES:
+        if page in SITEMAP_EXCLUDED_PAGES:
+            continue
         page_file = PAGE_FILE[page]
         freq, priority = CHANGEFREQ[page]
         ja_url = f"{base_url}/ja/{page_file}"

--- a/build.py
+++ b/build.py
@@ -25,6 +25,17 @@ SITEMAP_EXCLUDED_PAGES = {"docs"}
 
 PAGE_FILE = {p: ("index.html" if p == "index" else f"{p}.html") for p in PAGES}
 
+
+def page_url_path(page: str) -> str:
+    """SEO 用 URL パス。
+
+    index ページは末尾スラッシュのクリーン URL（``/{lang}/``）として扱い、
+    それ以外は明示的な拡張子付き（``/{lang}/{file}.html``）とする。
+    canonical / hreflang / sitemap でこの関数を共通利用することで、
+    ``/{lang}/index.html`` と ``/{lang}/`` のような表記揺れを排除する。
+    """
+    return "" if page == "index" else PAGE_FILE[page]
+
 CHANGEFREQ = {
     "index": ("weekly", 1.0),
     "docs": ("weekly", 0.9),
@@ -98,15 +109,15 @@ def build_json_ld(json_ld_type: str, base: str, lang: str, page: str, site_meta:
 
 def make_ctx(site: dict, page: str, lang: str, data: dict) -> dict:
     base = site["base_url"]
-    page_file = PAGE_FILE[page]
+    url_path = page_url_path(page)
     json_ld_type = data.get("json_ld_type", "breadcrumb")
     return {
         "lang": lang,
         "og_locale": "ja_JP" if lang == "ja" else "en_US",
-        "canonical_url": f"{base}/{lang}/{page_file}",
-        "hreflang_ja": f"{base}/ja/{page_file}",
-        "hreflang_en": f"{base}/en/{page_file}",
-        "hreflang_x_default": f"{base}/en/{page_file}",
+        "canonical_url": f"{base}/{lang}/{url_path}",
+        "hreflang_ja": f"{base}/ja/{url_path}",
+        "hreflang_en": f"{base}/en/{url_path}",
+        "hreflang_x_default": f"{base}/en/{url_path}",
         "og_image": site["og_image"],
         "twitter_site": site["twitter_site"],
         "robots": site.get("robots", "index, follow"),
@@ -154,10 +165,10 @@ def generate_sitemap(base_url: str, site: dict) -> None:
     for page in PAGES:
         if page in SITEMAP_EXCLUDED_PAGES:
             continue
-        page_file = PAGE_FILE[page]
+        url_path = page_url_path(page)
         freq, priority = CHANGEFREQ[page]
-        ja_url = f"{base_url}/ja/{page_file}"
-        en_url = f"{base_url}/en/{page_file}"
+        ja_url = f"{base_url}/ja/{url_path}"
+        en_url = f"{base_url}/en/{url_path}"
         for loc, alt_ja, alt_en in [(ja_url, ja_url, en_url), (en_url, ja_url, en_url)]:
             entries.append(
                 f"  <url>\n"

--- a/en/docs.html
+++ b/en/docs.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="robots" content="noindex, follow" />
   <meta http-equiv="refresh" content="0;url=install.html#commands" />
   <link rel="canonical" href="https://alforgelabs.com/en/install.html#commands" />
   <script>window.location.replace('install.html#commands');</script>

--- a/en/index.html
+++ b/en/index.html
@@ -7,12 +7,12 @@
   <meta name="description" content="High-performance time-series simulation CLI for software engineers. Backtest, Bayesian optimization, and walk-forward validation in one tool. Backtrader & vectorbt alternative." />
   <meta name="keywords" content="backtesting, algorithmic trading, time series simulation, backtrader alternative, vectorbt alternative, walk-forward validation, Bayesian optimization, CLI, Python" />
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
-  <link rel="canonical" href="https://alforgelabs.com/en/index.html" />
-  <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/index.html" />
-  <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/index.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/index.html" />
+  <link rel="canonical" href="https://alforgelabs.com/en/" />
+  <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/" />
+  <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/" />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://alforgelabs.com/en/index.html" />
+  <meta property="og:url" content="https://alforgelabs.com/en/" />
   <meta property="og:title" content="Alforge Labs — Backtesting CLI Framework" />
   <meta property="og:description" content="From noise to signal. Backtest, optimize, and validate algorithmic trading strategies with a local CLI." />
   <meta property="og:image" content="https://alforgelabs.com/assets/og-image.png" />

--- a/ja/docs.html
+++ b/ja/docs.html
@@ -2,6 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
+  <meta name="robots" content="noindex, follow" />
   <meta http-equiv="refresh" content="0;url=install.html#commands" />
   <link rel="canonical" href="https://alforgelabs.com/ja/install.html#commands" />
   <script>window.location.replace('install.html#commands');</script>

--- a/ja/index.html
+++ b/ja/index.html
@@ -7,12 +7,12 @@
   <meta name="description" content="ソフトウェアエンジニア向けの高速時系列シミュレーション CLI。バックテスト・ベイズ最適化・ウォークフォワード検証を一元管理。Backtrader・vectorbt の代替。" />
   <meta name="keywords" content="バックテスト, アルゴリズム取引, 時系列シミュレーション, backtesting, CLI, Backtrader代替, vectorbt代替, ウォークフォワード検証, ベイズ最適化" />
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
-  <link rel="canonical" href="https://alforgelabs.com/ja/index.html" />
-  <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/index.html" />
-  <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/index.html" />
-  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/index.html" />
+  <link rel="canonical" href="https://alforgelabs.com/ja/" />
+  <link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/" />
+  <link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/" />
+  <link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/" />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://alforgelabs.com/ja/index.html" />
+  <meta property="og:url" content="https://alforgelabs.com/ja/" />
   <meta property="og:title" content="Alforge Labs — バックテスト CLI フレームワーク" />
   <meta property="og:description" content="ノイズから、シグナルへ。高速時系列シミュレーション CLI でアルゴ戦略を検証・最適化。" />
   <meta property="og:image" content="https://alforgelabs.com/assets/og-image.png" />

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -38,24 +38,6 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://alforgelabs.com/ja/docs.html</loc>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/docs.html"/>
-    <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/docs.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/docs.html"/>
-    <lastmod>2026-05-01</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://alforgelabs.com/en/docs.html</loc>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/docs.html"/>
-    <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/docs.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/docs.html"/>
-    <lastmod>2026-05-01</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://alforgelabs.com/ja/tutorial-strategy.html</loc>
     <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/tutorial-strategy.html"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/tutorial-strategy.html"/>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,19 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>https://alforgelabs.com/ja/index.html</loc>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/index.html"/>
-    <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/index.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/index.html"/>
+    <loc>https://alforgelabs.com/ja/</loc>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/"/>
     <lastmod>2026-05-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://alforgelabs.com/en/index.html</loc>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/index.html"/>
-    <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/index.html"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/index.html"/>
+    <loc>https://alforgelabs.com/en/</loc>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://alforgelabs.com/ja/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://alforgelabs.com/en/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://alforgelabs.com/en/"/>
     <lastmod>2026-05-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>

--- a/templates/docs.html.j2
+++ b/templates/docs.html.j2
@@ -2,6 +2,7 @@
 <html lang="{{ lang }}">
 <head>
   <meta charset="UTF-8" />
+  <meta name="robots" content="noindex, follow" />
   <meta http-equiv="refresh" content="0;url=install.html#commands" />
   <link rel="canonical" href="https://alforgelabs.com/{{ lang }}/install.html#commands" />
   <script>window.location.replace('install.html#commands');</script>


### PR DESCRIPTION
## 概要

Google Search Console から通知された **「代替ページ（適切な canonical タグあり）」** 警告と、関連して見つかった **index ページの URL 表記揺れ** を 2 つのコミットでまとめて修正します。

## 修正1: docs.html を sitemap から除外し noindex を付与

### 原因

`docs.html` は `install.html#commands` への単純なリダイレクトページで、canonical も `install.html#commands` を指しています。しかし `sitemap.xml` には独立した正規ページとして登録されていたため、シグナルが矛盾し、Google が canonical を尊重して docs.html をインデックスから外し警告を発していました。

| ファイル | 旧状態 | 問題 |
|---------|--------|------|
| `ja/docs.html` / `en/docs.html` | canonical は `install.html#commands` を指す（リダイレクト） | sitemap には独立 URL として登録 → 矛盾 |
| `sitemap.xml` | docs.html を独立ページとして登録 | canonical と齟齬 |

### 変更内容

- `build.py` に `SITEMAP_EXCLUDED_PAGES = {"docs"}` を追加し、sitemap 生成時に docs.html を除外。
- `templates/docs.html.j2` に `<meta name=\"robots\" content=\"noindex, follow\">` を追加して、リダイレクト用ページであることを明示。

リダイレクト機能自体は維持されるため、外部からの `docs.html` リンクは引き続き正常に `install.html#commands` へ遷移します。

## 修正2: index ページの canonical/hreflang/sitemap をクリーン URL に統一

### 原因

- ルート `/index.html` の canonical は `/ja/` （クリーン URL）
- `ja/index.html` / `en/index.html` の canonical は `/ja/index.html` / `/en/index.html`（拡張子明示）
- `sitemap.xml` でも `/{lang}/index.html` を使用

GitHub Pages 上では `/ja/` と `/ja/index.html` は同一ページですが、Google からは 2 つの URL として認識される可能性があり、SEO 上の表記揺れになっていました。Search Console の重複警告の遠因にもなり得るため、**index ページのみ** クリーン URL（末尾スラッシュ）に統一します。

### 変更内容

- `build.py` に `page_url_path()` ヘルパーを追加し、index ページは `\"\"`（= `/{lang}/`）、その他は `\"{file}.html\"` を返すよう一元化。
- `make_ctx()` の `canonical_url` / `hreflang_*` / `x-default` をヘルパー経由に統一。
- `generate_sitemap()` も同じヘルパーを使って index ページの `<loc>` と alternate を `/{lang}/` に揃える。
- `install.html` 等の拡張子付きページは挙動・出力ともに変更なし。

### 修正後の URL 整合性

| ファイル | canonical | hreflang ja | hreflang en |
|---------|-----------|-------------|-------------|
| ルート `/index.html` | `/ja/` | `/ja/` | `/en/` |
| `ja/index.html` | `/ja/` | `/ja/` | `/en/` |
| `en/index.html` | `/en/` | `/ja/` | `/en/` |
| `ja/install.html` | `/ja/install.html` | `/ja/install.html` | `/en/install.html` |

## テスト計画

- [x] `uv run python build.py` が成功
- [x] sitemap.xml から docs.html が消えていること
- [x] `ja/docs.html` / `en/docs.html` に `noindex, follow` が付与されていること
- [x] リダイレクト動作（meta refresh + JS）に変更がないこと
- [x] `ja/index.html` / `en/index.html` の canonical が `/{lang}/` に統一されていること
- [x] sitemap.xml の index エントリが `/{lang}/` になっていること
- [x] `install.html` / `privacy.html` / `terms.html` / `tutorial-strategy.html` の出力に変更がないこと
- [ ] マージ後に GitHub Pages へデプロイされ、Search Console で `https://alforgelabs.com/sitemap.xml` を再送信
- [ ] 数日〜数週間後に Search Console の警告メッセージが解消することを確認