### PR TITLE
fix: Free プラン CTA で「インストール手順へ」をボタン下に改行表示

### DIFF
--- a/homepage-components.jsx
+++ b/homepage-components.jsx
@@ -324,7 +324,7 @@ function FreeBanner({ plan, comingSummer, lang }) {
         <a
           href={`/${lang}/install.html`}
           className="free-banner-install-link"
-          style={{ fontSize: '0.85em', textAlign: 'center', marginTop: '0.4rem', color: 'var(--text2)' }}
+          style={{ display: 'block', fontSize: '0.85em', textAlign: 'center', marginTop: '0.4rem', color: 'var(--text2)' }}
         >
           {plan.ctaHint}
         </a>


### PR DESCRIPTION
## Summary
- Free プランバナーの CTA エリアで「\$0 で登録」ボタンと「インストール手順へ」リンクが同一行に並んでしまっていた問題を修正
- ヒントリンクに \`display: block\` を付与し、ボタンの**直下に改行**して表示されるようにした
- \`marginTop: 0.4rem\` が inline 要素では効かない副作用も同時に解消され、ボタンとヒント間の縦余白が意図通りに反映される

## 修正前
\`\`\`
[ \$0 で登録 ]  インストール手順へ
       今夏提供開始予定
\`\`\`

## 修正後
\`\`\`
[ \$0 で登録 ]
  インストール手順へ
   今夏提供開始予定
\`\`\`

## 変更ファイル
- \`homepage-components.jsx\`（1 行差分）

## Test plan
- [ ] \`ja/index.html\` をブラウザで開き、Free プランバナー右側の CTA がボタン／ヒント／提供時期の 3 行縦並びになっていることを目視確認
- [ ] \`en/index.html\` でも同様に確認