### PR TITLE
docs(install): 全コマンドカタログとライセンス認証を現行 CLI に追従

### DIFF
--- a/en/install.html
+++ b/en/install.html
@@ -146,7 +146,7 @@
       <p class="page-subtitle" style="margin-bottom: 1.5rem;">Cards for the six core commands plus a full command catalog. Detailed parameters and output examples live in the official docs.</p>
 
       <div class="callout" style="margin-bottom: 2rem;">
-        <p style="margin-bottom: 0.75rem;">For detailed parameters, output examples, and error codes for all 76 subcommands, see the <strong>official documentation</strong>.</p>
+        <p style="margin-bottom: 0.75rem;">For detailed parameters, output examples, and error codes across every subcommand, see the <strong>official documentation</strong>.</p>
         <a href="/en/docs/cli-reference/" class="btn-primary">Open CLI Reference →</a>
       </div>
 
@@ -201,11 +201,11 @@
         <tbody>
           <tr><td><a href="/en/docs/cli-reference/backtest/"><code>forge backtest</code></a></td><td>Backtest execution, scanning, custom experiments</td><td>11</td></tr>
           <tr><td><a href="/en/docs/cli-reference/optimize/"><code>forge optimize</code></a></td><td>Parameter optimization (grid / bayes / wfa)</td><td>9</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>Strategy JSON save / validate / apply</td><td>7</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>Strategy JSON save / validate / apply</td><td>9</td></tr>
           <tr><td><a href="/en/docs/cli-reference/data/"><code>forge data</code></a></td><td>Historical data fetch / update</td><td>4</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/journal/"><code>forge journal</code></a></td><td>Trading journal and trade analysis</td><td>7</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/journal/"><code>forge journal</code></a></td><td>Trading journal and trade analysis</td><td>8</td></tr>
           <tr><td><a href="/en/docs/cli-reference/live/"><code>forge live</code></a></td><td>Live trading and broker integration</td><td>9</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/other/">Other commands</a></td><td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> and more</td><td>10 groups</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/other/">Other commands</a></td><td><code>system</code> / <code>pine</code> / <code>idea</code> / <code>analyze</code> / <code>explore</code> and more</td><td>10 groups</td></tr>
         </tbody>
       </table>
 

--- a/ja/install.html
+++ b/ja/install.html
@@ -146,7 +146,7 @@
       <p class="page-subtitle" style="margin-bottom: 1.5rem;">主要 6 コマンドのカードと全コマンドカタログ。詳細パラメータと出力例は公式ドキュメントへ。</p>
 
       <div class="callout" style="margin-bottom: 2rem;">
-        <p style="margin-bottom: 0.75rem;">全 76 サブコマンドの詳細パラメータ、出力例、エラーコードは<strong>公式ドキュメント</strong>を参照してください。</p>
+        <p style="margin-bottom: 0.75rem;">全サブコマンドの詳細パラメータ、出力例、エラーコードは<strong>公式ドキュメント</strong>を参照してください。</p>
         <a href="/ja/docs/cli-reference/" class="btn-primary">CLI リファレンスを開く →</a>
       </div>
 
@@ -201,11 +201,11 @@
         <tbody>
           <tr><td><a href="/ja/docs/cli-reference/backtest/"><code>forge backtest</code></a></td><td>バックテスト実行・スキャン・カスタム実験</td><td>11</td></tr>
           <tr><td><a href="/ja/docs/cli-reference/optimize/"><code>forge optimize</code></a></td><td>パラメータ最適化（grid / bayes / wfa）</td><td>9</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>戦略 JSON の保存・検証・適用</td><td>7</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>戦略 JSON の保存・検証・適用</td><td>9</td></tr>
           <tr><td><a href="/ja/docs/cli-reference/data/"><code>forge data</code></a></td><td>ヒストリカルデータ取得・更新</td><td>4</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/journal/"><code>forge journal</code></a></td><td>取引ジャーナル・トレード分析</td><td>7</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/journal/"><code>forge journal</code></a></td><td>取引ジャーナル・トレード分析</td><td>8</td></tr>
           <tr><td><a href="/ja/docs/cli-reference/live/"><code>forge live</code></a></td><td>ライブトレーディング・ブローカー連携</td><td>9</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/other/">その他コマンド</a></td><td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> 他</td><td>10 グループ</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/other/">その他コマンド</a></td><td><code>system</code> / <code>pine</code> / <code>idea</code> / <code>analyze</code> / <code>explore</code> 他</td><td>10 グループ</td></tr>
         </tbody>
       </table>
 

--- a/templates/install.html.j2
+++ b/templates/install.html.j2
@@ -65,15 +65,17 @@
       </div>
 
       <h2 class="section-heading">ライセンス認証</h2>
-      <p>購入完了メールに記載されているライセンスキーで認証します。認証情報は <code>~/.forge/license.json</code> に保存されます。</p>
-      <pre><code>forge license activate &lt;YOUR_LICENSE_KEY&gt;</code></pre>
+      <p>Whop アカウントで OAuth 2.0 PKCE 認証を行います。ブラウザが自動で開きます。認証情報は <code>~/.forge/credentials.json</code> に保存されます。</p>
+      <pre><code>forge system auth login</code></pre>
+      <p>認証済みメンバーシップは以下で確認できます：</p>
+      <pre><code>forge system auth status</code></pre>
 
       <h2 class="section-heading">トラブルシューティング</h2>
       <table class="cmd-table">
         <thead><tr><th>症状</th><th>対処</th></tr></thead>
         <tbody>
           <tr><td><code>command not found: forge</code></td><td>新しいターミナルを開くか、<code>source ~/.bashrc</code> を実行してください。</td></tr>
-          <tr><td>ライセンス認証エラー</td><td>ネットワーク接続を確認し、キーに余分なスペースがないか確認してください。</td></tr>
+          <tr><td>認証エラー</td><td>ネットワーク接続を確認のうえ <code>forge system auth login</code> を再実行してください。Whop マイページでメンバーシップが有効か確認してください。</td></tr>
           <tr><td>macOS セキュリティ警告</td><td>システム設定 → プライバシーとセキュリティ → 「forge を開く」を許可してください。</td></tr>
         </tbody>
       </table>
@@ -92,7 +94,7 @@
       <p class="page-subtitle" style="margin-bottom: 1.5rem;">主要 6 コマンドのカードと全コマンドカタログ。詳細パラメータと出力例は公式ドキュメントへ。</p>
 
       <div class="callout" style="margin-bottom: 2rem;">
-        <p style="margin-bottom: 0.75rem;">全 76 サブコマンドの詳細パラメータ、出力例、エラーコードは<strong>公式ドキュメント</strong>を参照してください。</p>
+        <p style="margin-bottom: 0.75rem;">全サブコマンドの詳細パラメータ、出力例、エラーコードは<strong>公式ドキュメント</strong>を参照してください。</p>
         <a href="/ja/docs/cli-reference/" class="btn-primary">CLI リファレンスを開く →</a>
       </div>
 
@@ -147,11 +149,11 @@
         <tbody>
           <tr><td><a href="/ja/docs/cli-reference/backtest/"><code>forge backtest</code></a></td><td>バックテスト実行・スキャン・カスタム実験</td><td>11</td></tr>
           <tr><td><a href="/ja/docs/cli-reference/optimize/"><code>forge optimize</code></a></td><td>パラメータ最適化（grid / bayes / wfa）</td><td>9</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>戦略 JSON の保存・検証・適用</td><td>7</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>戦略 JSON の保存・検証・適用</td><td>9</td></tr>
           <tr><td><a href="/ja/docs/cli-reference/data/"><code>forge data</code></a></td><td>ヒストリカルデータ取得・更新</td><td>4</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/journal/"><code>forge journal</code></a></td><td>取引ジャーナル・トレード分析</td><td>7</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/journal/"><code>forge journal</code></a></td><td>取引ジャーナル・トレード分析</td><td>8</td></tr>
           <tr><td><a href="/ja/docs/cli-reference/live/"><code>forge live</code></a></td><td>ライブトレーディング・ブローカー連携</td><td>9</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/other/">その他コマンド</a></td><td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> 他</td><td>10 グループ</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/other/">その他コマンド</a></td><td><code>system</code> / <code>pine</code> / <code>idea</code> / <code>analyze</code> / <code>explore</code> 他</td><td>10 グループ</td></tr>
         </tbody>
       </table>
 
@@ -195,15 +197,17 @@
       </div>
 
       <h2 class="section-heading">License Activation</h2>
-      <p>Use the license key from your purchase email. Activation data is cached at <code>~/.forge/license.json</code>.</p>
-      <pre><code>forge license activate &lt;YOUR_LICENSE_KEY&gt;</code></pre>
+      <p>Sign in with your Whop account via OAuth 2.0 PKCE — your browser opens automatically. Authentication data is cached at <code>~/.forge/credentials.json</code>.</p>
+      <pre><code>forge system auth login</code></pre>
+      <p>Verify the activated membership with:</p>
+      <pre><code>forge system auth status</code></pre>
 
       <h2 class="section-heading">Troubleshooting</h2>
       <table class="cmd-table">
         <thead><tr><th>Issue</th><th>Fix</th></tr></thead>
         <tbody>
           <tr><td><code>command not found: forge</code></td><td>Open a new terminal or run <code>source ~/.bashrc</code>.</td></tr>
-          <tr><td>License activation error</td><td>Check your network connection and make sure the key has no extra spaces.</td></tr>
+          <tr><td>Authentication error</td><td>Check your network connection and re-run <code>forge system auth login</code>. Make sure your Whop membership is active.</td></tr>
           <tr><td>macOS security warning</td><td>Open System Settings → Privacy & Security and allow <code>forge</code>.</td></tr>
         </tbody>
       </table>
@@ -222,7 +226,7 @@
       <p class="page-subtitle" style="margin-bottom: 1.5rem;">Cards for the six core commands plus a full command catalog. Detailed parameters and output examples live in the official docs.</p>
 
       <div class="callout" style="margin-bottom: 2rem;">
-        <p style="margin-bottom: 0.75rem;">For detailed parameters, output examples, and error codes for all 76 subcommands, see the <strong>official documentation</strong>.</p>
+        <p style="margin-bottom: 0.75rem;">For detailed parameters, output examples, and error codes across every subcommand, see the <strong>official documentation</strong>.</p>
         <a href="/en/docs/cli-reference/" class="btn-primary">Open CLI Reference →</a>
       </div>
 
@@ -277,11 +281,11 @@
         <tbody>
           <tr><td><a href="/en/docs/cli-reference/backtest/"><code>forge backtest</code></a></td><td>Backtest execution, scanning, custom experiments</td><td>11</td></tr>
           <tr><td><a href="/en/docs/cli-reference/optimize/"><code>forge optimize</code></a></td><td>Parameter optimization (grid / bayes / wfa)</td><td>9</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>Strategy JSON save / validate / apply</td><td>7</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>Strategy JSON save / validate / apply</td><td>9</td></tr>
           <tr><td><a href="/en/docs/cli-reference/data/"><code>forge data</code></a></td><td>Historical data fetch / update</td><td>4</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/journal/"><code>forge journal</code></a></td><td>Trading journal and trade analysis</td><td>7</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/journal/"><code>forge journal</code></a></td><td>Trading journal and trade analysis</td><td>8</td></tr>
           <tr><td><a href="/en/docs/cli-reference/live/"><code>forge live</code></a></td><td>Live trading and broker integration</td><td>9</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/other/">Other commands</a></td><td><code>pine</code> / <code>dashboard</code> / <code>license</code> / <code>config</code> and more</td><td>10 groups</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/other/">Other commands</a></td><td><code>system</code> / <code>pine</code> / <code>idea</code> / <code>analyze</code> / <code>explore</code> and more</td><td>10 groups</td></tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
## 概要

`ja/install.html` / `en/install.html` の「全コマンドカタログ」と「ライセンス認証」セクションに残っていた旧 CLI ベースの古い情報を、現行 `forge` CLI に同期しました。

## 背景

- #233 で `install.html` の license activate → `forge system auth login` 化が行われた際、**生成 HTML だけが直接編集され、テンプレート (`templates/install.html.j2`) が未更新**だったため、`uv run python build.py` を実行するとライセンス認証セクションが古い内容に巻き戻る状態でした。
- 加えて、`forge` CLI 階層整理（alpha-forge#610 / #644）に伴い増えた `strategy signals` / `journal report` などの新サブコマンドや、`forge dashboard` / `forge license` / `forge config` が廃止されていた事実が、コマンドカタログ表に反映されていませんでした。

## 変更内容

### ライセンス認証セクション（テンプレート同期）

| 修正前（テンプレート） | 修正後 |
|---|---|
| `forge license activate <KEY>` | `forge system auth login`（Whop OAuth 2.0 PKCE） |
| `~/.forge/license.json` | `~/.forge/credentials.json` |
| 「ライセンス認証エラー」 | 「認証エラー」（再ログイン手順を案内） |

加えて `forge system auth status` による認証確認手順を追記。

### 全コマンドカタログ

| 行 | 修正前 | 修正後 |
|---|---|---|
| `forge strategy` | 7 サブコマンド | **9**（`purge` / `validate` / `signals` 追加） |
| `forge journal` | 7 サブコマンド | **8**（`report` 追加） |
| その他コマンド例示 | `pine` / `dashboard` / `license` / `config` 他 | **`system` / `pine` / `idea` / `analyze` / `explore` 他**（廃止済みグループ名を削除） |
| カウント表記 | 「全 76 サブコマンド」 | 「全サブコマンド」（将来ドリフト回避） |

### 修正ファイル

- `templates/install.html.j2`（テンプレートの正）
- `ja/install.html` / `en/install.html`（`build.py` で再生成）

## テスト計画

- [x] `uv run python build.py` がエラーなく完走
- [x] `ja/install.html` / `en/install.html` に新表記が反映
- [x] テンプレートと生成 HTML が一致（次回ビルドで巻き戻らない）
- [ ] ブラウザで `https://alforgelabs.com/ja/install.html#commands` / `/en/install.html#commands` を開き、カタログ表と認証セクションが新表記になっていることを確認

## 注意

`templates/privacy.html.j2` / `templates/terms.html.j2` / `templates/tutorial-strategy.html.j2` も同様にテンプレート未同期の箇所が残っていることをビルド時に確認しました（#233 / #234 の生成 HTML 直接編集分）。本 PR の scope 外として、今回は `install.html` 関連のみコミットしています（残りは別 PR で対応推奨）。