### PR TITLE
docs: Whop Storefront URL を確定値に更新（alpha-forge #533）

### DIFF
--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -84,7 +84,7 @@ window.COPY = {
             '将来バージョンのアップデート込み',
             '1台のマシンでアクティベート',
           ],
-          url: 'https://whop.com/alforge-labs'
+          url: 'https://whop.com/alforge-labs/alphaforge/'
         },
         {
           name: 'Annual',
@@ -102,7 +102,7 @@ window.COPY = {
             '将来バージョンのアップデート込み',
             '1台のマシンでアクティベート',
           ],
-          url: 'https://whop.com/alforge-labs'
+          url: 'https://whop.com/alforge-labs/alphaforge/'
         },
         {
           name: 'Monthly',
@@ -120,7 +120,7 @@ window.COPY = {
             '将来バージョンのアップデート込み',
             '1台のマシンでアクティベート',
           ],
-          url: 'https://whop.com/alforge-labs'
+          url: 'https://whop.com/alforge-labs/alphaforge/'
         },
       ],
       buyNow: '今すぐ購入',
@@ -501,7 +501,7 @@ window.COPY = {
             'Future version updates included',
             'Activate on 1 machine',
           ],
-          url: 'https://whop.com/alforge-labs'
+          url: 'https://whop.com/alforge-labs/alphaforge/'
         },
         {
           name: 'Annual',
@@ -519,7 +519,7 @@ window.COPY = {
             'Future version updates included',
             'Activate on 1 machine',
           ],
-          url: 'https://whop.com/alforge-labs'
+          url: 'https://whop.com/alforge-labs/alphaforge/'
         },
         {
           name: 'Monthly',
@@ -537,7 +537,7 @@ window.COPY = {
             'Future version updates included',
             'Activate on 1 machine',
           ],
-          url: 'https://whop.com/alforge-labs'
+          url: 'https://whop.com/alforge-labs/alphaforge/'
         },
       ],
       buyNow: 'Get Access',


### PR DESCRIPTION
## Summary

alpha-forge 側で Whop ダッシュボードの Storefront URL が確定したため、`homepage-copy.jsx` の `pricing.plans[].url` を更新します。

## 変更内容

`homepage-copy.jsx` の有料 Plan（Lifetime / Annual / Monthly × ja・en の計 6 箇所）の URL を更新:

- **旧**: `https://whop.com/alforge-labs`
- **新**: `https://whop.com/alforge-labs/alphaforge/`

| 行 | セクション | 変更後 |
|----|-----------|--------|
| 87 | ja Lifetime | `https://whop.com/alforge-labs/alphaforge/` |
| 105 | ja Annual | `https://whop.com/alforge-labs/alphaforge/` |
| 123 | ja Monthly | `https://whop.com/alforge-labs/alphaforge/` |
| 504 | en Lifetime | `https://whop.com/alforge-labs/alphaforge/` |
| 522 | en Annual | `https://whop.com/alforge-labs/alphaforge/` |
| 540 | en Monthly | `https://whop.com/alforge-labs/alphaforge/` |

## Free Plan について

Free Plan の CTA は現状 `$0 で登録 → インストール手順へ` でインストールページに遷移する構成になっており、Whop Free Product URL（`https://whop.com/alforge-labs/alphaforge-free/`）には紐づいていません。Free Storefront を CTA に紐づけるかは別 PR で検討します。

## Related

- alpha-forge Issue #533（Whop Storefront 整備）
- alpha-forge PR #558（同 URL を内部ドキュメントに反映）

🤖 Generated with [Claude Code](https://claude.com/claude-code)