### PR TITLE
docs: install / tutorial-strategy を現行 forge CLI に追従

### DIFF
--- a/en/install.html
+++ b/en/install.html
@@ -117,15 +117,17 @@
       </div>
 
       <h2 class="section-heading">License Activation</h2>
-      <p>Use the license key from your purchase email. Activation data is cached at <code>~/.forge/license.json</code>.</p>
-      <pre><code>forge license activate &lt;YOUR_LICENSE_KEY&gt;</code></pre>
+      <p>Sign in with your Whop account via OAuth 2.0 PKCE — your browser opens automatically. Authentication data is cached at <code>~/.forge/auth.json</code>.</p>
+      <pre><code>forge system auth login</code></pre>
+      <p>Verify the activated membership with:</p>
+      <pre><code>forge system auth status</code></pre>
 
       <h2 class="section-heading">Troubleshooting</h2>
       <table class="cmd-table">
         <thead><tr><th>Issue</th><th>Fix</th></tr></thead>
         <tbody>
           <tr><td><code>command not found: forge</code></td><td>Open a new terminal or run <code>source ~/.bashrc</code>.</td></tr>
-          <tr><td>License activation error</td><td>Check your network connection and make sure the key has no extra spaces.</td></tr>
+          <tr><td>Authentication error</td><td>Check your network connection and re-run <code>forge system auth login</code>. Make sure your Whop membership is active.</td></tr>
           <tr><td>macOS security warning</td><td>Open System Settings → Privacy & Security and allow <code>forge</code>.</td></tr>
         </tbody>
       </table>

--- a/en/tutorial-strategy.html
+++ b/en/tutorial-strategy.html
@@ -211,13 +211,13 @@
                 <div>
                   <strong>Install alpha-forge</strong>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                    Use the license key and binary provided after purchase.
+                    After purchase, sign in with your Whop account (OAuth 2.0 PKCE) — the browser opens automatically.
                   </p>
                   <pre><code># Install with uv (includes all dependencies)
 uv add alpha-forge
 
-# Activate your license
-forge license activate YOUR_LICENSE_KEY</code></pre>
+# Sign in via Whop OAuth
+forge system auth login</code></pre>
                 </div>
               </li>
               <li>
@@ -316,7 +316,8 @@ forge data fetch SPY QQQ --period 5y</code></pre>
             <div class="callout">
               <strong>Note on HMM states:</strong> The <code>hmm_state</code> value of <code>1</code>
               typically corresponds to the bullish regime, but this can vary per dataset.
-              Use <code>forge hmm inspect</code> after backtesting to verify state meanings.
+              Run <code>forge backtest run &lt;SYMBOL&gt; --strategy &lt;id&gt; --regime</code> to inspect
+              the per-regime statistics and verify state meanings.
             </div>
           </section>
 
@@ -373,28 +374,29 @@ forge data fetch SPY QQQ --period 5y</code></pre>
               <li>
                 <div>
                   <strong>Run optimization (200 trials)</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize \
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize run CL=F \
   --strategy cl_hmm_bb_rsi_v1 \
-  --symbol CL=F \
   --trials 200 \
-  --metric sharpe_ratio</code></pre>
+  --metric sharpe_ratio \
+  --save</code></pre>
                 </div>
               </li>
               <li>
                 <div>
-                  <strong>View top results</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize results \
-  --strategy cl_hmm_bb_rsi_v1 \
-  --top 5</code></pre>
+                  <strong>View the optimization history</strong>
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize history \
+  --strategy cl_hmm_bb_rsi_v1</code></pre>
                 </div>
               </li>
               <li>
                 <div>
                   <strong>Apply the best parameters</strong>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
+                    The result file is printed by <code>optimize run --save</code> and lives under <code>data/results/</code>.
+                  </p>
                   <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize apply \
-  --strategy cl_hmm_bb_rsi_v1 \
-  --rank 1 \
-  --output strategies/cl_hmm_bb_rsi_v1_optimized.json</code></pre>
+  data/results/optimize_cl_hmm_bb_rsi_v1_&lt;timestamp&gt;.json \
+  --to-strategy cl_hmm_bb_rsi_v1</code></pre>
                 </div>
               </li>
             </ol>
@@ -419,18 +421,18 @@ forge data fetch SPY QQQ --period 5y</code></pre>
               <li>
                 <div>
                   <strong>Run walk-forward test</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge wft run CL=F \
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize walk-forward CL=F \
   --strategy cl_hmm_bb_rsi_v1_optimized \
-  --train-months 24 \
-  --test-months 6 \
-  --step-months 6</code></pre>
+  --windows 5 \
+  --metric sharpe_ratio</code></pre>
                 </div>
               </li>
               <li>
                 <div>
-                  <strong>View the fold-by-fold report</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge wft report \
-  --strategy cl_hmm_bb_rsi_v1_optimized</code></pre>
+                  <strong>View the fold-by-fold report (JSON)</strong>
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize walk-forward CL=F \
+  --strategy cl_hmm_bb_rsi_v1_optimized \
+  --windows 5 --json | jq '.windows'</code></pre>
                 </div>
               </li>
             </ol>
@@ -490,7 +492,7 @@ forge data fetch SPY QQQ --period 5y</code></pre>
                   <strong style="display:block;margin-bottom:0.4rem;">What do HMM state numbers mean?</strong>
                   <p style="font-size:0.88rem;color:var(--text2);line-height:1.7;">
                     HMM state numbers (0, 1, ...) can change between training runs.
-                    Run <code>forge hmm inspect --strategy &lt;strategy_id&gt;</code> after backtesting
+                    Run <code>forge backtest run &lt;SYMBOL&gt; --strategy &lt;strategy_id&gt; --regime</code>
                     to view the mean return and volatility for each state and identify which is the bullish regime.
                   </p>
                 </div>
@@ -499,7 +501,7 @@ forge data fetch SPY QQQ --period 5y</code></pre>
                 <div>
                   <strong style="display:block;margin-bottom:0.4rem;">How do I connect to TradingView?</strong>
                   <p style="font-size:0.88rem;color:var(--text2);line-height:1.7;">
-                    Run <code>forge pinescript generate --strategy &lt;strategy_id&gt;</code> to generate
+                    Run <code>forge pine generate --strategy &lt;strategy_id&gt;</code> to generate
                     TradingView Pine Script v6 code. Set up a Webhook alert in TradingView pointing to
                     alpha-strike for automated order execution.
                   </p>
@@ -512,7 +514,7 @@ forge data fetch SPY QQQ --period 5y</code></pre>
                     100–200 trials is sufficient for strategies with 3–5 parameters.
                     For more parameters or higher precision, use 500–1000 trials.
                   </p>
-                  <pre><code>forge optimize --strategy cl_hmm_bb_rsi_v1 --trials 500 --metric sharpe_ratio</code></pre>
+                  <pre><code>forge optimize run CL=F --strategy cl_hmm_bb_rsi_v1 --trials 500 --metric sharpe_ratio --save</code></pre>
                 </div>
               </li>
             </ul>

--- a/ja/install.html
+++ b/ja/install.html
@@ -117,15 +117,17 @@
       </div>
 
       <h2 class="section-heading">ライセンス認証</h2>
-      <p>購入完了メールに記載されているライセンスキーで認証します。認証情報は <code>~/.forge/license.json</code> に保存されます。</p>
-      <pre><code>forge license activate &lt;YOUR_LICENSE_KEY&gt;</code></pre>
+      <p>Whop アカウントで OAuth 2.0 PKCE 認証を行います。ブラウザが自動で開きます。認証情報は <code>~/.forge/auth.json</code> に保存されます。</p>
+      <pre><code>forge system auth login</code></pre>
+      <p>認証済みメンバーシップは以下で確認できます：</p>
+      <pre><code>forge system auth status</code></pre>
 
       <h2 class="section-heading">トラブルシューティング</h2>
       <table class="cmd-table">
         <thead><tr><th>症状</th><th>対処</th></tr></thead>
         <tbody>
           <tr><td><code>command not found: forge</code></td><td>新しいターミナルを開くか、<code>source ~/.bashrc</code> を実行してください。</td></tr>
-          <tr><td>ライセンス認証エラー</td><td>ネットワーク接続を確認し、キーに余分なスペースがないか確認してください。</td></tr>
+          <tr><td>認証エラー</td><td>ネットワーク接続を確認のうえ <code>forge system auth login</code> を再実行してください。Whop マイページでメンバーシップが有効か確認してください。</td></tr>
           <tr><td>macOS セキュリティ警告</td><td>システム設定 → プライバシーとセキュリティ → 「forge を開く」を許可してください。</td></tr>
         </tbody>
       </table>

--- a/ja/tutorial-strategy.html
+++ b/ja/tutorial-strategy.html
@@ -210,13 +210,13 @@
                 <div>
                   <strong>alpha-forge を取得してインストール</strong>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                    購入後に発行されるライセンスキーとバイナリを使ってインストールします。
+                    購入後、Whop アカウントで OAuth 2.0 PKCE 認証を行います（ブラウザが自動で開きます）。
                   </p>
                   <pre><code># uv で依存関係を含めてインストール
 uv add alpha-forge
 
-# ライセンスを有効化
-forge license activate YOUR_LICENSE_KEY</code></pre>
+# Whop アカウントで認証
+forge system auth login</code></pre>
                 </div>
               </li>
               <li>
@@ -377,33 +377,34 @@ forge data fetch SPY QQQ --period 5y</code></pre>
               <li>
                 <div>
                   <strong>最適化を実行（200 試行）</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize \
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize run CL=F \
   --strategy cl_hmm_bb_rsi_v1 \
-  --symbol CL=F \
   --trials 200 \
-  --metric sharpe_ratio</code></pre>
+  --metric sharpe_ratio \
+  --save</code></pre>
                 </div>
               </li>
               <li>
                 <div>
-                  <strong>最適化結果を確認</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize results \
-  --strategy cl_hmm_bb_rsi_v1 \
-  --top 5</code></pre>
-                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.5rem;">出力例：</p>
-                  <pre><code>Rank  Sharpe  CAGR    MaxDD   bb_length  bb_std  rsi_length  rsi_entry  rsi_exit
-1     1.24    15.3%  -16.1%  25         2.0     12          35         65
-2     1.18    14.7%  -17.4%  20         2.0     14          40         60
-3     1.15    14.2%  -18.2%  25         2.5     12          35         60</code></pre>
+                  <strong>最適化履歴を確認</strong>
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize history \
+  --strategy cl_hmm_bb_rsi_v1</code></pre>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.5rem;">出力例（スコアボード形式）：</p>
+                  <pre><code>Timestamp           Sharpe  CAGR    MaxDD   bb_length  bb_std  rsi_length  rsi_entry  rsi_exit
+20260512_103200     1.24    15.3%  -16.1%  25         2.0     12          35         65
+20260511_180415     1.18    14.7%  -17.4%  20         2.0     14          40         60
+20260510_094822     1.15    14.2%  -18.2%  25         2.5     12          35         60</code></pre>
                 </div>
               </li>
               <li>
                 <div>
                   <strong>最適パラメータを戦略 JSON に反映</strong>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
+                    結果ファイルは <code>optimize run --save</code> の出力に表示され、<code>data/results/</code> 配下に保存されます。
+                  </p>
                   <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize apply \
-  --strategy cl_hmm_bb_rsi_v1 \
-  --rank 1 \
-  --output strategies/cl_hmm_bb_rsi_v1_optimized.json</code></pre>
+  data/results/optimize_cl_hmm_bb_rsi_v1_&lt;timestamp&gt;.json \
+  --to-strategy cl_hmm_bb_rsi_v1</code></pre>
                 </div>
               </li>
             </ol>
@@ -429,18 +430,18 @@ forge data fetch SPY QQQ --period 5y</code></pre>
               <li>
                 <div>
                   <strong>ウォークフォワード検証を実行</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge wft run CL=F \
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize walk-forward CL=F \
   --strategy cl_hmm_bb_rsi_v1_optimized \
-  --train-months 24 \
-  --test-months 6 \
-  --step-months 6</code></pre>
+  --windows 5 \
+  --metric sharpe_ratio</code></pre>
                 </div>
               </li>
               <li>
                 <div>
-                  <strong>結果レポートを確認</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge wft report \
-  --strategy cl_hmm_bb_rsi_v1_optimized</code></pre>
+                  <strong>ウィンドウ別の詳細を確認（JSON）</strong>
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize walk-forward CL=F \
+  --strategy cl_hmm_bb_rsi_v1_optimized \
+  --windows 5 --json | jq '.windows'</code></pre>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.5rem;">出力例：</p>
                   <pre><code>Walk-Forward Test Report — cl_hmm_bb_rsi_v1_optimized / CL=F
 Folds: 6  |  Train: 24M  |  Test: 6M  |  Step: 6M
@@ -513,7 +514,7 @@ Avg Sharpe: 1.10  |  Avg CAGR: 13.9%  |  WF Efficiency: 89%</code></pre>
                   <strong style="display:block;margin-bottom:0.4rem;">HMM の状態番号の意味は？</strong>
                   <p style="font-size:0.88rem;color:var(--text2);line-height:1.7;">
                     HMM の状態番号（0, 1, ...）は学習の都度変わります。
-                    バックテスト後に <code>forge hmm inspect --strategy &lt;strategy_id&gt;</code> で
+                    バックテスト後に <code>forge backtest run &lt;SYMBOL&gt; --strategy &lt;strategy_id&gt; --regime</code> で
                     各状態の平均リターン・ボラティリティを確認して、「上昇トレンド」状態を特定してください。
                   </p>
                 </div>
@@ -522,7 +523,7 @@ Avg Sharpe: 1.10  |  Avg CAGR: 13.9%  |  WF Efficiency: 89%</code></pre>
                 <div>
                   <strong style="display:block;margin-bottom:0.4rem;">TradingView との連携方法は？</strong>
                   <p style="font-size:0.88rem;color:var(--text2);line-height:1.7;">
-                    最適化後に <code>forge pinescript generate --strategy &lt;strategy_id&gt;</code> を実行すると
+                    最適化後に <code>forge pine generate --strategy &lt;strategy_id&gt;</code> を実行すると
                     TradingView Pine Script v6 のコードが生成されます。
                     アラートを alpha-strike に送信することで自動実行が可能です。
                   </p>
@@ -535,7 +536,7 @@ Avg Sharpe: 1.10  |  Avg CAGR: 13.9%  |  WF Efficiency: 89%</code></pre>
                     パラメータ数が 3〜5 個の場合は 100〜200 試行で十分な探索が可能です。
                     パラメータ数が多い場合や精度を高めたい場合は 500〜1000 試行を推奨します。
                   </p>
-                  <pre><code>forge optimize --strategy cl_hmm_bb_rsi_v1 --trials 500 --metric sharpe_ratio</code></pre>
+                  <pre><code>forge optimize run CL=F --strategy cl_hmm_bb_rsi_v1 --trials 500 --metric sharpe_ratio --save</code></pre>
                 </div>
               </li>
             </ul>


### PR DESCRIPTION
## Summary

Whop OAuth 認証への移行と CLI 階層整理（alpha-forge#610 / #644）に伴う旧コマンド名の刷新が、ユーザーが最初に触れる `install.html` / `tutorial-strategy.html` に反映されていなかった。**Getting Started で必ず詰まる状態** だったため、現行 CLI に合わせて全面修正する。

## 修正コマンド対応

| 修正前（陳腐化） | 修正後（現行 CLI） |
|---|---|
| `forge license activate <KEY>` | `forge system auth login`（Whop OAuth 2.0 PKCE） |
| `forge hmm inspect --strategy X` | `forge backtest run <SYMBOL> --strategy X --regime` |
| `forge pinescript generate --strategy X` | `forge pine generate --strategy X` |
| `forge wft run <SYMBOL> --train-months 24 --test-months 6 --step-months 6` | `forge optimize walk-forward <SYMBOL> --windows 5` |
| `forge wft report --strategy X` | `forge optimize walk-forward ... --json \| jq '.windows'` |
| `forge optimize --strategy X --symbol Y --trials N` | `forge optimize run Y --strategy X --trials N --save` |
| `forge optimize results --strategy X --top 5` | `forge optimize history --strategy X` |
| `forge optimize apply --strategy X --rank 1 --output ...` | `forge optimize apply <result_file> --to-strategy X` |

## 修正ファイル

### `{en,ja}/install.html`

- License Activation セクションを Whop OAuth 認証手順に書き換え
- トラブルシューティング表の「License activation error」を「Authentication error」に変更
- 認証情報の保存先を `~/.forge/license.json` → `~/.forge/auth.json`

### `{en,ja}/tutorial-strategy.html`

- インストール手順: `license activate` → `system auth login`
- 最適化セクション: `optimize run` / `optimize history` / `optimize apply` に統一
- ウォークフォワード: `wft` → `optimize walk-forward`
- FAQ:
  - HMM 状態の確認方法を `backtest run --regime` に
  - Pine 生成を `pine generate` に
  - 「試行回数」の例も `optimize run` 形式に

## 残課題（別 PR で対応推奨）

\`terms.html\` / \`privacy.html\` にも \`forge license activate\` / \`forge license deactivate\` と
**「LemonSqueezy License API」** の記述が残っており、Whop OAuth への切替が反映されていない。
法務・プライバシー文書として影響範囲が大きいため、別途レビュー後に修正することを推奨。

## 関連

- 旧 CLI alias 撤去元: ysakae/alpha-forge#644
- CLI 階層整理元: ysakae/alpha-forge#610
- 直近のドキュメント追従 PR: alforge-labs#232

## Test plan

- [x] grep で `forge hmm` / `forge wft` / `forge pinescript` / `forge license` の残存が install / tutorial 配下に存在しないことを確認
- [x] 修正後の各コマンドが現行 CLI のシグネチャと一致することを `src/alpha_forge/commands/optimize.py` / `cli.py` で照合