### PR TITLE
fix(install): forge.dist 全体コピー方式に切り替えてインストール後の動作を修復

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 # AlphaForge forge インストーラー
-# Usage: bash <(curl -sSL https://alforge-labs.github.io/install.sh)
-#        bash <(curl -sSL https://alforge-labs.github.io/install.sh) --dry-run
+# Usage:
+#   bash <(curl -sSL https://alforge-labs.github.io/install.sh)
+#   bash <(curl -sSL https://alforge-labs.github.io/install.sh) --dry-run
+#
+# 実装メモ:
+#   - Nuitka standalone ビルドの forge.dist/ は forge バイナリ + 1100+ の dylib /
+#     データファイルから成り、forge は @executable_path 相対で同居 dylib を
+#     ロードする。よってバイナリ単体ではなく forge.dist/ ディレクトリ全体を
+#     インストール先に置き、forge を symlink で PATH に通すレイアウトを取る。
+#   - macOS Gatekeeper は curl 経由 DL に com.apple.quarantine xattr を付ける
+#     ので、未署名バイナリの抑止解除のため xattr -dr で除去する。
+#   - curl | bash 経由実行では stdin がスクリプト本文に占有されているため、
+#     対話 read は </dev/tty で TTY 直結する。
+
 set -euo pipefail
 
 DRY_RUN=false
@@ -11,12 +23,31 @@ if [[ "${1:-}" == "--dry-run" ]]; then
 fi
 
 REPO="alforge-labs/alforge-labs.github.io"
-DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
-INSTALL_DIR=""
+
+# bin: 実行ファイル symlink を置く場所 (PATH に通っているべき)
+DEFAULT_BIN_DIR="${HOME}/.local/bin"
+BIN_DIR=""
+
+# lib: forge.dist/ 配下の全ファイルを置く場所 (バイナリ + dylib + データ)
+# bin 配下に「forge.dist」名で展開し、forge -> forge.dist/forge の symlink を貼る
+DIST_NAME="forge.dist"
 
 ok()   { echo "  ✓ $*"; }
 info() { echo "  → $*"; }
 fail() { printf "  ✗ %b\n" "$*" >&2; exit 1; }
+
+# curl | bash の stdin はスクリプト本文に占有されているため、対話読みは TTY 直結。
+# TTY が無い (CI 等) なら空文字を返してデフォルトにフォールバック。
+prompt_tty() {
+  local prompt_msg=$1
+  local reply=""
+  # /dev/tty が無い・読めない環境（CI, --no-tty 等）では即フォールバック。
+  # bash のリダイレクト失敗は read 単体への 2>/dev/null では捕まらないため、
+  # ブロック全体を { ... } 2>/dev/null で囲む。
+  # shellcheck disable=SC2229
+  { read -r -p "${prompt_msg}" reply </dev/tty; } 2>/dev/null || reply=""
+  printf '%s' "${reply}"
+}
 
 # ── 1. OS + アーキテクチャ検出 ──────────────────────────────────
 OS="$(uname -s)"
@@ -69,62 +100,120 @@ if [ "${DRY_RUN}" = "false" ]; then
   curl -sSfL "${DOWNLOAD_URL}" -o "${TMP_DIR}/archive.${EXT}" \
     || fail "ダウンロードに失敗しました。\n  ${DOWNLOAD_URL}"
   tar xzf "${TMP_DIR}/archive.${EXT}" -C "${TMP_DIR}"
-  BINARY="${TMP_DIR}/forge.dist/forge"
-  if [ ! -f "${BINARY}" ]; then
-    fail "展開後にバイナリが見つかりません"
+  if [ ! -d "${TMP_DIR}/forge.dist" ]; then
+    fail "展開後に forge.dist ディレクトリが見つかりません"
+  fi
+  if [ ! -x "${TMP_DIR}/forge.dist/forge" ]; then
+    fail "展開後に forge.dist/forge が実行可能ファイルでありません"
   fi
   ok "ダウンロード・展開完了"
 else
-  echo "  [dry-run] curl -L ${DOWNLOAD_URL} → tar xzf → ${TMP_DIR}/forge.dist/forge"
-  BINARY="${TMP_DIR}/forge.dist/forge"
+  echo "  [dry-run] curl -L ${DOWNLOAD_URL} → tar xzf → ${TMP_DIR}/forge.dist/"
 fi
 
-# ── 4. インストール先を確定 ──────────────────────────────────────
-echo ""
-echo "インストール先を選択してください（デフォルト: ${DEFAULT_INSTALL_DIR}）"
-if [ "${DRY_RUN}" = "true" ]; then
-  INSTALL_DIR="${DEFAULT_INSTALL_DIR}"
-  echo "  [dry-run] インストール先: ${INSTALL_DIR}（デフォルト）"
-else
-  read -r -p "  /usr/local/bin にインストールしますか？ [y/N] " REPLY
-  if [[ "${REPLY}" =~ ^[Yy]$ ]]; then
-    INSTALL_DIR="/usr/local/bin"
-  else
-    INSTALL_DIR="${DEFAULT_INSTALL_DIR}"
+# ── 4. macOS Gatekeeper の quarantine 属性を除去 ─────────────────
+# curl 経由でダウンロードしたバイナリには com.apple.quarantine xattr が付き、
+# 未署名のため起動時 Abort trap: 6 で必ず死ぬ。展開直後に除去しておく。
+if [ "${DRY_RUN}" = "false" ] && [ "${OS}" = "Darwin" ]; then
+  if command -v xattr >/dev/null 2>&1; then
+    xattr -dr com.apple.quarantine "${TMP_DIR}/forge.dist" 2>/dev/null || true
+    ok "macOS quarantine 属性を除去しました"
   fi
 fi
 
-if [ "${DRY_RUN}" = "false" ]; then
-  mkdir -p "${INSTALL_DIR}"
-  if [ -w "${INSTALL_DIR}" ]; then
-    install -m 755 "${BINARY}" "${INSTALL_DIR}/forge"
+# ── 5. インストール先を確定 ──────────────────────────────────────
+echo ""
+echo "インストール先を選択してください（デフォルト: ${DEFAULT_BIN_DIR}）"
+if [ "${DRY_RUN}" = "true" ]; then
+  BIN_DIR="${DEFAULT_BIN_DIR}"
+  echo "  [dry-run] インストール先: ${BIN_DIR}（デフォルト）"
+else
+  REPLY="$(prompt_tty "  /usr/local/bin にインストールしますか？ [y/N] ")"
+  if [[ "${REPLY}" =~ ^[Yy]$ ]]; then
+    BIN_DIR="/usr/local/bin"
   else
-    info "sudo でインストールします..."
-    if ! sudo install -m 755 "${BINARY}" "${INSTALL_DIR}/forge"; then
-      info "sudo 失敗。${DEFAULT_INSTALL_DIR} にフォールバックします"
-      INSTALL_DIR="${DEFAULT_INSTALL_DIR}"
-      mkdir -p "${INSTALL_DIR}"
-      install -m 755 "${BINARY}" "${INSTALL_DIR}/forge"
+    BIN_DIR="${DEFAULT_BIN_DIR}"
+  fi
+fi
+
+# forge.dist の同居先（bin と同階層）。ここに 1100+ ファイル一式を展開する。
+DIST_DIR="$(dirname "${BIN_DIR}")/share/alpha-forge/${DIST_NAME}"
+SYMLINK_PATH="${BIN_DIR}/forge"
+
+# ── 6. インストール ──────────────────────────────────────────────
+if [ "${DRY_RUN}" = "false" ]; then
+  info "forge.dist 全体を ${DIST_DIR} に展開します"
+  if ! mkdir -p "${BIN_DIR}" 2>/dev/null; then
+    info "sudo で ${BIN_DIR} を作成します..."
+    sudo mkdir -p "${BIN_DIR}"
+  fi
+  if ! mkdir -p "$(dirname "${DIST_DIR}")" 2>/dev/null; then
+    info "sudo で $(dirname "${DIST_DIR}") を作成します..."
+    sudo mkdir -p "$(dirname "${DIST_DIR}")"
+  fi
+
+  # 既存 install があれば一旦退避してアトミックに置換（途中失敗時の救済余地）
+  if [ -d "${DIST_DIR}" ]; then
+    BACKUP="${DIST_DIR}.bak.$$"
+    info "既存インストール (${DIST_DIR}) を ${BACKUP} に退避"
+    if [ -w "$(dirname "${DIST_DIR}")" ]; then
+      mv "${DIST_DIR}" "${BACKUP}"
+    else
+      sudo mv "${DIST_DIR}" "${BACKUP}"
     fi
   fi
-  ok "forge を ${INSTALL_DIR}/forge に配置しました"
+
+  # cp -R の方が dotfiles を含めて素直にコピーできる
+  if [ -w "$(dirname "${DIST_DIR}")" ]; then
+    cp -R "${TMP_DIR}/forge.dist" "${DIST_DIR}"
+  else
+    info "sudo でコピーします..."
+    sudo cp -R "${TMP_DIR}/forge.dist" "${DIST_DIR}"
+  fi
+
+  # quarantine 属性が再付与されることがあるので念のためインストール先でも除去
+  if [ "${OS}" = "Darwin" ] && command -v xattr >/dev/null 2>&1; then
+    xattr -dr com.apple.quarantine "${DIST_DIR}" 2>/dev/null \
+      || sudo xattr -dr com.apple.quarantine "${DIST_DIR}" 2>/dev/null \
+      || true
+  fi
+
+  # symlink を BIN_DIR/forge に貼る（既存ファイル・symlink は ln -sfn で上書き）
+  if [ -w "${BIN_DIR}" ]; then
+    ln -sfn "${DIST_DIR}/forge" "${SYMLINK_PATH}"
+  else
+    info "sudo で symlink を貼ります..."
+    sudo ln -sfn "${DIST_DIR}/forge" "${SYMLINK_PATH}"
+  fi
+
+  ok "forge を ${SYMLINK_PATH} に配置しました (実体: ${DIST_DIR}/forge)"
+
+  # 古いバックアップは成功後にクリーンアップ
+  if [ -n "${BACKUP:-}" ] && [ -d "${BACKUP}" ]; then
+    if [ -w "$(dirname "${BACKUP}")" ]; then
+      rm -rf "${BACKUP}"
+    else
+      sudo rm -rf "${BACKUP}"
+    fi
+  fi
 else
-  echo "  [dry-run] install -m 755 forge → ${INSTALL_DIR}/forge"
+  echo "  [dry-run] cp -R forge.dist → ${DIST_DIR}"
+  echo "  [dry-run] ln -sfn ${DIST_DIR}/forge → ${SYMLINK_PATH}"
 fi
 
-# ── 5. PATH 自動追記 ─────────────────────────────────────────────
-if [[ ":${PATH}:" != *":${INSTALL_DIR}:"* ]]; then
-  SHELL_NAME="$(basename "${SHELL:-bash}")"
-  case "${SHELL_NAME}" in
-    zsh)  RC="${HOME}/.zshrc" ;;
-    fish) RC="${HOME}/.config/fish/config.fish" ;;
-    *)    RC="${HOME}/.bashrc" ;;
-  esac
+# ── 7. PATH 自動追記 ─────────────────────────────────────────────
+SHELL_NAME="$(basename "${SHELL:-bash}")"
+case "${SHELL_NAME}" in
+  zsh)  RC="${HOME}/.zshrc" ;;
+  fish) RC="${HOME}/.config/fish/config.fish" ;;
+  *)    RC="${HOME}/.bashrc" ;;
+esac
 
-  PATH_LINE="export PATH=\"${INSTALL_DIR}:\${PATH}\""
+if [[ ":${PATH}:" != *":${BIN_DIR}:"* ]]; then
+  PATH_LINE="export PATH=\"${BIN_DIR}:\${PATH}\""
 
   if [ "${DRY_RUN}" = "false" ]; then
-    if ! grep -qF "${INSTALL_DIR}" "${RC}" 2>/dev/null; then
+    if ! grep -qF "${BIN_DIR}" "${RC}" 2>/dev/null; then
       printf '\n# AlphaForge forge\n%s\n' "${PATH_LINE}" >> "${RC}"
       ok "PATH を ${RC} に追記しました"
     else
@@ -137,48 +226,48 @@ else
   ok "PATH はすでに設定済みです"
 fi
 
-# ── 6. ライセンスアクティベーション ──────────────────────────────
-echo ""
-echo "ライセンスアクティベーション"
-echo "  Whop でご購入のライセンスキーを入力してください。"
-if [ "${DRY_RUN}" = "true" ]; then
-  echo "  [dry-run] ライセンスキー入力をスキップ"
-  LICENSE_KEY=""
-else
-  read -r -p "  ライセンスキー（Enter でスキップ）: " LICENSE_KEY
-fi
-
-if [ -n "${LICENSE_KEY}" ]; then
-  if [ "${DRY_RUN}" = "false" ]; then
-    if "${INSTALL_DIR}/forge" license activate "${LICENSE_KEY}"; then
-      ok "ライセンス認証が完了しました"
-    else
-      echo "  ⚠ ライセンス認証に失敗しました。後から再実行してください:"
-      echo "      forge license activate <YOUR_LICENSE_KEY>"
-    fi
-  else
-    echo "  [dry-run] forge license activate ${LICENSE_KEY}"
-  fi
-else
-  echo "  → スキップしました。後から実行してください:"
-  echo "      forge license activate <YOUR_LICENSE_KEY>"
-fi
-
-# ── 7. 確認 ─────────────────────────────────────────────────────
+# ── 8. 動作確認（フルパス実行で dylib 解決を検証）─────────────────
 echo ""
 if [ "${DRY_RUN}" = "false" ]; then
-  if "${INSTALL_DIR}/forge" --version >/dev/null 2>&1; then
-    ok "インストール完了！"
-    echo ""
-    echo "  PATH を反映するには新しいターミナルを開くか、以下を実行してください:"
-    echo "    source ${RC:-~/.zshrc}"
-    echo ""
-    echo "  使い方: forge --help"
+  if "${SYMLINK_PATH}" --version >/dev/null 2>&1; then
+    ok "インストール完了！ ($(${SYMLINK_PATH} --version))"
   else
-    echo "  ⚠ forge コマンドの確認に失敗しました。PATH を確認してください:"
-    echo "    export PATH=\"${INSTALL_DIR}:\${PATH}\""
-    echo "    forge --version"
+    fail "forge コマンドの動作確認に失敗しました。\n  手動確認: ${SYMLINK_PATH} --version\n  問題が続く場合: $(${SYMLINK_PATH} --version 2>&1 | head -5)"
   fi
 else
   ok "ドライランが完了しました。実際にインストールするには --dry-run を外して再実行してください。"
+fi
+
+# ── 9. ライセンス認証の案内（forge system auth login）────────────
+echo ""
+echo "次のステップ: ライセンス認証"
+echo "  AlphaForge は Whop OAuth でライセンス認証を行います。"
+echo "  以下のコマンドを実行するとブラウザが開き、Whop で購入したアカウントで認証できます："
+echo ""
+echo "      forge system auth login"
+echo ""
+echo "  認証状態を確認:"
+echo "      forge system auth status"
+
+# ── 10. シェルへの反映案内 ──────────────────────────────────────
+echo ""
+if [ "${DRY_RUN}" = "false" ]; then
+  # 現在のシェルから PATH を反映するための手順
+  if [[ ":${PATH}:" != *":${BIN_DIR}:"* ]]; then
+    echo "PATH を現在のシェルに反映するには、次のいずれかを実行してください："
+    echo "    source ${RC}"
+    case "${SHELL_NAME}" in
+      zsh)  echo "    # または: rehash (zsh のコマンドハッシュをクリア)" ;;
+      bash) echo "    # または: hash -r (bash のコマンドハッシュをクリア)" ;;
+    esac
+    echo "    # または新しいターミナルを開く"
+  else
+    # 既に PATH に入っているが、シェルのコマンドキャッシュが古い場合に備えて案内
+    case "${SHELL_NAME}" in
+      zsh)  echo "現在のシェルで forge が見つからない場合は 'rehash' を実行してください。" ;;
+      bash) echo "現在のシェルで forge が見つからない場合は 'hash -r' を実行してください。" ;;
+    esac
+  fi
+  echo ""
+  echo "使い方: forge --help"
 fi


### PR DESCRIPTION
## Reported Issues (v0.3.1 インストール時)

ユーザーから 3 件の致命的問題が報告された：

```
$ curl -sSL https://alforge-labs.github.io/install.sh | bash
  → プラットフォーム: Darwin-arm64 → forge-macos-arm64
  → 最新バージョンを確認中...
  ✓ 最新バージョン: v0.3.1
  → ダウンロード中: ...
  ✓ ダウンロード・展開完了

インストール先を選択してください（デフォルト: /Users/sakae/.local/bin）
  ✓ forge を /Users/sakae/.local/bin/forge に配置しました   ← ① プロンプトがスキップされている
  ✓ PATH はすでに設定済みです

ライセンスアクティベーション
  Whop でご購入のライセンスキーを入力してください。
  → スキップしました。後から実行してください:
      forge license activate <YOUR_LICENSE_KEY>           ← ② 廃止済みコマンド

bash: line 182: 95585 Abort trap: 6  "${INSTALL_DIR}/forge" --version
  ⚠ forge コマンドの確認に失敗しました。                      ← ③ そもそも起動できていない
```

## 根本原因の分析

### ① 対話プロンプトがスキップ

`curl|bash` 経由実行では bash の stdin はスクリプト本文に占有されているため、
`read -r -p` はパイプから空文字を読んで即返ってしまう。

### ② ライセンス活性化が旧版

`forge license activate <KEY>` は廃止済みで、現行 CLI には license トップ
コマンドが存在しない。認証は `forge system auth login`（Whop OAuth、
ブラウザ起動）に統一されている。

```
$ forge system auth --help
Commands:
  check   認証状態の検証
  login   Whop で認証する（ブラウザが開きます）
  logout  ログアウトして認証情報を削除する
  status  現在の認証状態を表示する
```

### ③ Abort trap: 6 で起動不能

**最重要バグ**。旧 install.sh は `install -m 755 ${TMP}/forge.dist/forge ${INSTALL_DIR}/forge` と「バイナリ単体」だけをコピーしていた。しかし Nuitka standalone の forge は **`@executable_path/libpython3.12.dylib` 等 1100+ の同居 dylib・データファイル**に依存しており、ローカル再現で確認：

```
$ /tmp/forge-only-test/forge --version
dyld[96607]: Library not loaded: @executable_path/libpython3.12.dylib
  Referenced from: /private/tmp/forge-only-test/forge
  Reason: tried: '/private/tmp/forge-only-test/libpython3.12.dylib' (no such file)
```

バイナリ単体では dyld が dylib を見つけられず SIGABRT (Abort trap: 6)。
さらに curl ダウンロードに付く `com.apple.quarantine` xattr も Gatekeeper の
抑止に寄与しうる。

## 修正内容

### 1. `forge.dist` 全体コピー方式に変更

```
${BIN_DIR}/forge → symlink → ${DIST_BASE}/share/alpha-forge/forge.dist/forge
                                                                ├── libpython3.12.dylib
                                                                ├── alpha_forge/
                                                                ├── numpy/, pandas/, sklearn/...
                                                                └── (全 1153 ファイル)
```

- `${BIN_DIR}/forge` は薄い symlink のみ
- 実体（forge.dist 全 1153 ファイル）は `share/alpha-forge/forge.dist/` に展開
- 既存 install があれば `.bak.$$` にアトミック退避 → 成功時のみ削除

### 2. `prompt_tty()` ヘルパで /dev/tty 直結

```bash
prompt_tty() {
  local reply=""
  # bash のリダイレクト失敗は read 単体への 2>/dev/null では捕まらないため、
  # ブロック全体を { ... } 2>/dev/null で囲む。
  { read -r -p "${prompt_msg}" reply </dev/tty; } 2>/dev/null || reply=""
  printf '%s' "${reply}"
}
```

これで `curl|bash` でも対話プロンプトが動作。/dev/tty が無い CI 等では
silent にフォールバック。

### 3. ライセンス案内を `forge system auth login` に更新

```
次のステップ: ライセンス認証
  AlphaForge は Whop OAuth でライセンス認証を行います。
  以下のコマンドを実行するとブラウザが開き、Whop で購入したアカウントで認証できます：

      forge system auth login

  認証状態を確認:
      forge system auth status
```

### 4. macOS Gatekeeper quarantine 除去

```bash
xattr -dr com.apple.quarantine "${TMP_DIR}/forge.dist" 2>/dev/null || true
# install 後にも念のため
xattr -dr com.apple.quarantine "${DIST_DIR}" 2>/dev/null || true
```

### 5. シェル反映案内の改善

```
PATH を現在のシェルに反映するには、次のいずれかを実行してください：
    source ~/.zshrc
    # または: rehash (zsh のコマンドハッシュをクリア)
    # または新しいターミナルを開く
```

## Test

実機テスト（一時 HOME 環境でエンドツーエンド）：

```
✅ ダウンロード・展開・quarantine 除去
✅ forge.dist 全 1153 ファイルが ~/.local/share/alpha-forge/forge.dist/ に展開
✅ ~/.local/bin/forge → forge.dist/forge シンボリックリンク作成
✅ ${BIN_DIR}/forge --version → "AlphaForge, version 0.3.1" 出力（前回は Abort trap: 6）
✅ ライセンス案内が forge system auth login に更新
✅ "Device not configured" エラーメッセージも完全に silence
```

`bash -n install.sh` も OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)