### PR TITLE
fix(landing): Trial で開始セクションの CSS class を free-start → trial-start にリネーム

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -369,42 +369,42 @@
     }
 
     /* ── FREE START ── */
-    .free-start {
+    .trial-start {
       padding: 4.75rem 0;
       border-bottom: 1px solid var(--border);
       background:
         linear-gradient(180deg, var(--bg) 0%, var(--accent-bg) 100%);
     }
-    .free-start-shell {
+    .trial-start-shell {
       display: grid;
       grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
       gap: 2rem;
       align-items: stretch;
     }
-    .free-start-copy {
+    .trial-start-copy {
       display: flex;
       flex-direction: column;
       justify-content: center;
       gap: 1rem;
     }
-    .free-start-title {
+    .trial-start-title {
       color: var(--text);
       font-size: clamp(1.6rem, 3.2vw, 2.35rem);
       font-weight: 600;
       line-height: 1.15;
     }
-    .free-start-subtitle {
+    .trial-start-subtitle {
       max-width: 620px;
       color: var(--text2);
       font-size: 0.95rem;
       line-height: 1.8;
     }
-    .free-start-limits {
+    .trial-start-limits {
       display: flex;
       flex-wrap: wrap;
       gap: 0.45rem;
     }
-    .free-start-limit {
+    .trial-start-limit {
       border: 1px solid var(--accent-glow);
       border-radius: 100px;
       background: var(--surface);
@@ -413,14 +413,14 @@
       font-size: 0.68rem;
       padding: 0.25rem 0.65rem;
     }
-    .free-start-actions {
+    .trial-start-actions {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
       gap: 0.75rem;
       margin-top: 0.35rem;
     }
-    .free-start-link {
+    .trial-start-link {
       color: var(--text2);
       font-size: 0.86rem;
       text-decoration: none;
@@ -428,18 +428,18 @@
       padding-bottom: 0.1rem;
       transition: color 0.15s, border-color 0.15s;
     }
-    .free-start-link:hover {
+    .trial-start-link:hover {
       color: var(--accent);
       border-color: var(--accent);
     }
-    .free-start-note {
+    .trial-start-note {
       max-width: 620px;
       color: var(--text3);
       font-family: var(--mono);
       font-size: 0.7rem;
       line-height: 1.7;
     }
-    .free-start-steps {
+    .trial-start-steps {
       display: grid;
       grid-template-columns: 1fr;
       gap: 1px;
@@ -448,7 +448,7 @@
       border-radius: var(--r);
       background: var(--border);
     }
-    .free-start-step {
+    .trial-start-step {
       min-height: 132px;
       background: var(--surface);
       padding: 1.35rem;
@@ -459,21 +459,21 @@
       align-content: start;
       transition: background 0.2s;
     }
-    .free-start-step:hover { background: var(--surface-h); }
-    .free-start-step-num {
+    .trial-start-step:hover { background: var(--surface-h); }
+    .trial-start-step-num {
       grid-row: span 2;
       color: var(--accent);
       font-family: var(--mono);
       font-size: 0.72rem;
       letter-spacing: 0.08em;
     }
-    .free-start-step-title {
+    .trial-start-step-title {
       color: var(--text);
       font-size: 0.98rem;
       font-weight: 600;
       line-height: 1.35;
     }
-    .free-start-step-desc {
+    .trial-start-step-desc {
       color: var(--text2);
       font-size: 0.84rem;
       line-height: 1.65;
@@ -1042,16 +1042,16 @@
       .trust-safety { padding: 4.5rem 0; }
       .trust-safety-grid { grid-template-columns: 1fr; }
       .trust-safety-card { min-height: auto; }
-      .free-start { padding: 4rem 0; }
-      .free-start-shell { grid-template-columns: 1fr; }
-      .free-start-actions { align-items: stretch; }
-      .free-start-actions .btn-primary,
-      .free-start-actions .btn-secondary {
+      .trial-start { padding: 4rem 0; }
+      .trial-start-shell { grid-template-columns: 1fr; }
+      .trial-start-actions { align-items: stretch; }
+      .trial-start-actions .btn-primary,
+      .trial-start-actions .btn-secondary {
         width: 100%;
         justify-content: center;
         text-align: center;
       }
-      .free-start-link { width: fit-content; }
+      .trial-start-link { width: fit-content; }
       .free-banner { flex-direction: column; align-items: flex-start; }
       .free-banner-cta { width: 100%; }
       .free-banner-cta .btn-secondary { width: 100%; }

--- a/ja/index.html
+++ b/ja/index.html
@@ -369,42 +369,42 @@
     }
 
     /* ── FREE START ── */
-    .free-start {
+    .trial-start {
       padding: 4.75rem 0;
       border-bottom: 1px solid var(--border);
       background:
         linear-gradient(180deg, var(--bg) 0%, var(--accent-bg) 100%);
     }
-    .free-start-shell {
+    .trial-start-shell {
       display: grid;
       grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
       gap: 2rem;
       align-items: stretch;
     }
-    .free-start-copy {
+    .trial-start-copy {
       display: flex;
       flex-direction: column;
       justify-content: center;
       gap: 1rem;
     }
-    .free-start-title {
+    .trial-start-title {
       color: var(--text);
       font-size: clamp(1.6rem, 3.2vw, 2.35rem);
       font-weight: 600;
       line-height: 1.15;
     }
-    .free-start-subtitle {
+    .trial-start-subtitle {
       max-width: 620px;
       color: var(--text2);
       font-size: 0.95rem;
       line-height: 1.8;
     }
-    .free-start-limits {
+    .trial-start-limits {
       display: flex;
       flex-wrap: wrap;
       gap: 0.45rem;
     }
-    .free-start-limit {
+    .trial-start-limit {
       border: 1px solid var(--accent-glow);
       border-radius: 100px;
       background: var(--surface);
@@ -413,14 +413,14 @@
       font-size: 0.68rem;
       padding: 0.25rem 0.65rem;
     }
-    .free-start-actions {
+    .trial-start-actions {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
       gap: 0.75rem;
       margin-top: 0.35rem;
     }
-    .free-start-link {
+    .trial-start-link {
       color: var(--text2);
       font-size: 0.86rem;
       text-decoration: none;
@@ -428,18 +428,18 @@
       padding-bottom: 0.1rem;
       transition: color 0.15s, border-color 0.15s;
     }
-    .free-start-link:hover {
+    .trial-start-link:hover {
       color: var(--accent);
       border-color: var(--accent);
     }
-    .free-start-note {
+    .trial-start-note {
       max-width: 620px;
       color: var(--text3);
       font-family: var(--mono);
       font-size: 0.7rem;
       line-height: 1.7;
     }
-    .free-start-steps {
+    .trial-start-steps {
       display: grid;
       grid-template-columns: 1fr;
       gap: 1px;
@@ -448,7 +448,7 @@
       border-radius: var(--r);
       background: var(--border);
     }
-    .free-start-step {
+    .trial-start-step {
       min-height: 132px;
       background: var(--surface);
       padding: 1.35rem;
@@ -459,21 +459,21 @@
       align-content: start;
       transition: background 0.2s;
     }
-    .free-start-step:hover { background: var(--surface-h); }
-    .free-start-step-num {
+    .trial-start-step:hover { background: var(--surface-h); }
+    .trial-start-step-num {
       grid-row: span 2;
       color: var(--accent);
       font-family: var(--mono);
       font-size: 0.72rem;
       letter-spacing: 0.08em;
     }
-    .free-start-step-title {
+    .trial-start-step-title {
       color: var(--text);
       font-size: 0.98rem;
       font-weight: 600;
       line-height: 1.35;
     }
-    .free-start-step-desc {
+    .trial-start-step-desc {
       color: var(--text2);
       font-size: 0.84rem;
       line-height: 1.65;
@@ -1042,16 +1042,16 @@
       .trust-safety { padding: 4.5rem 0; }
       .trust-safety-grid { grid-template-columns: 1fr; }
       .trust-safety-card { min-height: auto; }
-      .free-start { padding: 4rem 0; }
-      .free-start-shell { grid-template-columns: 1fr; }
-      .free-start-actions { align-items: stretch; }
-      .free-start-actions .btn-primary,
-      .free-start-actions .btn-secondary {
+      .trial-start { padding: 4rem 0; }
+      .trial-start-shell { grid-template-columns: 1fr; }
+      .trial-start-actions { align-items: stretch; }
+      .trial-start-actions .btn-primary,
+      .trial-start-actions .btn-secondary {
         width: 100%;
         justify-content: center;
         text-align: center;
       }
-      .free-start-link { width: fit-content; }
+      .trial-start-link { width: fit-content; }
       .free-banner { flex-direction: column; align-items: flex-start; }
       .free-banner-cta { width: 100%; }
       .free-banner-cta .btn-secondary { width: 100%; }

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -289,42 +289,42 @@
     }
 
     /* ── FREE START ── */
-    .free-start {
+    .trial-start {
       padding: 4.75rem 0;
       border-bottom: 1px solid var(--border);
       background:
         linear-gradient(180deg, var(--bg) 0%, var(--accent-bg) 100%);
     }
-    .free-start-shell {
+    .trial-start-shell {
       display: grid;
       grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
       gap: 2rem;
       align-items: stretch;
     }
-    .free-start-copy {
+    .trial-start-copy {
       display: flex;
       flex-direction: column;
       justify-content: center;
       gap: 1rem;
     }
-    .free-start-title {
+    .trial-start-title {
       color: var(--text);
       font-size: clamp(1.6rem, 3.2vw, 2.35rem);
       font-weight: 600;
       line-height: 1.15;
     }
-    .free-start-subtitle {
+    .trial-start-subtitle {
       max-width: 620px;
       color: var(--text2);
       font-size: 0.95rem;
       line-height: 1.8;
     }
-    .free-start-limits {
+    .trial-start-limits {
       display: flex;
       flex-wrap: wrap;
       gap: 0.45rem;
     }
-    .free-start-limit {
+    .trial-start-limit {
       border: 1px solid var(--accent-glow);
       border-radius: 100px;
       background: var(--surface);
@@ -333,14 +333,14 @@
       font-size: 0.68rem;
       padding: 0.25rem 0.65rem;
     }
-    .free-start-actions {
+    .trial-start-actions {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
       gap: 0.75rem;
       margin-top: 0.35rem;
     }
-    .free-start-link {
+    .trial-start-link {
       color: var(--text2);
       font-size: 0.86rem;
       text-decoration: none;
@@ -348,18 +348,18 @@
       padding-bottom: 0.1rem;
       transition: color 0.15s, border-color 0.15s;
     }
-    .free-start-link:hover {
+    .trial-start-link:hover {
       color: var(--accent);
       border-color: var(--accent);
     }
-    .free-start-note {
+    .trial-start-note {
       max-width: 620px;
       color: var(--text3);
       font-family: var(--mono);
       font-size: 0.7rem;
       line-height: 1.7;
     }
-    .free-start-steps {
+    .trial-start-steps {
       display: grid;
       grid-template-columns: 1fr;
       gap: 1px;
@@ -368,7 +368,7 @@
       border-radius: var(--r);
       background: var(--border);
     }
-    .free-start-step {
+    .trial-start-step {
       min-height: 132px;
       background: var(--surface);
       padding: 1.35rem;
@@ -379,21 +379,21 @@
       align-content: start;
       transition: background 0.2s;
     }
-    .free-start-step:hover { background: var(--surface-h); }
-    .free-start-step-num {
+    .trial-start-step:hover { background: var(--surface-h); }
+    .trial-start-step-num {
       grid-row: span 2;
       color: var(--accent);
       font-family: var(--mono);
       font-size: 0.72rem;
       letter-spacing: 0.08em;
     }
-    .free-start-step-title {
+    .trial-start-step-title {
       color: var(--text);
       font-size: 0.98rem;
       font-weight: 600;
       line-height: 1.35;
     }
-    .free-start-step-desc {
+    .trial-start-step-desc {
       color: var(--text2);
       font-size: 0.84rem;
       line-height: 1.65;
@@ -962,16 +962,16 @@
       .trust-safety { padding: 4.5rem 0; }
       .trust-safety-grid { grid-template-columns: 1fr; }
       .trust-safety-card { min-height: auto; }
-      .free-start { padding: 4rem 0; }
-      .free-start-shell { grid-template-columns: 1fr; }
-      .free-start-actions { align-items: stretch; }
-      .free-start-actions .btn-primary,
-      .free-start-actions .btn-secondary {
+      .trial-start { padding: 4rem 0; }
+      .trial-start-shell { grid-template-columns: 1fr; }
+      .trial-start-actions { align-items: stretch; }
+      .trial-start-actions .btn-primary,
+      .trial-start-actions .btn-secondary {
         width: 100%;
         justify-content: center;
         text-align: center;
       }
-      .free-start-link { width: fit-content; }
+      .trial-start-link { width: fit-content; }
       .free-banner { flex-direction: column; align-items: flex-start; }
       .free-banner-cta { width: 100%; }
       .free-banner-cta .btn-secondary { width: 100%; }


### PR DESCRIPTION
## 原因

ランディングページの「Trial で開始」セクションのレイアウトが崩壊していました（添付スクリーンショット参照）。

- JSX (`homepage-components.jsx` の `TrialStart` コンポーネント): **`trial-start-*`** クラスを出力
- インライン CSS (`templates/index.html.j2`): **`.free-start-*`** のみ定義（旧名のまま）

過去の Free → Trial ティアリネーム（`5bc4102` 等）で JSX 側だけリネームされ、CSS 側 24 行が取りこぼされたためマッチせず、ブラウザのデフォルトスタイルで描画されていました。

## 症状

- `trial-start-limits` の flex / gap が無効 → 制限事項が改行なしで「データは2023年12月31日まで最適化50回Pine Script生成なし」と連結表示
- `trial-start-actions` のボタン整列が崩れ、「2 ステップで始める」「料金比較を見る →」「更新情報をXで追う」の間隔がバラバラ
- `trial-start-step-num` `trial-start-step` のグリッドが効かず、「01」「02」が裸のテキストとして見える

## 修正

- `templates/index.html.j2`: インライン `<style>` 内の `.free-start-*` 24 行を `.trial-start-*` に一括リネーム
- `ja/index.html` / `en/index.html`: `uv run python build.py` で再生成

## テスト

- `grep -c "free-start" templates/index.html.j2 ja/index.html en/index.html` → すべて 0
- `grep -c "trial-start" ja/index.html en/index.html` → 各 23 件で JSX と一致

過去にも類似の不整合があり PR `bfa0603` で同種の修正をしていたため、再発防止策として CI に JSX classNames と CSS セレクタの整合性チェックを入れる余地はあるが、本 PR では最小修正のみ実施。