### PR TITLE
fix: tutorial-strategy のインストール手順を curl install.sh に修正

### DIFF
--- a/en/tutorial-strategy.html
+++ b/en/tutorial-strategy.html
@@ -211,10 +211,10 @@
                 <div>
                   <strong>Install alpha-forge</strong>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                    After purchase, sign in with your Whop account (OAuth 2.0 PKCE) — the browser opens automatically.
+                    The installer downloads the latest binary (macOS / Linux shown). See the <a href="install.html">installation guide</a> for Windows or manual placement. Then sign in with your Whop account (OAuth 2.0 PKCE) — the browser opens automatically.
                   </p>
-                  <pre><code># Install with uv (includes all dependencies)
-uv add alpha-forge
+                  <pre><code># Install the latest binary (macOS / Linux)
+curl -sSL https://alforge-labs.github.io/install.sh | bash
 
 # Sign in via Whop OAuth
 forge system auth login</code></pre>

--- a/ja/tutorial-strategy.html
+++ b/ja/tutorial-strategy.html
@@ -210,10 +210,10 @@
                 <div>
                   <strong>alpha-forge を取得してインストール</strong>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                    購入後、Whop アカウントで OAuth 2.0 PKCE 認証を行います（ブラウザが自動で開きます）。
+                    インストーラーが最新バイナリをダウンロードします（macOS / Linux 例）。Windows / 手動配置は <a href="install.html">インストールガイド</a> を参照してください。続けて Whop アカウントで OAuth 2.0 PKCE 認証を行います（ブラウザが自動で開きます）。
                   </p>
-                  <pre><code># uv で依存関係を含めてインストール
-uv add alpha-forge
+                  <pre><code># 最新バイナリをインストール（macOS / Linux）
+curl -sSL https://alforge-labs.github.io/install.sh | bash
 
 # Whop アカウントで認証
 forge system auth login</code></pre>

--- a/templates/tutorial-strategy.html.j2
+++ b/templates/tutorial-strategy.html.j2
@@ -158,10 +158,10 @@
                 <div>
                   <strong>alpha-forge を取得してインストール</strong>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                    購入後、Whop アカウントで OAuth 2.0 PKCE 認証を行います（ブラウザが自動で開きます）。
+                    インストーラーが最新バイナリをダウンロードします（macOS / Linux 例）。Windows / 手動配置は <a href="install.html">インストールガイド</a> を参照してください。続けて Whop アカウントで OAuth 2.0 PKCE 認証を行います（ブラウザが自動で開きます）。
                   </p>
-                  <pre><code># uv で依存関係を含めてインストール
-uv add alpha-forge
+                  <pre><code># 最新バイナリをインストール（macOS / Linux）
+curl -sSL https://alforge-labs.github.io/install.sh | bash
 
 # Whop アカウントで認証
 forge system auth login</code></pre>
@@ -556,10 +556,10 @@ Avg Sharpe: 1.10  |  Avg CAGR: 13.9%  |  WF Efficiency: 89%</code></pre>
                 <div>
                   <strong>Install alpha-forge</strong>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                    After purchase, sign in with your Whop account (OAuth 2.0 PKCE) — the browser opens automatically.
+                    The installer downloads the latest binary (macOS / Linux shown). See the <a href="install.html">installation guide</a> for Windows or manual placement. Then sign in with your Whop account (OAuth 2.0 PKCE) — the browser opens automatically.
                   </p>
-                  <pre><code># Install with uv (includes all dependencies)
-uv add alpha-forge
+                  <pre><code># Install the latest binary (macOS / Linux)
+curl -sSL https://alforge-labs.github.io/install.sh | bash
 
 # Sign in via Whop OAuth
 forge system auth login</code></pre>


### PR DESCRIPTION
## 概要

`templates/tutorial-strategy.html.j2`（ja/en 両セクション）に記載されていた `uv add alpha-forge` は誤り。alpha-forge は PyPI パッケージではなく GitHub Releases 配布のバイナリのため、正しいインストール方法である `curl -sSL https://alforge-labs.github.io/install.sh | bash` に修正しました。

## 変更点

- `templates/tutorial-strategy.html.j2`
  - ja「インストールと初期設定」のコード例を `uv add alpha-forge` → `curl ... install.sh | bash` に変更。Windows / 手動配置は `install.html` へリンクで補足。
  - en も同じ修正（"Install with uv" → "Install the latest binary (macOS / Linux)" + link to installation guide）。
- 生成物 `ja/tutorial-strategy.html` / `en/tutorial-strategy.html` も `uv run python build.py` で再生成して同梱。

## 動作確認

- [x] `uv run python build.py` 成功
- [x] 生成 HTML に `curl -sSL https://alforge-labs.github.io/install.sh | bash` が出力されていることを grep で確認
- [x] `uv add alpha-forge` / `pip install alpha-forge` が `templates/` / `mkdocs_src/` 配下に残存していないことを確認