### PR TITLE
chore: 過去の seo.yaml / template 更新をビルド成果物に反映

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -45,23 +45,23 @@
           "@type": "Offer",
           "price": "0.00",
           "priceCurrency": "USD",
-          "name": "Trial"
+          "name": "Free"
         },
         {
           "@type": "Offer",
-          "price": "19.00",
+          "price": "9.00",
           "priceCurrency": "USD",
           "name": "Monthly"
         },
         {
           "@type": "Offer",
-          "price": "159.00",
+          "price": "99.00",
           "priceCurrency": "USD",
           "name": "Annual"
         },
         {
           "@type": "Offer",
-          "price": "299.00",
+          "price": "499.00",
           "priceCurrency": "USD",
           "name": "Lifetime"
         }
@@ -369,42 +369,42 @@
     }
 
     /* ── FREE START ── */
-    .trial-start {
+    .free-start {
       padding: 4.75rem 0;
       border-bottom: 1px solid var(--border);
       background:
         linear-gradient(180deg, var(--bg) 0%, var(--accent-bg) 100%);
     }
-    .trial-start-shell {
+    .free-start-shell {
       display: grid;
       grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
       gap: 2rem;
       align-items: stretch;
     }
-    .trial-start-copy {
+    .free-start-copy {
       display: flex;
       flex-direction: column;
       justify-content: center;
       gap: 1rem;
     }
-    .trial-start-title {
+    .free-start-title {
       color: var(--text);
       font-size: clamp(1.6rem, 3.2vw, 2.35rem);
       font-weight: 600;
       line-height: 1.15;
     }
-    .trial-start-subtitle {
+    .free-start-subtitle {
       max-width: 620px;
       color: var(--text2);
       font-size: 0.95rem;
       line-height: 1.8;
     }
-    .trial-start-limits {
+    .free-start-limits {
       display: flex;
       flex-wrap: wrap;
       gap: 0.45rem;
     }
-    .trial-start-limit {
+    .free-start-limit {
       border: 1px solid var(--accent-glow);
       border-radius: 100px;
       background: var(--surface);
@@ -413,14 +413,14 @@
       font-size: 0.68rem;
       padding: 0.25rem 0.65rem;
     }
-    .trial-start-actions {
+    .free-start-actions {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
       gap: 0.75rem;
       margin-top: 0.35rem;
     }
-    .trial-start-link {
+    .free-start-link {
       color: var(--text2);
       font-size: 0.86rem;
       text-decoration: none;
@@ -428,18 +428,18 @@
       padding-bottom: 0.1rem;
       transition: color 0.15s, border-color 0.15s;
     }
-    .trial-start-link:hover {
+    .free-start-link:hover {
       color: var(--accent);
       border-color: var(--accent);
     }
-    .trial-start-note {
+    .free-start-note {
       max-width: 620px;
       color: var(--text3);
       font-family: var(--mono);
       font-size: 0.7rem;
       line-height: 1.7;
     }
-    .trial-start-steps {
+    .free-start-steps {
       display: grid;
       grid-template-columns: 1fr;
       gap: 1px;
@@ -448,7 +448,7 @@
       border-radius: var(--r);
       background: var(--border);
     }
-    .trial-start-step {
+    .free-start-step {
       min-height: 132px;
       background: var(--surface);
       padding: 1.35rem;
@@ -459,21 +459,21 @@
       align-content: start;
       transition: background 0.2s;
     }
-    .trial-start-step:hover { background: var(--surface-h); }
-    .trial-start-step-num {
+    .free-start-step:hover { background: var(--surface-h); }
+    .free-start-step-num {
       grid-row: span 2;
       color: var(--accent);
       font-family: var(--mono);
       font-size: 0.72rem;
       letter-spacing: 0.08em;
     }
-    .trial-start-step-title {
+    .free-start-step-title {
       color: var(--text);
       font-size: 0.98rem;
       font-weight: 600;
       line-height: 1.35;
     }
-    .trial-start-step-desc {
+    .free-start-step-desc {
       color: var(--text2);
       font-size: 0.84rem;
       line-height: 1.65;
@@ -667,7 +667,7 @@
     }
 
     /* ── FREE BANNER ── */
-    .trial-banner {
+    .free-banner {
       margin-top: 2rem;
       border: 1px dashed rgba(0,228,154,0.35);
       border-radius: var(--r);
@@ -675,37 +675,37 @@
       padding: 1.1rem 1.4rem;
       display: flex; align-items: center; gap: 1.2rem; flex-wrap: wrap;
     }
-    .trial-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
-    .trial-banner-body { flex: 1; min-width: 200px; }
-    .trial-banner-title {
+    .free-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
+    .free-banner-body { flex: 1; min-width: 200px; }
+    .free-banner-title {
       font-size: 0.95rem; font-weight: 600;
       display: flex; align-items: center; gap: 0.5rem;
     }
-    .trial-badge {
+    .free-badge {
       font-family: var(--mono); font-size: 0.6rem; letter-spacing: 0.08em;
       text-transform: uppercase;
       background: rgba(0,228,154,0.12); color: var(--accent);
       border: 1px solid rgba(0,228,154,0.25); border-radius: 4px; padding: 1px 6px;
     }
-    .trial-banner-desc {
+    .free-banner-desc {
       margin-top: 0.3rem; color: var(--text2);
       font-size: 0.82rem; line-height: 1.5;
     }
-    .trial-banner-pills {
+    .free-banner-pills {
       margin-top: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.4rem;
     }
-    .trial-pill {
+    .free-pill {
       font-size: 0.68rem; padding: 2px 8px; border-radius: 20px;
       border: 1px solid var(--border); color: var(--text2);
     }
-    .trial-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
-    .trial-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
-    .trial-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
-    .trial-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
-    .trial-banner-cta .btn-secondary {
+    .free-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
+    .free-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
+    .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
+    .free-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
+    .free-banner-cta .btn-secondary {
       width: 100%; justify-content: center;
     }
-    .trial-banner-status {
+    .free-banner-status {
       margin-top: 0.35rem;
       color: var(--text3);
       font-family: var(--mono);
@@ -729,11 +729,11 @@
     }
     .comparison-table thead tr { border-bottom: 1px solid var(--border); }
     .comparison-th-feature { padding: 0.5rem 0.75rem; text-align: left; font-weight: 600; font-size: 0.78rem; width: 48%; }
-    .comparison-th-trial    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
-    .comparison-th-lifetime    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
+    .comparison-th-free    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
+    .comparison-th-paid    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
     .comparison-td-feature { padding: 0.5rem 0.75rem; color: var(--text2); border-bottom: 1px solid rgba(255,255,255,0.04); }
-    .comparison-td-trial    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
-    .comparison-td-lifetime    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-free    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-paid    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
     .comparison-table tbody tr:last-child td { border-bottom: none; }
     .comparison-table tbody tr:nth-child(even) td { background: rgba(255,255,255,0.015); }
     .cmp-ok    { color: var(--accent); }
@@ -1042,19 +1042,19 @@
       .trust-safety { padding: 4.5rem 0; }
       .trust-safety-grid { grid-template-columns: 1fr; }
       .trust-safety-card { min-height: auto; }
-      .trial-start { padding: 4rem 0; }
-      .trial-start-shell { grid-template-columns: 1fr; }
-      .trial-start-actions { align-items: stretch; }
-      .trial-start-actions .btn-primary,
-      .trial-start-actions .btn-secondary {
+      .free-start { padding: 4rem 0; }
+      .free-start-shell { grid-template-columns: 1fr; }
+      .free-start-actions { align-items: stretch; }
+      .free-start-actions .btn-primary,
+      .free-start-actions .btn-secondary {
         width: 100%;
         justify-content: center;
         text-align: center;
       }
-      .trial-start-link { width: fit-content; }
-      .trial-banner { flex-direction: column; align-items: flex-start; }
-      .trial-banner-cta { width: 100%; }
-      .trial-banner-cta .btn-secondary { width: 100%; }
+      .free-start-link { width: fit-content; }
+      .free-banner { flex-direction: column; align-items: flex-start; }
+      .free-banner-cta { width: 100%; }
+      .free-banner-cta .btn-secondary { width: 100%; }
       .nav-page-link { padding: 0 0.55rem; }
       .lang-btn { padding: 0 0.55rem; }
       .follow-btn-nav {

--- a/en/install.html
+++ b/en/install.html
@@ -87,8 +87,8 @@
     <div class="lang-en">
       
       <div class="page-label">Getting Started</div>
-      <h1 class="page-title">Get AlphaForge Running in 2 Steps</h1>
-      <p class="page-subtitle">Install → Use the Trial plan immediately. Whop registration is only needed when you purchase a paid plan (Lifetime / Annual / Monthly) — about 10 minutes total. Full instructions live in the official docs.</p>
+      <h1 class="page-title">Get AlphaForge Running in 3 Steps</h1>
+      <p class="page-subtitle">Register on Whop → Install → Sign in. The Free plan is free of charge (about 10 minutes total). Full instructions live in the official docs.</p>
 
       <div class="callout" style="margin-bottom: 2rem;">
         <p style="margin-bottom: 0.75rem;">
@@ -100,7 +100,20 @@
         </a>
       </div>
 
-      <h2 class="section-heading">Step 1 — Install the CLI</h2>
+      <h2 class="section-heading">Step 1 — Create a Whop Account</h2>
+      <p>
+        AlphaForge requires a Whop account for <strong>every plan, including Free</strong>. Start with the Free plan and upgrade to a paid plan later if you need more.
+      </p>
+      <p style="margin-top: 1rem;">
+        <a href="https://whop.com/alforge-labs/alphaforge-free/" target="_blank" rel="noopener" class="btn-primary">
+          Register Free on Whop →
+        </a>
+      </p>
+      <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
+        Want to start on a paid plan? Pick one from the <a href="https://whop.com/alforge-labs/alphaforge/" target="_blank" rel="noopener">paid plans page</a>. See <a href="/en/docs/guides/freemium-limits/">Freemium Limits</a> for the differences.
+      </p>
+
+      <h2 class="section-heading">Step 2 — Install the CLI</h2>
       <div class="platform-tabs" role="tablist">
         <button type="button" class="platform-tab active" role="tab" aria-selected="true" aria-controls="tab-en-mac" onclick="switchTab('en', 'mac', event)">macOS / Linux</button>
         <button type="button" class="platform-tab" role="tab" aria-selected="false" aria-controls="tab-en-win" onclick="switchTab('en', 'win', event)">Windows</button>
@@ -121,23 +134,8 @@
         <a href="https://github.com/alforge-labs/alforge-labs.github.io/releases/latest" target="_blank" rel="noopener">GitHub Releases (latest)</a>.
       </p>
 
-      <h2 class="section-heading">Step 2 — Run as the Trial Plan (No Whop Registration Needed)</h2>
-      <p>From the moment installation finishes, <code>forge</code> runs on the Trial plan. No Whop registration required. The Trial plan is permanent and applies these limits only:</p>
-      <ul>
-        <li>Data fetch / evaluation cap: <strong>2023-12-31</strong></li>
-        <li>Optimization trials: <strong>50 per run</strong></li>
-        <li>Pine Script export: blocked (a paid plan is required)</li>
-      </ul>
-      <p>For the full Trial limit details, see <a href="/en/docs/guides/trial-limits/">Trial Limits</a>.</p>
-
-      <h2 class="section-heading">(Optional) Unlock Everything with a Paid Plan</h2>
-      <p>Purchase one of the paid plans — Lifetime (one-time), Annual, or Monthly — to unlock the latest data, unlimited optimization trials, and full Pine Script export. Any of the paid tiers unlocks the same feature set.</p>
-      <p style="margin-top: 1rem;">
-        <a href="https://whop.com/alforge-labs/alphaforge/" target="_blank" rel="noopener" class="btn-primary">
-          Buy a Paid Plan →
-        </a>
-      </p>
-      <p>After the purchase, run the following in your terminal and complete the Whop OAuth flow in your browser. Credentials are cached at <code>~/.config/forge/credentials.json</code>.</p>
+      <h2 class="section-heading">Step 3 — Sign in with Whop</h2>
+      <p>Sign in with the Whop account you registered in Step 1 via OAuth 2.0 PKCE — your browser opens automatically. Authentication data is cached at <code>~/.forge/credentials.json</code>.</p>
       <pre><code>forge system auth login</code></pre>
       <p>Verify the activated membership with:</p>
       <pre><code>forge system auth status</code></pre>

--- a/ja/index.html
+++ b/ja/index.html
@@ -45,23 +45,23 @@
           "@type": "Offer",
           "price": "0.00",
           "priceCurrency": "USD",
-          "name": "Trial"
+          "name": "Free"
         },
         {
           "@type": "Offer",
-          "price": "19.00",
+          "price": "9.00",
           "priceCurrency": "USD",
           "name": "Monthly"
         },
         {
           "@type": "Offer",
-          "price": "159.00",
+          "price": "99.00",
           "priceCurrency": "USD",
           "name": "Annual"
         },
         {
           "@type": "Offer",
-          "price": "299.00",
+          "price": "499.00",
           "priceCurrency": "USD",
           "name": "Lifetime"
         }
@@ -369,42 +369,42 @@
     }
 
     /* ── FREE START ── */
-    .trial-start {
+    .free-start {
       padding: 4.75rem 0;
       border-bottom: 1px solid var(--border);
       background:
         linear-gradient(180deg, var(--bg) 0%, var(--accent-bg) 100%);
     }
-    .trial-start-shell {
+    .free-start-shell {
       display: grid;
       grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
       gap: 2rem;
       align-items: stretch;
     }
-    .trial-start-copy {
+    .free-start-copy {
       display: flex;
       flex-direction: column;
       justify-content: center;
       gap: 1rem;
     }
-    .trial-start-title {
+    .free-start-title {
       color: var(--text);
       font-size: clamp(1.6rem, 3.2vw, 2.35rem);
       font-weight: 600;
       line-height: 1.15;
     }
-    .trial-start-subtitle {
+    .free-start-subtitle {
       max-width: 620px;
       color: var(--text2);
       font-size: 0.95rem;
       line-height: 1.8;
     }
-    .trial-start-limits {
+    .free-start-limits {
       display: flex;
       flex-wrap: wrap;
       gap: 0.45rem;
     }
-    .trial-start-limit {
+    .free-start-limit {
       border: 1px solid var(--accent-glow);
       border-radius: 100px;
       background: var(--surface);
@@ -413,14 +413,14 @@
       font-size: 0.68rem;
       padding: 0.25rem 0.65rem;
     }
-    .trial-start-actions {
+    .free-start-actions {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
       gap: 0.75rem;
       margin-top: 0.35rem;
     }
-    .trial-start-link {
+    .free-start-link {
       color: var(--text2);
       font-size: 0.86rem;
       text-decoration: none;
@@ -428,18 +428,18 @@
       padding-bottom: 0.1rem;
       transition: color 0.15s, border-color 0.15s;
     }
-    .trial-start-link:hover {
+    .free-start-link:hover {
       color: var(--accent);
       border-color: var(--accent);
     }
-    .trial-start-note {
+    .free-start-note {
       max-width: 620px;
       color: var(--text3);
       font-family: var(--mono);
       font-size: 0.7rem;
       line-height: 1.7;
     }
-    .trial-start-steps {
+    .free-start-steps {
       display: grid;
       grid-template-columns: 1fr;
       gap: 1px;
@@ -448,7 +448,7 @@
       border-radius: var(--r);
       background: var(--border);
     }
-    .trial-start-step {
+    .free-start-step {
       min-height: 132px;
       background: var(--surface);
       padding: 1.35rem;
@@ -459,21 +459,21 @@
       align-content: start;
       transition: background 0.2s;
     }
-    .trial-start-step:hover { background: var(--surface-h); }
-    .trial-start-step-num {
+    .free-start-step:hover { background: var(--surface-h); }
+    .free-start-step-num {
       grid-row: span 2;
       color: var(--accent);
       font-family: var(--mono);
       font-size: 0.72rem;
       letter-spacing: 0.08em;
     }
-    .trial-start-step-title {
+    .free-start-step-title {
       color: var(--text);
       font-size: 0.98rem;
       font-weight: 600;
       line-height: 1.35;
     }
-    .trial-start-step-desc {
+    .free-start-step-desc {
       color: var(--text2);
       font-size: 0.84rem;
       line-height: 1.65;
@@ -667,7 +667,7 @@
     }
 
     /* ── FREE BANNER ── */
-    .trial-banner {
+    .free-banner {
       margin-top: 2rem;
       border: 1px dashed rgba(0,228,154,0.35);
       border-radius: var(--r);
@@ -675,37 +675,37 @@
       padding: 1.1rem 1.4rem;
       display: flex; align-items: center; gap: 1.2rem; flex-wrap: wrap;
     }
-    .trial-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
-    .trial-banner-body { flex: 1; min-width: 200px; }
-    .trial-banner-title {
+    .free-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
+    .free-banner-body { flex: 1; min-width: 200px; }
+    .free-banner-title {
       font-size: 0.95rem; font-weight: 600;
       display: flex; align-items: center; gap: 0.5rem;
     }
-    .trial-badge {
+    .free-badge {
       font-family: var(--mono); font-size: 0.6rem; letter-spacing: 0.08em;
       text-transform: uppercase;
       background: rgba(0,228,154,0.12); color: var(--accent);
       border: 1px solid rgba(0,228,154,0.25); border-radius: 4px; padding: 1px 6px;
     }
-    .trial-banner-desc {
+    .free-banner-desc {
       margin-top: 0.3rem; color: var(--text2);
       font-size: 0.82rem; line-height: 1.5;
     }
-    .trial-banner-pills {
+    .free-banner-pills {
       margin-top: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.4rem;
     }
-    .trial-pill {
+    .free-pill {
       font-size: 0.68rem; padding: 2px 8px; border-radius: 20px;
       border: 1px solid var(--border); color: var(--text2);
     }
-    .trial-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
-    .trial-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
-    .trial-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
-    .trial-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
-    .trial-banner-cta .btn-secondary {
+    .free-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
+    .free-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
+    .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
+    .free-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
+    .free-banner-cta .btn-secondary {
       width: 100%; justify-content: center;
     }
-    .trial-banner-status {
+    .free-banner-status {
       margin-top: 0.35rem;
       color: var(--text3);
       font-family: var(--mono);
@@ -729,11 +729,11 @@
     }
     .comparison-table thead tr { border-bottom: 1px solid var(--border); }
     .comparison-th-feature { padding: 0.5rem 0.75rem; text-align: left; font-weight: 600; font-size: 0.78rem; width: 48%; }
-    .comparison-th-trial    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
-    .comparison-th-lifetime    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
+    .comparison-th-free    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
+    .comparison-th-paid    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
     .comparison-td-feature { padding: 0.5rem 0.75rem; color: var(--text2); border-bottom: 1px solid rgba(255,255,255,0.04); }
-    .comparison-td-trial    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
-    .comparison-td-lifetime    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-free    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-paid    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
     .comparison-table tbody tr:last-child td { border-bottom: none; }
     .comparison-table tbody tr:nth-child(even) td { background: rgba(255,255,255,0.015); }
     .cmp-ok    { color: var(--accent); }
@@ -1042,19 +1042,19 @@
       .trust-safety { padding: 4.5rem 0; }
       .trust-safety-grid { grid-template-columns: 1fr; }
       .trust-safety-card { min-height: auto; }
-      .trial-start { padding: 4rem 0; }
-      .trial-start-shell { grid-template-columns: 1fr; }
-      .trial-start-actions { align-items: stretch; }
-      .trial-start-actions .btn-primary,
-      .trial-start-actions .btn-secondary {
+      .free-start { padding: 4rem 0; }
+      .free-start-shell { grid-template-columns: 1fr; }
+      .free-start-actions { align-items: stretch; }
+      .free-start-actions .btn-primary,
+      .free-start-actions .btn-secondary {
         width: 100%;
         justify-content: center;
         text-align: center;
       }
-      .trial-start-link { width: fit-content; }
-      .trial-banner { flex-direction: column; align-items: flex-start; }
-      .trial-banner-cta { width: 100%; }
-      .trial-banner-cta .btn-secondary { width: 100%; }
+      .free-start-link { width: fit-content; }
+      .free-banner { flex-direction: column; align-items: flex-start; }
+      .free-banner-cta { width: 100%; }
+      .free-banner-cta .btn-secondary { width: 100%; }
       .nav-page-link { padding: 0 0.55rem; }
       .lang-btn { padding: 0 0.55rem; }
       .follow-btn-nav {

--- a/ja/install.html
+++ b/ja/install.html
@@ -87,8 +87,8 @@
     <div class="lang-ja">
       
       <div class="page-label">Getting Started</div>
-      <h1 class="page-title">2 ステップで AlphaForge を動かす</h1>
-      <p class="page-subtitle">インストール → そのまま Trial プランで実行。Whop 登録は有料プラン（Lifetime / Annual / Monthly）を購入するときだけ必要です（所要時間 約 10 分）。詳細手順は公式ドキュメントへ。</p>
+      <h1 class="page-title">3 ステップで AlphaForge を動かす</h1>
+      <p class="page-subtitle">Whop 登録 → インストール → ログイン認証。Free プランなら無料で始められます（所要時間 約 10 分）。詳細手順は公式ドキュメントへ。</p>
 
       <div class="callout" style="margin-bottom: 2rem;">
         <p style="margin-bottom: 0.75rem;">
@@ -100,7 +100,20 @@
         </a>
       </div>
 
-      <h2 class="section-heading">ステップ 1 — CLI をインストール</h2>
+      <h2 class="section-heading">ステップ 1 — Whop でアカウント登録</h2>
+      <p>
+        AlphaForge は Whop でのアカウント登録が必要です（<strong>Free プランも含めて全プラン共通</strong>）。まずは無料プランで登録し、CLI を動かしてから必要に応じて有料プランへアップグレードできます。
+      </p>
+      <p style="margin-top: 1rem;">
+        <a href="https://whop.com/alforge-labs/alphaforge-free/" target="_blank" rel="noopener" class="btn-primary">
+          無料で Whop に登録 →
+        </a>
+      </p>
+      <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
+        最初から有料プランで始めたい場合は <a href="https://whop.com/alforge-labs/alphaforge/" target="_blank" rel="noopener">有料プラン一覧</a> から購入してください。Free / 有料の機能差は <a href="/ja/docs/guides/freemium-limits/">フリーミアム制限</a> を参照。
+      </p>
+
+      <h2 class="section-heading">ステップ 2 — CLI をインストール</h2>
       <div class="platform-tabs" role="tablist">
         <button type="button" class="platform-tab active" role="tab" aria-selected="true" aria-controls="tab-ja-mac" onclick="switchTab('ja', 'mac', event)">macOS / Linux</button>
         <button type="button" class="platform-tab" role="tab" aria-selected="false" aria-controls="tab-ja-win" onclick="switchTab('ja', 'win', event)">Windows</button>
@@ -122,23 +135,8 @@
         から各プラットフォーム向けバイナリを直接ダウンロードできます。
       </p>
 
-      <h2 class="section-heading">ステップ 2 — そのまま Trial プランで実行（Whop 登録不要）</h2>
-      <p>インストール直後から <code>forge</code> コマンドが Trial プランとして動作します。Whop 登録は不要です。Trial プランは期限なしで利用でき、以下の制限のみ適用されます：</p>
-      <ul>
-        <li>データ取得・評価の上限日: <strong>2023-12-31</strong> まで</li>
-        <li>最適化トライアル: <strong>50 回</strong>まで</li>
-        <li>Pine Script エクスポート: 不可（有料プランが必要）</li>
-      </ul>
-      <p>Trial プランの全制限詳細は <a href="/ja/docs/guides/trial-limits/">Trial 制限</a> を参照してください。</p>
-
-      <h2 class="section-heading">（任意）有料プランで全機能を解放</h2>
-      <p>有料プラン（Lifetime / Annual / Monthly のいずれか）を購入すると、最新データ・無制限の最適化トライアル・Pine Script エクスポートのすべてが解放されます。Lifetime（買い切り）/ Annual（年額）/ Monthly（月額）から用途に合わせて選べます。</p>
-      <p style="margin-top: 1rem;">
-        <a href="https://whop.com/alforge-labs/alphaforge/" target="_blank" rel="noopener" class="btn-primary">
-          有料プランを購入 →
-        </a>
-      </p>
-      <p>購入後はターミナルで以下を実行し、ブラウザで Whop OAuth 認証を完了します。認証情報は <code>~/.config/forge/credentials.json</code> に保存されます。</p>
+      <h2 class="section-heading">ステップ 3 — Whop でログイン認証</h2>
+      <p>ステップ 1 で登録した Whop アカウントで OAuth 2.0 PKCE 認証を行います。ブラウザが自動で開きます。認証情報は <code>~/.forge/credentials.json</code> に保存されます。</p>
       <pre><code>forge system auth login</code></pre>
       <p>認証済みメンバーシップは以下で確認できます：</p>
       <pre><code>forge system auth status</code></pre>


### PR DESCRIPTION
## Summary

`templates/*.html.j2` と `seo.yaml` への過去の変更が、PR #258（Trial プランカード CTA 整理）や #261（pnpm 移行）のときに `build.py` が回らずビルド成果物に反映されていなかったため、最新ソースから一括再生成して整合させます。

機能変更なし（ビルド成果物の追従のみ）。tutorial-strategy には触れていません（#262 ですでに最新）。

## 主な実差分

### `{ja,en}/index.html`
- JSON-LD `Offer.name` `Trial` → `Free`
- JSON-LD `Offer.price`
  - Monthly: `19.00` → `9.00`
  - Annual: `159.00` → `99.00`
  - Lifetime: `299.00` → `499.00`
- CSS クラス名 `trial-start*` → `free-start*`（テンプレ側で既に変更済み）

### `{ja,en}/install.html`
- 「2 ステップで AlphaForge を動かす」→ **3 ステップ**
- サブタイトル: 「インストール → そのまま Trial プランで実行」→ Whop 登録 → CLI → ログイン認証の 3 ステップ構成
- ステップ 1 を「Whop でアカウント登録」に変更（Free プラン経路を案内）

## Test plan

- [x] `uv run python build.py` → 全 12 ページ正常ビルド、最後の `Build complete.` のみ
- [x] `git status -s` で残差分なし
- [x] tutorial-strategy.html は #262 マージ後の状態を維持（無関係）

## 追記: 今後の運用

template / seo.yaml を編集する PR ではビルド成果物の同期コミットを必ず含めるか、GitHub Actions でビルド成果物を自動生成・コミットする仕組みを入れると今回のような追従漏れが防げます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)