### PR TITLE
fix: Free プラン CTA をボタン・リンク・提供時期まで中央揃え

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -700,7 +700,7 @@
     .free-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
     .free-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
     .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
-    .free-banner-cta { flex-shrink: 0; min-width: 140px; }
+    .free-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
     .free-banner-cta .btn-secondary {
       width: 100%; justify-content: center;
     }

--- a/ja/index.html
+++ b/ja/index.html
@@ -700,7 +700,7 @@
     .free-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
     .free-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
     .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
-    .free-banner-cta { flex-shrink: 0; min-width: 140px; }
+    .free-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
     .free-banner-cta .btn-secondary {
       width: 100%; justify-content: center;
     }

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -620,7 +620,7 @@
     .free-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
     .free-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
     .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
-    .free-banner-cta { flex-shrink: 0; min-width: 140px; }
+    .free-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
     .free-banner-cta .btn-secondary {
       width: 100%; justify-content: center;
     }


### PR DESCRIPTION
## Summary
- Free プランバナー右側の CTA カラムで、ボタン「\$0 で登録」だけが左寄せになり、下の「インストール手順へ」「今夏提供開始予定」と縦軸が揃っていなかった問題を修正
- `.free-banner-cta` に `text-align: center` を追加し、inline-flex のボタンを含めて 3 要素すべてカラム中央に揃える

## 修正前
\`\`\`
[ \$0 で登録 ]
      インストール手順へ
       今夏提供開始予定
\`\`\`

## 修正後
\`\`\`
   [ \$0 で登録 ]
   インストール手順へ
    今夏提供開始予定
\`\`\`

## 変更ファイル
- \`templates/index.html.j2\`（1 行差分）
- \`ja/index.html\` / \`en/index.html\`（build.py 生成物）

## Test plan
- [ ] \`ja/index.html\` をブラウザで開き、Free プランバナー右側の CTA 3 要素がすべて中央揃えで縦に並んでいるか確認
- [ ] \`en/index.html\` でも同様に確認