### PR TITLE
fix(docs): MkDocs ナビの「alpha-visualizer」を日英でリラベル

### DIFF
--- a/en/docs/404.html
+++ b/en/docs/404.html
@@ -305,7 +305,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1128,7 +1128,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1144,7 +1144,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/alpha-visualizer/configuration/index.html
+++ b/en/docs/alpha-visualizer/configuration/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1146,7 +1146,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1162,7 +1162,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/alpha-visualizer/faq/index.html
+++ b/en/docs/alpha-visualizer/faq/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1146,7 +1146,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1162,7 +1162,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/alpha-visualizer/features/index.html
+++ b/en/docs/alpha-visualizer/features/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1146,7 +1146,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1162,7 +1162,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/alpha-visualizer/index.html
+++ b/en/docs/alpha-visualizer/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1146,7 +1146,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1162,7 +1162,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/alpha-visualizer/installation/index.html
+++ b/en/docs/alpha-visualizer/installation/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1146,7 +1146,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1162,7 +1162,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/alpha-visualizer/release-0.2.0/index.html
+++ b/en/docs/alpha-visualizer/release-0.2.0/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1146,7 +1146,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1162,7 +1162,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/cli-reference/backtest/index.html
+++ b/en/docs/cli-reference/backtest/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/cli-reference/data/index.html
+++ b/en/docs/cli-reference/data/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/cli-reference/index.html
+++ b/en/docs/cli-reference/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/cli-reference/journal/index.html
+++ b/en/docs/cli-reference/journal/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/cli-reference/live/index.html
+++ b/en/docs/cli-reference/live/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/cli-reference/optimize/index.html
+++ b/en/docs/cli-reference/optimize/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/cli-reference/other/index.html
+++ b/en/docs/cli-reference/other/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/cli-reference/strategy/index.html
+++ b/en/docs/cli-reference/strategy/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/getting-started/index.html
+++ b/en/docs/getting-started/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1420,7 +1420,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1436,7 +1436,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/guides/ai-exploration-workflow/index.html
+++ b/en/docs/guides/ai-exploration-workflow/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1683,7 +1683,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1699,7 +1699,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/guides/end-to-end-workflow/index.html
+++ b/en/docs/guides/end-to-end-workflow/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1262,7 +1262,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1278,7 +1278,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/guides/freemium-limits/index.html
+++ b/en/docs/guides/freemium-limits/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1315,7 +1315,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1331,7 +1331,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/guides/output-examples/index.html
+++ b/en/docs/guides/output-examples/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1368,7 +1368,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1384,7 +1384,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/guides/tradingview-alpha-strike/index.html
+++ b/en/docs/guides/tradingview-alpha-strike/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1251,7 +1251,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1267,7 +1267,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/guides/tradingview-pine-integration/index.html
+++ b/en/docs/guides/tradingview-pine-integration/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1312,7 +1312,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1328,7 +1328,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/index.html
+++ b/en/docs/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1219,7 +1219,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1235,7 +1235,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/legal/disclaimers/index.html
+++ b/en/docs/legal/disclaimers/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/legal/eula/index.html
+++ b/en/docs/legal/eula/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/legal/privacy/index.html
+++ b/en/docs/legal/privacy/index.html
@@ -314,7 +314,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1139,7 +1139,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1155,7 +1155,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/legal/trust-safety-limits/index.html
+++ b/en/docs/legal/trust-safety-limits/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/strategy-gallery/index.html
+++ b/en/docs/strategy-gallery/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1631,7 +1631,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1647,7 +1647,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/templates/index.html
+++ b/en/docs/templates/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1536,7 +1536,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1552,7 +1552,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/usecases/ai-agents/index.html
+++ b/en/docs/usecases/ai-agents/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1231,7 +1231,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1247,7 +1247,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/usecases/auto-trading/index.html
+++ b/en/docs/usecases/auto-trading/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1253,7 +1253,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1269,7 +1269,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/usecases/comparison/index.html
+++ b/en/docs/usecases/comparison/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1531,7 +1531,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1547,7 +1547,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/usecases/index.html
+++ b/en/docs/usecases/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1161,7 +1161,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1177,7 +1177,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/usecases/python-dev/index.html
+++ b/en/docs/usecases/python-dev/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1242,7 +1242,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1258,7 +1258,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/usecases/quants/index.html
+++ b/en/docs/usecases/quants/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1242,7 +1242,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1258,7 +1258,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/en/docs/usecases/tradingview/index.html
+++ b/en/docs/usecases/tradingview/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  Visualization
 
         </a>
       </li>
@@ -1242,7 +1242,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    Visualization
   
 
     
@@ -1258,7 +1258,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    Visualization
   
 
           </label>

--- a/ja/docs/404.html
+++ b/ja/docs/404.html
@@ -305,7 +305,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1128,7 +1128,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1144,7 +1144,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/alpha-visualizer/configuration/index.html
+++ b/ja/docs/alpha-visualizer/configuration/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1146,7 +1146,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1162,7 +1162,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/alpha-visualizer/faq/index.html
+++ b/ja/docs/alpha-visualizer/faq/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1146,7 +1146,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1162,7 +1162,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/alpha-visualizer/features/index.html
+++ b/ja/docs/alpha-visualizer/features/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1146,7 +1146,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1162,7 +1162,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/alpha-visualizer/index.html
+++ b/ja/docs/alpha-visualizer/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1146,7 +1146,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1162,7 +1162,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/alpha-visualizer/installation/index.html
+++ b/ja/docs/alpha-visualizer/installation/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1146,7 +1146,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1162,7 +1162,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/alpha-visualizer/release-0.2.0/index.html
+++ b/ja/docs/alpha-visualizer/release-0.2.0/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1146,7 +1146,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1162,7 +1162,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/cli-reference/backtest/index.html
+++ b/ja/docs/cli-reference/backtest/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/cli-reference/data/index.html
+++ b/ja/docs/cli-reference/data/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/cli-reference/index.html
+++ b/ja/docs/cli-reference/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/cli-reference/journal/index.html
+++ b/ja/docs/cli-reference/journal/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/cli-reference/live/index.html
+++ b/ja/docs/cli-reference/live/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/cli-reference/optimize/index.html
+++ b/ja/docs/cli-reference/optimize/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/cli-reference/other/index.html
+++ b/ja/docs/cli-reference/other/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/cli-reference/strategy/index.html
+++ b/ja/docs/cli-reference/strategy/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/getting-started/index.html
+++ b/ja/docs/getting-started/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1420,7 +1420,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1436,7 +1436,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/guides/ai-exploration-workflow/index.html
+++ b/ja/docs/guides/ai-exploration-workflow/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1683,7 +1683,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1699,7 +1699,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/guides/end-to-end-workflow/index.html
+++ b/ja/docs/guides/end-to-end-workflow/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1262,7 +1262,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1278,7 +1278,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/guides/freemium-limits/index.html
+++ b/ja/docs/guides/freemium-limits/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1315,7 +1315,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1331,7 +1331,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/guides/output-examples/index.html
+++ b/ja/docs/guides/output-examples/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1368,7 +1368,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1384,7 +1384,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/guides/tradingview-alpha-strike/index.html
+++ b/ja/docs/guides/tradingview-alpha-strike/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1251,7 +1251,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1267,7 +1267,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/guides/tradingview-pine-integration/index.html
+++ b/ja/docs/guides/tradingview-pine-integration/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1312,7 +1312,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1328,7 +1328,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/index.html
+++ b/ja/docs/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1219,7 +1219,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1235,7 +1235,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/legal/disclaimers/index.html
+++ b/ja/docs/legal/disclaimers/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/legal/eula/index.html
+++ b/ja/docs/legal/eula/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/legal/privacy/index.html
+++ b/ja/docs/legal/privacy/index.html
@@ -314,7 +314,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1139,7 +1139,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1155,7 +1155,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/legal/trust-safety-limits/index.html
+++ b/ja/docs/legal/trust-safety-limits/index.html
@@ -316,7 +316,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1141,7 +1141,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1157,7 +1157,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/strategy-gallery/index.html
+++ b/ja/docs/strategy-gallery/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1631,7 +1631,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1647,7 +1647,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/templates/index.html
+++ b/ja/docs/templates/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1536,7 +1536,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1552,7 +1552,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/usecases/ai-agents/index.html
+++ b/ja/docs/usecases/ai-agents/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1231,7 +1231,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1247,7 +1247,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/usecases/auto-trading/index.html
+++ b/ja/docs/usecases/auto-trading/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1253,7 +1253,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1269,7 +1269,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/usecases/comparison/index.html
+++ b/ja/docs/usecases/comparison/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1531,7 +1531,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1547,7 +1547,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/usecases/index.html
+++ b/ja/docs/usecases/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1161,7 +1161,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1177,7 +1177,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/usecases/python-dev/index.html
+++ b/ja/docs/usecases/python-dev/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1242,7 +1242,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1258,7 +1258,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/usecases/quants/index.html
+++ b/ja/docs/usecases/quants/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1242,7 +1242,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1258,7 +1258,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/ja/docs/usecases/tradingview/index.html
+++ b/ja/docs/usecases/tradingview/index.html
@@ -318,7 +318,7 @@
           
   
   
-  alpha-visualizer
+  データ可視化
 
         </a>
       </li>
@@ -1242,7 +1242,7 @@
   <span class="md-ellipsis">
     
   
-    alpha-visualizer
+    データ可視化
   
 
     
@@ -1258,7 +1258,7 @@
             <span class="md-nav__icon md-icon"></span>
             
   
-    alpha-visualizer
+    データ可視化
   
 
           </label>

--- a/mkdocs.en.yml
+++ b/mkdocs.en.yml
@@ -75,7 +75,7 @@ nav:
   - Strategy Catalog:
       - Strategy Templates: templates.md
       - Strategy Gallery: strategy-gallery.md
-  - alpha-visualizer:
+  - Visualization:
       - Overview: alpha-visualizer/index.md
       - Installation: alpha-visualizer/installation.md
       - Features: alpha-visualizer/features.md

--- a/mkdocs.ja.yml
+++ b/mkdocs.ja.yml
@@ -75,7 +75,7 @@ nav:
   - 戦略カタログ:
       - 戦略テンプレート: templates.md
       - 戦略実例ギャラリー: strategy-gallery.md
-  - alpha-visualizer:
+  - データ可視化:
       - 概要: alpha-visualizer/index.md
       - インストール: alpha-visualizer/installation.md
       - 機能詳細: alpha-visualizer/features.md


### PR DESCRIPTION
## Summary
- MkDocs のヘッダーナビ上で「alpha-visualizer」だけが小文字＋ハイフンのパッケージ名表記になり、周囲の日本語ラベル（「戦略カタログ」「CLI リファレンス」等）と語感が揃わず座りが悪かった
- 表示ラベルのみを下記に変更:
  - **JP: `alpha-visualizer` → `データ可視化`**
  - **EN: `alpha-visualizer` → `Visualization`**
- URL スラッグ（`/alpha-visualizer/...`）は変更せず、リンク互換性を維持

## 変更ファイル
- `mkdocs.ja.yml` / `mkdocs.en.yml`（各 1 行）
- `ja/docs/**/*.html` / `en/docs/**/*.html`（MkDocs ビルド生成物）

## Test plan
- [ ] `ja/docs/index.html` をブラウザで開き、ヘッダーナビが「データ可視化」表記になっていることを確認
- [ ] `en/docs/index.html` でも `Visualization` 表記を確認
- [ ] 既存ページ URL（`/alpha-visualizer/index.html` 等）が引き続きアクセス可能か確認