### PR TITLE
docs: CLAUDE.md に親 alpha-trade/CLAUDE.md への参照を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 alforge-labs.github.io のランディングページです。
 
+> 親 `alpha-trade/CLAUDE.md` の 9-rule template・プロジェクト固有ガイド・ワークツリー / GitHub Flow / TDD / `uv` 等のルールに従うこと。本ファイルには alforge-labs 固有の事項（ビルドシステム・テンプレート編集ルール）のみ記載する。なお、親 `alpha-trade/CLAUDE.md` 指針10「ドキュメント同期」で alpha-forge / alpha-strike の変更時に本リポジトリの MkDocs ビルドを実行する旨が規定されている。
+
 ## ビルドシステムの概要
 
 ```


### PR DESCRIPTION
## Summary
冒頭に親リポジトリの 9-rule template・プロジェクト固有ガイド・ワークツリー / GitHub Flow / TDD / `uv` 等の共通ルールへの委譲ノートを追加。親側の指針10「ドキュメント同期」で本リポジトリの MkDocs ビルドが規定されている旨も明記し、相互参照を強化した。

本ファイルは元々簡潔で内部重複はなかったため変更はこの 1 箇所のみ。

## Test plan
- [x] Markdown プレビューでフォーマット崩れがないこと