### PR TITLE
feat: ランディングページの購入ボタンを Whop 購入ページに配線（alpha-forge #533）

### DIFF
--- a/homepage-components.jsx
+++ b/homepage-components.jsx
@@ -313,11 +313,20 @@ function FreeBanner({ plan, comingSummer, lang }) {
       </div>
       <div className="free-banner-cta">
         <a
-          href={`/${lang}/install.html`}
-          className="btn-secondary"
+          href={plan.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn-primary"
           style={{ justifyContent: 'center' }}
         >
-          {plan.ctaHint || plan.ctaLabel}
+          {plan.ctaLabel}
+        </a>
+        <a
+          href={`/${lang}/install.html`}
+          className="free-banner-install-link"
+          style={{ fontSize: '0.85em', textAlign: 'center', marginTop: '0.4rem', color: 'var(--text2)' }}
+        >
+          {plan.ctaHint}
         </a>
         <div className="free-banner-status">{comingSummer}</div>
       </div>
@@ -393,7 +402,9 @@ function Pricing({ t, lang }) {
                 ))}
               </ul>
               <a
-                href="#roadmap"
+                href={plan.url}
+                target="_blank"
+                rel="noopener noreferrer"
                 className={plan.featured ? 'btn-primary' : 'btn-secondary'}
                 style={{ justifyContent: 'center', marginTop: 'auto', flexDirection: 'column', gap: '2px' }}
               >

--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -66,6 +66,7 @@ window.COPY = {
         ctaLabel: '$0 で登録',
         ctaHint: 'インストール手順へ',
         comingSummer: '今夏提供開始予定',
+        url: 'https://whop.com/alforge-labs/alphaforge-free/',
       },
       plans: [
         {
@@ -483,6 +484,7 @@ window.COPY = {
         ctaLabel: 'Register for $0',
         ctaHint: 'View install steps',
         comingSummer: 'Coming This Summer',
+        url: 'https://whop.com/alforge-labs/alphaforge-free/',
       },
       plans: [
         {


### PR DESCRIPTION
## Summary

PR #211 で \`homepage-copy.jsx\` の \`pricing.plans[]\` に Whop URL を設定済みだったが、\`homepage-components.jsx\` 側では \`href=\"#roadmap\"\` がハードコードされており URL は未配線だった。Whop ストアフロントが Public 公開・購入可能な状態のため、購入ボタンを実際の Whop URL に飛ばすよう配線する。

## 採用方針（事前確認済み）

| 項目 | 方針 |
|------|------|
| Paid Plan の disabled 表示（取り消し線＋"今夏販売開始予定"） | **保持**（リンクのみ機能化）|
| Free Plan の CTA | **両方**（メイン: Whop Free 登録 / サブ: インストール手順）|
| Whop URL のリンク挙動 | **別タブ**（\`target=\"_blank\"\` ＋ \`rel=\"noopener noreferrer\"\`）|

## 変更内容

### \`homepage-copy.jsx\`

\`pricing.freePlan.url\` を新設（ja・en × 1 箇所）:
\`\`\`js
url: 'https://whop.com/alforge-labs/alphaforge-free/',
\`\`\`

### \`homepage-components.jsx\`

- **Pricing コンポーネント（行 395）**: \`href=\"#roadmap\"\` → \`href={plan.url}\`、\`target=\"_blank\"\` 付き。disabled 表示は意図的に保持
- **FreeBanner コンポーネント（行 314）**: メイン CTA を Whop Free 登録に変更（btn-secondary → btn-primary）、サブリンクとしてインストール手順への小さなテキストリンクを併設

## ビルドへの影響

Babel in-browser 方式のため JSX を編集すれば即時反映（mkdocs ビルド対象外）。

## Test plan

- [ ] ローカル serve（\`python3 -m http.server\`）で \`http://localhost:8000/ja/\` を開き Pricing セクションを確認
- [ ] Paid 3 Plan のボタン → 別タブで \`https://whop.com/alforge-labs/alphaforge/\` が開くこと
- [ ] Paid Plan の disabled 表示（取り消し線・"今夏販売開始予定"）が保持されていること
- [ ] Free Plan のメインボタン → 別タブで \`https://whop.com/alforge-labs/alphaforge-free/\` が開くこと
- [ ] Free Plan のサブリンク → 同タブで \`/ja/install.html\` に遷移すること
- [ ] en でも同じ挙動

## Related

- alpha-forge Issue #533（Whop Storefront 整備）
- 本 repo PR #211（C 案価格戦略を反映、URL データ設定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)