### PR TITLE
fix(landing): Trial プランカードの CTA 挙動を整理

### DIFF
--- a/homepage-components.jsx
+++ b/homepage-components.jsx
@@ -314,20 +314,17 @@ function TrialBanner({ plan, comingSummer, lang }) {
       <div className="trial-banner-cta">
         <a
           href={plan.url}
-          target="_blank"
-          rel="noopener noreferrer"
           className="btn-primary"
           style={{ justifyContent: 'center' }}
         >
           {plan.ctaLabel}
         </a>
-        <a
-          href={`/${lang}/install.html`}
+        <span
           className="trial-banner-install-link"
           style={{ display: 'block', fontSize: '0.85em', textAlign: 'center', marginTop: '0.4rem', color: 'var(--text2)' }}
         >
           {plan.ctaHint}
-        </a>
+        </span>
         <div className="trial-banner-status">{comingSummer}</div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

ランディング pricing セクションの Trial プランカードで、2 つの導線の挙動がバラバラだったのを統一します。

## 修正前

- 「インストール手順を見る」ボタン: \`target=\"_blank\"\` で **新規タブ** に \`/ja/install.html\` を開く（ユーザーから見ると「ポップアップ」表示）
- 「Whop 登録は不要です」テキスト: \`<a href=\"/ja/install.html\">\` で **同タブ** 遷移

メイン CTA とサブテキストで挙動がチグハグ。さらに 2 つ並んでいるのに飛び先は同じインストールページ、というのが冗長で混乱しやすい状態でした。

## 修正後

- 「インストール手順を見る」: \`target\` / \`rel\` を外し、**同タブ** で \`plan.url\` に遷移
- 「Whop 登録は不要です」: \`<a>\` → \`<span>\` に変更して **ただの注記テキスト** 化（遷移先が上のボタンと同じなので補助リンクは冗長）

## Test plan

- [x] diff は className 維持・スタイル維持の最小修正のみ
- [ ] Pages デプロイ完了後、本番でボタンを押すと**同じタブで** install.html に遷移することを確認
- [ ] 「Whop 登録は不要です」がカーソルを当てても**リンクではない**（pointer cursor 出ない）ことを確認