### PR TITLE
docs(templates): privacy / terms / tutorial を現行 CLI / Whop OAuth に同期

### DIFF
--- a/seo.yaml
+++ b/seo.yaml
@@ -74,17 +74,17 @@ pages:
   privacy:
     ja:
       title: "プライバシーポリシー — Alforge Labs"
-      description: "Alforge Labs のプライバシーポリシー。購入・ライセンス認証・サポート時のデータ取り扱いについて。"
+      description: "Alforge Labs のプライバシーポリシー。購入・認証・サポート時のデータ取り扱いについて。"
       keywords: "プライバシーポリシー, Alforge Labs"
       og_title: "プライバシーポリシー — Alforge Labs"
-      og_description: "購入・ライセンス認証・サポート時のデータ取り扱い方針。"
+      og_description: "購入・認証・サポート時のデータ取り扱い方針。"
       json_ld_type: breadcrumb
     en:
       title: "Privacy Policy — Alforge Labs"
-      description: "Alforge Labs privacy policy covering data handling for purchases, license activation, and support."
+      description: "Alforge Labs privacy policy covering data handling for purchases, authentication, and support."
       keywords: "privacy policy, Alforge Labs"
       og_title: "Privacy Policy — Alforge Labs"
-      og_description: "How Alforge Labs handles data for purchases, license activation, and support requests."
+      og_description: "How Alforge Labs handles data for purchases, authentication, and support requests."
       json_ld_type: breadcrumb
 
   terms:

--- a/templates/privacy.html.j2
+++ b/templates/privacy.html.j2
@@ -24,25 +24,31 @@
       {% if lang == 'ja' %}
       <div class="page-label">Legal</div>
       <h1 class="page-title">プライバシーポリシー</h1>
-      <p class="page-subtitle">最終更新日: 2026年4月25日</p>
+      <p class="page-subtitle">最終更新日: 2026年5月12日</p>
 
       <p>Alforge Labs（以下「当社」）は、AlphaForge CLI の提供にあたり収集する個人情報の取り扱いについて、以下の通りプライバシーポリシーを定めます。</p>
 
       <h2 class="section-heading">1. 収集する情報</h2>
       <h3 class="sub-heading">1.1 購入時に収集する情報</h3>
-      <p>LemonSqueezy を通じたライセンス購入時に、氏名または会社名、メールアドレス、決済情報、国・地域情報が収集されます。決済情報は LemonSqueezy が処理し、当社は保持しません。</p>
+      <p>Whop を通じたメンバーシップ購入時に、氏名または会社名、メールアドレス、決済情報、国・地域情報が収集されます。決済情報は Whop およびその決済プロバイダ（Stripe 等）が処理し、当社はカード番号等の機微情報を保持しません。</p>
 
-      <h3 class="sub-heading">1.2 ライセンス認証時に収集する情報</h3>
-      <p><code>forge license activate</code> 実行時に、ライセンスキー、インスタンス名、アクティベーション日時が LemonSqueezy の License API に送信されます。</p>
+      <h3 class="sub-heading">1.2 認証時に収集・送受信する情報</h3>
+      <p><code>forge system auth login</code> 実行時に、OAuth 2.0 PKCE フローに従い以下の情報が Whop API（<code>api.whop.com</code>）と送受信されます。</p>
+      <ul>
+        <li>当社からの送信: OAuth 認可コード、PKCE code_verifier、リフレッシュトークン（更新時）</li>
+        <li>Whop からの受信: アクセストークン（access_token）、リフレッシュトークン（refresh_token）、ユーザー ID、メンバーシップ有効性</li>
+        <li>定期的なアクセス検証時: アクセストークンを <code>api.whop.com/api/v1</code> に送信し、購入済みプロダクトへのアクセス権を確認</li>
+      </ul>
+      <p>取得したトークンと認証メタデータはローカルの <code>~/.forge/credentials.json</code> に保存され、当社サーバーには保管されません。</p>
 
       <h3 class="sub-heading">1.3 収集しない情報</h3>
       <div class="callout">
-        <p>AlphaForge CLI はローカル完結型ソフトウェアです。バックテスト設定、最適化パラメータ、戦略データ、取引履歴、ポジション情報、ローカルファイル、操作ログは当社サーバーへ送信されません。</p>
+        <p>AlphaForge CLI はローカル完結型ソフトウェアです。バックテスト設定、最適化パラメータ、戦略データ、取引履歴、ポジション情報、ローカルファイル、操作ログは当社サーバーへ送信されません。Whop API への通信は認証・メンバーシップ確認のみを目的とします。</p>
       </div>
 
       <h2 class="section-heading">2. 情報の利用目的</h2>
       <ul>
-        <li>ライセンスキーの発行・認証・管理</li>
+        <li>メンバーシップの認証・有効性確認</li>
         <li>購入確認メール・領収書の送付</li>
         <li>製品アップデートのお知らせ（登録ユーザーのみ、配信停止可）</li>
         <li>サポート対応</li>
@@ -50,13 +56,13 @@
       </ul>
 
       <h2 class="section-heading">3. 第三者への情報提供</h2>
-      <p>当社は、決済処理・ライセンス管理のために LemonSqueezy と必要な情報を共有する場合、および法令上の要請がある場合を除き、個人情報を第三者に提供しません。マーケティング目的でのデータ販売・共有は行いません。</p>
+      <p>当社は、決済処理・メンバーシップ管理のために Whop（および Whop の決済委託先）と必要な情報を共有する場合、および法令上の要請がある場合を除き、個人情報を第三者に提供しません。マーケティング目的でのデータ販売・共有は行いません。</p>
 
       <h2 class="section-heading">4. データの保存期間</h2>
       <ul>
-        <li>購入情報・ライセンス情報: LemonSqueezy のデータ保持ポリシーに準拠</li>
+        <li>購入情報・メンバーシップ情報: Whop のデータ保持ポリシーに準拠</li>
         <li>サポートメール: 対応完了後2年間</li>
-        <li>ローカル認証キャッシュ: ユーザーが削除するまで、または <code>forge license deactivate</code> 実行まで保持</li>
+        <li>ローカル認証キャッシュ（<code>~/.forge/credentials.json</code>）: ユーザーが削除するまで、または <code>forge system auth logout</code> 実行まで保持</li>
       </ul>
 
       <h2 class="section-heading">5. Cookie・トラッキング</h2>
@@ -68,25 +74,31 @@
       {% else %}
       <div class="page-label">Legal</div>
       <h1 class="page-title">Privacy Policy</h1>
-      <p class="page-subtitle">Last Updated: April 25, 2026</p>
+      <p class="page-subtitle">Last Updated: May 12, 2026</p>
 
       <p>Alforge Labs defines this privacy policy to explain how personal information is handled in connection with AlphaForge CLI.</p>
 
       <h2 class="section-heading">1. Information We Collect</h2>
       <h3 class="sub-heading">1.1 Purchase Information</h3>
-      <p>When you purchase a license through LemonSqueezy, information such as your name or company name, email address, payment details, and country or region may be collected. Payment details are processed by LemonSqueezy and are not stored by Alforge Labs.</p>
+      <p>When you purchase a membership through Whop, information such as your name or company name, email address, payment details, and country or region may be collected. Payment details are processed by Whop and its payment providers (e.g. Stripe); Alforge Labs does not store card-level information.</p>
 
-      <h3 class="sub-heading">1.2 License Activation Information</h3>
-      <p>When you run <code>forge license activate</code>, the license key, instance name, and activation timestamp are sent to the LemonSqueezy License API.</p>
+      <h3 class="sub-heading">1.2 Information Exchanged During Authentication</h3>
+      <p>When you run <code>forge system auth login</code>, the OAuth 2.0 PKCE flow sends and receives the following with the Whop API (<code>api.whop.com</code>):</p>
+      <ul>
+        <li>Sent to Whop: OAuth authorization code, PKCE code_verifier, refresh token (during token refresh)</li>
+        <li>Received from Whop: access token, refresh token, user ID, membership validity</li>
+        <li>During periodic re-verification: the access token is sent to <code>api.whop.com/api/v1</code> to confirm access to your purchased product</li>
+      </ul>
+      <p>The retrieved tokens and authentication metadata are stored locally at <code>~/.forge/credentials.json</code> and are not sent to Alforge Labs servers.</p>
 
       <h3 class="sub-heading">1.3 Information We Do Not Collect</h3>
       <div class="callout">
-        <p>AlphaForge CLI is local-first software. Backtest settings, optimization parameters, strategy data, trading history, positions, local files, and usage logs are not sent to Alforge Labs servers.</p>
+        <p>AlphaForge CLI is local-first software. Backtest settings, optimization parameters, strategy data, trading history, positions, local files, and usage logs are not sent to Alforge Labs servers. Communication with the Whop API is limited to authentication and membership verification.</p>
       </div>
 
       <h2 class="section-heading">2. How We Use Information</h2>
       <ul>
-        <li>Issuing, activating, and managing license keys</li>
+        <li>Authenticating and verifying the validity of your membership</li>
         <li>Sending purchase confirmations and receipts</li>
         <li>Sending product update notices to registered users, with opt-out available</li>
         <li>Providing technical support</li>
@@ -94,13 +106,13 @@
       </ul>
 
       <h2 class="section-heading">3. Third-Party Sharing</h2>
-      <p>We do not share personal information with third parties except when necessary for payment processing and license management through LemonSqueezy, or when required by law. We do not sell or share data for marketing purposes.</p>
+      <p>We do not share personal information with third parties except when necessary for payment processing and membership management through Whop (and Whop's payment processors), or when required by law. We do not sell or share data for marketing purposes.</p>
 
       <h2 class="section-heading">4. Data Retention</h2>
       <ul>
-        <li>Purchase and license information: retained according to LemonSqueezy's data retention policy</li>
+        <li>Purchase and membership information: retained according to Whop's data retention policy</li>
         <li>Support email: retained for two years after the support request is resolved</li>
-        <li>Local authentication cache: retained until the user removes it or runs <code>forge license deactivate</code></li>
+        <li>Local authentication cache (<code>~/.forge/credentials.json</code>): retained until the user removes it or runs <code>forge system auth logout</code></li>
       </ul>
 
       <h2 class="section-heading">5. Cookies and Tracking</h2>

--- a/templates/terms.html.j2
+++ b/templates/terms.html.j2
@@ -42,27 +42,27 @@
       <p>過去の実績は将来の結果を示すものではありません。仮想またはシミュレーションされたパフォーマンス結果には固有の制約があります。いかなる口座も、バックテストで示された利益または損失と同様の結果を達成する、または達成する可能性が高いと表明するものではありません。</p>
 
       <h2 class="section-heading">5. 返金ポリシー</h2>
-      <p>本ソフトウェアはデジタル製品であり、ライセンスキーおよび実行可能バイナリが即時に提供される性質を持つため、すべての販売は最終的なもの（返金不可）とします。購入前にドキュメントと技術要件を十分に確認してください。</p>
+      <p>本ソフトウェアはデジタル製品であり、メンバーシップおよび実行可能バイナリが即時に提供される性質を持つため、すべての販売は最終的なもの（返金不可）とします。購入前にドキュメントと技術要件を十分に確認してください。</p>
 
       <h2 class="section-heading">6. ライセンス条件</h2>
       <h3 class="sub-heading">6.1 付与されるライセンス</h3>
-      <p>有効なライセンスキーを購入したユーザーに対し、非独占的・非譲渡的な使用権を付与します。</p>
+      <p>Whop で有効なメンバーシップを購入したユーザーに対し、非独占的・非譲渡的な使用権を付与します。</p>
       <ul>
-        <li>ライセンスキー1本につき1台のマシンでのみ有効です。</li>
+        <li>1 Whop アカウントにつき 1 ユーザーの利用を前提とします。</li>
         <li>ライセンスは個人利用を対象とします。法人利用または商用利用については別途お問い合わせください。</li>
-        <li>Lifetime ライセンスには、購入後の将来バージョンアップが含まれます。</li>
+        <li>Lifetime プランには、購入後の将来バージョンアップが含まれます。</li>
       </ul>
 
       <h3 class="sub-heading">6.2 禁止事項</h3>
       <ul>
-        <li>ライセンスキーの第三者への譲渡、共有、販売</li>
+        <li>Whop アカウント、認証トークン、その他認証情報の第三者への譲渡、共有、販売</li>
         <li>バイナリのリバースエンジニアリング、逆コンパイル、逆アセンブル</li>
         <li>本ソフトウェアを改変した派生物の再配布</li>
-        <li>ライセンス認証機構の回避または無効化</li>
+        <li>ライセンス認証機構（Whop OAuth およびメンバーシップ検証）の回避または無効化</li>
       </ul>
 
-      <h3 class="sub-heading">6.3 ライセンスの移行</h3>
-      <p>マシン変更時は <code>forge license deactivate</code> で旧デバイスのライセンスを解除してから、新デバイスで再認証してください。</p>
+      <h3 class="sub-heading">6.3 マシン変更時</h3>
+      <p>マシン変更時は旧デバイスで <code>forge system auth logout</code> を実行してローカル認証キャッシュを削除してから、新デバイスで <code>forge system auth login</code> を実行してください。同一の Whop アカウントで再認証することで利用を継続できます。</p>
 
       <h2 class="section-heading">7. サービスの変更・終了</h2>
       <p>Alforge Labs は、予告なく本ソフトウェアの機能変更、提供条件の変更、または開発終了を行う権利を留保します。重要な変更がある場合は、ウェブサイトへの掲載または登録メールアドレスへの通知によりお知らせします。</p>
@@ -83,7 +83,7 @@
       <p>技術サポートまたはお問い合わせは以下までご連絡ください。</p>
       <p>Email: <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a></p>
 
-      <p class="page-subtitle" style="margin-top: 3rem;">最終更新日: 2026年4月25日</p>
+      <p class="page-subtitle" style="margin-top: 3rem;">最終更新日: 2026年5月12日</p>
       {% else %}
       <div class="page-label">Legal</div>
       <h1 class="page-title">Terms of Service &amp; Risk Disclaimer</h1>
@@ -105,27 +105,27 @@
       <p>Past performance is not indicative of future results. Hypothetical or simulated performance results have certain inherent limitations. No representation is being made that any account will or is likely to achieve profits or losses similar to those shown in any backtest.</p>
 
       <h2 class="section-heading">5. Refund Policy</h2>
-      <p>Due to the digital nature of the software and the immediate delivery of license keys and executable binaries, all sales are final. Please review the documentation and technical requirements thoroughly before purchase.</p>
+      <p>Due to the digital nature of the software and the immediate delivery of memberships and executable binaries, all sales are final. Please review the documentation and technical requirements thoroughly before purchase.</p>
 
       <h2 class="section-heading">6. License Terms</h2>
       <h3 class="sub-heading">6.1 License Grant</h3>
-      <p>Users who purchase a valid license key receive a non-exclusive, non-transferable right to use the software.</p>
+      <p>Users with an active Whop membership receive a non-exclusive, non-transferable right to use the software.</p>
       <ul>
-        <li>Each license key is valid for one machine only.</li>
+        <li>Each Whop account is intended for use by a single user.</li>
         <li>The license is intended for personal use. Please contact us separately for corporate or commercial use.</li>
-        <li>Lifetime licenses include future version updates after purchase.</li>
+        <li>Lifetime plans include future version updates after purchase.</li>
       </ul>
 
       <h3 class="sub-heading">6.2 Prohibited Actions</h3>
       <ul>
-        <li>Transferring, sharing, or selling license keys to third parties</li>
+        <li>Transferring, sharing, or selling Whop accounts, authentication tokens, or other credentials to third parties</li>
         <li>Reverse engineering, decompiling, or disassembling binaries</li>
         <li>Redistributing modified derivatives of the software</li>
-        <li>Circumventing or disabling the license activation mechanism</li>
+        <li>Circumventing or disabling the license activation mechanism (Whop OAuth and membership verification)</li>
       </ul>
 
-      <h3 class="sub-heading">6.3 License Transfer</h3>
-      <p>When changing machines, deactivate the old device with <code>forge license deactivate</code> before activating the license on the new device.</p>
+      <h3 class="sub-heading">6.3 Switching Machines</h3>
+      <p>When changing machines, run <code>forge system auth logout</code> on the old device to clear the local authentication cache, then run <code>forge system auth login</code> on the new device. Signing in with the same Whop account preserves your access.</p>
 
       <h2 class="section-heading">7. Service Changes and Termination</h2>
       <p>Alforge Labs reserves the right to change software features, terms of availability, or discontinue development without prior notice. Material changes may be announced on the website or by email to registered users.</p>
@@ -145,7 +145,7 @@
       <h2 class="section-heading">12. Contact Information</h2>
       <p>For technical support or inquiries, please contact: <a href="mailto:support@alforgelabs.com">support@alforgelabs.com</a></p>
 
-      <p class="page-subtitle" style="margin-top: 3rem;">Last Updated: April 25, 2026</p>
+      <p class="page-subtitle" style="margin-top: 3rem;">Last Updated: May 12, 2026</p>
       {% endif %}
     </div>
   </div>

--- a/templates/tutorial-strategy.html.j2
+++ b/templates/tutorial-strategy.html.j2
@@ -158,13 +158,13 @@
                 <div>
                   <strong>alpha-forge を取得してインストール</strong>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                    購入後に発行されるライセンスキーとバイナリを使ってインストールします。
+                    購入後、Whop アカウントで OAuth 2.0 PKCE 認証を行います（ブラウザが自動で開きます）。
                   </p>
                   <pre><code># uv で依存関係を含めてインストール
 uv add alpha-forge
 
-# ライセンスを有効化
-forge license activate YOUR_LICENSE_KEY</code></pre>
+# Whop アカウントで認証
+forge system auth login</code></pre>
                 </div>
               </li>
               <li>
@@ -174,7 +174,7 @@ forge license activate YOUR_LICENSE_KEY</code></pre>
                     作業ディレクトリに <code>forge.yaml</code>（設定ファイル）と <code>strategies/</code> ディレクトリが生成されます。
                   </p>
                   <pre><code>mkdir my-strategies && cd my-strategies
-forge init
+forge system init
 # → forge.yaml, strategies/, data/ が作成されます</code></pre>
                 </div>
               </li>
@@ -325,33 +325,34 @@ forge data fetch SPY QQQ --period 5y</code></pre>
               <li>
                 <div>
                   <strong>最適化を実行（200 試行）</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize \
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize run CL=F \
   --strategy cl_hmm_bb_rsi_v1 \
-  --symbol CL=F \
   --trials 200 \
-  --metric sharpe_ratio</code></pre>
+  --metric sharpe_ratio \
+  --save</code></pre>
                 </div>
               </li>
               <li>
                 <div>
-                  <strong>最適化結果を確認</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize results \
-  --strategy cl_hmm_bb_rsi_v1 \
-  --top 5</code></pre>
-                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.5rem;">出力例：</p>
-                  <pre><code>Rank  Sharpe  CAGR    MaxDD   bb_length  bb_std  rsi_length  rsi_entry  rsi_exit
-1     1.24    15.3%  -16.1%  25         2.0     12          35         65
-2     1.18    14.7%  -17.4%  20         2.0     14          40         60
-3     1.15    14.2%  -18.2%  25         2.5     12          35         60</code></pre>
+                  <strong>最適化履歴を確認</strong>
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize history \
+  --strategy cl_hmm_bb_rsi_v1</code></pre>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.5rem;">出力例（スコアボード形式）：</p>
+                  <pre><code>Timestamp           Sharpe  CAGR    MaxDD   bb_length  bb_std  rsi_length  rsi_entry  rsi_exit
+20260512_103200     1.24    15.3%  -16.1%  25         2.0     12          35         65
+20260511_180415     1.18    14.7%  -17.4%  20         2.0     14          40         60
+20260510_094822     1.15    14.2%  -18.2%  25         2.5     12          35         60</code></pre>
                 </div>
               </li>
               <li>
                 <div>
                   <strong>最適パラメータを戦略 JSON に反映</strong>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
+                    結果ファイルは <code>optimize run --save</code> の出力に表示され、<code>data/results/</code> 配下に保存されます。
+                  </p>
                   <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize apply \
-  --strategy cl_hmm_bb_rsi_v1 \
-  --rank 1 \
-  --output strategies/cl_hmm_bb_rsi_v1_optimized.json</code></pre>
+  data/results/optimize_cl_hmm_bb_rsi_v1_&lt;timestamp&gt;.json \
+  --to-strategy cl_hmm_bb_rsi_v1</code></pre>
                 </div>
               </li>
             </ol>
@@ -377,18 +378,18 @@ forge data fetch SPY QQQ --period 5y</code></pre>
               <li>
                 <div>
                   <strong>ウォークフォワード検証を実行</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge wft run CL=F \
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize walk-forward CL=F \
   --strategy cl_hmm_bb_rsi_v1_optimized \
-  --train-months 24 \
-  --test-months 6 \
-  --step-months 6</code></pre>
+  --windows 5 \
+  --metric sharpe_ratio</code></pre>
                 </div>
               </li>
               <li>
                 <div>
-                  <strong>結果レポートを確認</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge wft report \
-  --strategy cl_hmm_bb_rsi_v1_optimized</code></pre>
+                  <strong>ウィンドウ別の詳細を確認（JSON）</strong>
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize walk-forward CL=F \
+  --strategy cl_hmm_bb_rsi_v1_optimized \
+  --windows 5 --json | jq '.windows'</code></pre>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.5rem;">出力例：</p>
                   <pre><code>Walk-Forward Test Report — cl_hmm_bb_rsi_v1_optimized / CL=F
 Folds: 6  |  Train: 24M  |  Test: 6M  |  Step: 6M
@@ -461,7 +462,7 @@ Avg Sharpe: 1.10  |  Avg CAGR: 13.9%  |  WF Efficiency: 89%</code></pre>
                   <strong style="display:block;margin-bottom:0.4rem;">HMM の状態番号の意味は？</strong>
                   <p style="font-size:0.88rem;color:var(--text2);line-height:1.7;">
                     HMM の状態番号（0, 1, ...）は学習の都度変わります。
-                    バックテスト後に <code>forge hmm inspect --strategy &lt;strategy_id&gt;</code> で
+                    バックテスト後に <code>forge backtest run &lt;SYMBOL&gt; --strategy &lt;strategy_id&gt; --regime</code> で
                     各状態の平均リターン・ボラティリティを確認して、「上昇トレンド」状態を特定してください。
                   </p>
                 </div>
@@ -470,7 +471,7 @@ Avg Sharpe: 1.10  |  Avg CAGR: 13.9%  |  WF Efficiency: 89%</code></pre>
                 <div>
                   <strong style="display:block;margin-bottom:0.4rem;">TradingView との連携方法は？</strong>
                   <p style="font-size:0.88rem;color:var(--text2);line-height:1.7;">
-                    最適化後に <code>forge pinescript generate --strategy &lt;strategy_id&gt;</code> を実行すると
+                    最適化後に <code>forge pine generate --strategy &lt;strategy_id&gt;</code> を実行すると
                     TradingView Pine Script v6 のコードが生成されます。
                     アラートを alpha-strike に送信することで自動実行が可能です。
                   </p>
@@ -483,7 +484,7 @@ Avg Sharpe: 1.10  |  Avg CAGR: 13.9%  |  WF Efficiency: 89%</code></pre>
                     パラメータ数が 3〜5 個の場合は 100〜200 試行で十分な探索が可能です。
                     パラメータ数が多い場合や精度を高めたい場合は 500〜1000 試行を推奨します。
                   </p>
-                  <pre><code>forge optimize --strategy cl_hmm_bb_rsi_v1 --trials 500 --metric sharpe_ratio</code></pre>
+                  <pre><code>forge optimize run CL=F --strategy cl_hmm_bb_rsi_v1 --trials 500 --metric sharpe_ratio --save</code></pre>
                 </div>
               </li>
             </ul>
@@ -555,13 +556,13 @@ Avg Sharpe: 1.10  |  Avg CAGR: 13.9%  |  WF Efficiency: 89%</code></pre>
                 <div>
                   <strong>Install alpha-forge</strong>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                    Use the license key and binary provided after purchase.
+                    After purchase, sign in with your Whop account (OAuth 2.0 PKCE) — the browser opens automatically.
                   </p>
                   <pre><code># Install with uv (includes all dependencies)
 uv add alpha-forge
 
-# Activate your license
-forge license activate YOUR_LICENSE_KEY</code></pre>
+# Sign in via Whop OAuth
+forge system auth login</code></pre>
                 </div>
               </li>
               <li>
@@ -571,7 +572,7 @@ forge license activate YOUR_LICENSE_KEY</code></pre>
                     Creates <code>forge.yaml</code>, <code>strategies/</code>, and <code>data/</code> directories.
                   </p>
                   <pre><code>mkdir my-strategies && cd my-strategies
-forge init</code></pre>
+forge system init</code></pre>
                 </div>
               </li>
               <li>
@@ -660,7 +661,8 @@ forge data fetch SPY QQQ --period 5y</code></pre>
             <div class="callout">
               <strong>Note on HMM states:</strong> The <code>hmm_state</code> value of <code>1</code>
               typically corresponds to the bullish regime, but this can vary per dataset.
-              Use <code>forge hmm inspect</code> after backtesting to verify state meanings.
+              Run <code>forge backtest run &lt;SYMBOL&gt; --strategy &lt;id&gt; --regime</code> to inspect
+              the per-regime statistics and verify state meanings.
             </div>
           </section>
 
@@ -717,28 +719,29 @@ forge data fetch SPY QQQ --period 5y</code></pre>
               <li>
                 <div>
                   <strong>Run optimization (200 trials)</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize \
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize run CL=F \
   --strategy cl_hmm_bb_rsi_v1 \
-  --symbol CL=F \
   --trials 200 \
-  --metric sharpe_ratio</code></pre>
+  --metric sharpe_ratio \
+  --save</code></pre>
                 </div>
               </li>
               <li>
                 <div>
-                  <strong>View top results</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize results \
-  --strategy cl_hmm_bb_rsi_v1 \
-  --top 5</code></pre>
+                  <strong>View the optimization history</strong>
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize history \
+  --strategy cl_hmm_bb_rsi_v1</code></pre>
                 </div>
               </li>
               <li>
                 <div>
                   <strong>Apply the best parameters</strong>
+                  <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
+                    The result file is printed by <code>optimize run --save</code> and lives under <code>data/results/</code>.
+                  </p>
                   <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize apply \
-  --strategy cl_hmm_bb_rsi_v1 \
-  --rank 1 \
-  --output strategies/cl_hmm_bb_rsi_v1_optimized.json</code></pre>
+  data/results/optimize_cl_hmm_bb_rsi_v1_&lt;timestamp&gt;.json \
+  --to-strategy cl_hmm_bb_rsi_v1</code></pre>
                 </div>
               </li>
             </ol>
@@ -763,18 +766,18 @@ forge data fetch SPY QQQ --period 5y</code></pre>
               <li>
                 <div>
                   <strong>Run walk-forward test</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge wft run CL=F \
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize walk-forward CL=F \
   --strategy cl_hmm_bb_rsi_v1_optimized \
-  --train-months 24 \
-  --test-months 6 \
-  --step-months 6</code></pre>
+  --windows 5 \
+  --metric sharpe_ratio</code></pre>
                 </div>
               </li>
               <li>
                 <div>
-                  <strong>View the fold-by-fold report</strong>
-                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge wft report \
-  --strategy cl_hmm_bb_rsi_v1_optimized</code></pre>
+                  <strong>View the fold-by-fold report (JSON)</strong>
+                  <pre><code>FORGE_CONFIG=./forge.yaml uv run forge optimize walk-forward CL=F \
+  --strategy cl_hmm_bb_rsi_v1_optimized \
+  --windows 5 --json | jq '.windows'</code></pre>
                 </div>
               </li>
             </ol>
@@ -834,7 +837,7 @@ forge data fetch SPY QQQ --period 5y</code></pre>
                   <strong style="display:block;margin-bottom:0.4rem;">What do HMM state numbers mean?</strong>
                   <p style="font-size:0.88rem;color:var(--text2);line-height:1.7;">
                     HMM state numbers (0, 1, ...) can change between training runs.
-                    Run <code>forge hmm inspect --strategy &lt;strategy_id&gt;</code> after backtesting
+                    Run <code>forge backtest run &lt;SYMBOL&gt; --strategy &lt;strategy_id&gt; --regime</code>
                     to view the mean return and volatility for each state and identify which is the bullish regime.
                   </p>
                 </div>
@@ -843,7 +846,7 @@ forge data fetch SPY QQQ --period 5y</code></pre>
                 <div>
                   <strong style="display:block;margin-bottom:0.4rem;">How do I connect to TradingView?</strong>
                   <p style="font-size:0.88rem;color:var(--text2);line-height:1.7;">
-                    Run <code>forge pinescript generate --strategy &lt;strategy_id&gt;</code> to generate
+                    Run <code>forge pine generate --strategy &lt;strategy_id&gt;</code> to generate
                     TradingView Pine Script v6 code. Set up a Webhook alert in TradingView pointing to
                     alpha-strike for automated order execution.
                   </p>
@@ -856,7 +859,7 @@ forge data fetch SPY QQQ --period 5y</code></pre>
                     100–200 trials is sufficient for strategies with 3–5 parameters.
                     For more parameters or higher precision, use 500–1000 trials.
                   </p>
-                  <pre><code>forge optimize --strategy cl_hmm_bb_rsi_v1 --trials 500 --metric sharpe_ratio</code></pre>
+                  <pre><code>forge optimize run CL=F --strategy cl_hmm_bb_rsi_v1 --trials 500 --metric sharpe_ratio --save</code></pre>
                 </div>
               </li>
             </ul>


### PR DESCRIPTION
## 概要

`templates/privacy.html.j2` / `templates/terms.html.j2` / `templates/tutorial-strategy.html.j2` の3テンプレートと `seo.yaml` を、現行の生成 HTML（Whop OAuth + 新 `forge` CLI 階層）に同期しました。

## 背景

PR #233 / #234 で `ja/*.html` / `en/*.html` の **生成 HTML が直接編集** されており、対応するテンプレート (`templates/*.html.j2`) が更新されていませんでした。そのため、誰かが `uv run python build.py` を実行すると以下が発生する状態でした:

- privacy.html / terms.html が LemonSqueezy 版に巻き戻る
- tutorial-strategy.html が旧 CLI (`forge license activate` / `forge init` / `forge wft run` / `forge hmm inspect` / `forge pinescript generate` など) に巻き戻る

本 PR ではテンプレート側を **現在の生成 HTML と一致する状態に同期** し、build.py を実行しても差分が出ない状態に揃えました。

## 同期した内容

### `templates/privacy.html.j2`
- 1.1: LemonSqueezy → Whop（Stripe 等の決済プロバイダ言及を追加）
- 1.2: 「ライセンス認証時に収集する情報」→「認証時に収集・送受信する情報」（OAuth 2.0 PKCE フローで送受信される情報を箇条書きで明記）
- 2: 「ライセンスキーの発行・認証・管理」→「メンバーシップの認証・有効性確認」
- 3: LemonSqueezy → Whop
- 4: 「ローカル認証キャッシュ」を `~/.forge/credentials.json` と `forge system auth logout` に更新
- 最終更新日: 2026年4月25日 → 2026年5月12日

### `templates/terms.html.j2`
- 5: 「ライセンスキー」→「メンバーシップ」
- 6.1: 「Whop で有効なメンバーシップ」、「1 Whop アカウントにつき 1 ユーザー」、「Lifetime プラン」
- 6.2: 禁止事項を Whop アカウント/トークン譲渡禁止へ変更
- 6.3: 「ライセンスの移行」→「マシン変更時」（`forge license deactivate` → `forge system auth logout` + `forge system auth login`）
- 最終更新日: 2026年4月25日 → 2026年5月12日

### `templates/tutorial-strategy.html.j2`

| 変更前 | 変更後 |
|---|---|
| `forge license activate YOUR_LICENSE_KEY` | `forge system auth login`（Whop OAuth） |
| `forge init` | `forge system init` |
| `forge optimize --strategy X --symbol Y --trials N --metric M` | `forge optimize run Y --strategy X --trials N --metric M --save` |
| `forge optimize results --strategy X --top 5` | `forge optimize history --strategy X`（タイムスタンプ形式の出力例に変更） |
| `forge optimize apply --strategy X --rank 1 --output ...` | `forge optimize apply <result_file> --to-strategy X` |
| `forge wft run --train-months 24 --test-months 6 --step-months 6` | `forge optimize walk-forward --windows 5 --metric sharpe_ratio` |
| `forge wft report --strategy X` | `forge optimize walk-forward ... --json \| jq '.windows'` |
| `forge hmm inspect --strategy X` | `forge backtest run <SYMBOL> --strategy X --regime` |
| `forge pinescript generate --strategy X` | `forge pine generate --strategy X` |

### `seo.yaml`
- privacy ja: description / og_description で「ライセンス認証」→「認証」
- privacy en: description / og_description で「license activation」→「authentication」

## テスト計画

- [x] `uv run python build.py` を実行
- [x] ja/privacy.html・ja/terms.html・ja/tutorial-strategy.html および対応する en/ 版に差分が出ないこと（=テンプレートが現行生成 HTML と一致）を確認
- [ ] マージ後にデプロイされた alforgelabs.com で privacy / terms / tutorial-strategy の表示が変わっていないこと

## 注意

- `templates/install.html.j2` および `ja/install.html` / `en/install.html` は別 PR #236 で同様の同期を行うため、本 PR では一切触れていません。
- 関連: #233 (install / tutorial-strategy 直接編集), #234 (privacy / terms 直接編集)