### PR TITLE
fix(landing): ヘッダーから「ロードマップ」削除・フッターから「インストール / ドキュメント」削除

### DIFF
--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -14,7 +14,7 @@ window.EQUITY_CURVE = {
 // Bilingual copy — window.COPY
 window.COPY = {
   ja: {
-    nav: { products: 'プロダクト', pricing: '料金', install: 'インストール', docs: 'ドキュメント', roadmap: 'ロードマップ', faq: 'FAQ', follow: 'フォロー' },
+    nav: { products: 'プロダクト', pricing: '料金', install: 'インストール', tutorial: 'チュートリアル', faq: 'FAQ', docs: 'ドキュメント', follow: 'フォロー' },
     hero: {
       tag: '開発進行中',
       h1a: 'ノイズから、',
@@ -430,8 +430,6 @@ window.COPY = {
       copy: '© 2026 Alforge Labs.',
       note: 'このサイトは開発者向けソフトウェアツールを提供します。特定の投資・運用を推奨するものではありません。',
       links: [
-        { label: 'インストール', url: '/install.html' },
-        { label: 'ドキュメント', url: '/ja/docs/' },
         { label: '利用規約', url: '/terms.html' },
         { label: 'プライバシー', url: '/privacy.html' },
       ],
@@ -439,7 +437,7 @@ window.COPY = {
   },
 
   en: {
-    nav: { products: 'Products', pricing: 'Pricing', install: 'Install', docs: 'Docs', roadmap: 'Roadmap', faq: 'FAQ', follow: 'Follow' },
+    nav: { products: 'Products', pricing: 'Pricing', install: 'Install', tutorial: 'Tutorial', faq: 'FAQ', docs: 'Docs', follow: 'Follow' },
     hero: {
       tag: 'In Development',
       h1a: 'From Noise',
@@ -819,8 +817,6 @@ window.COPY = {
       copy: '© 2026 Alforge Labs.',
       note: 'This site provides developer software tools. Nothing here constitutes professional advice or specific product recommendations.',
       links: [
-        { label: 'Install', url: '/install.html' },
-        { label: 'Docs', url: '/en/docs/' },
         { label: 'Terms', url: '/terms.html' },
         { label: 'Privacy', url: '/privacy.html' },
       ],

--- a/site-header.jsx
+++ b/site-header.jsx
@@ -33,10 +33,9 @@ const HEADER_LINKS = [
   { key: 'products', href: _anchorBase + '#products' },
   { key: 'pricing',  href: _anchorBase + '#pricing' },
   { key: 'install',  href: 'install.html' },
-  { key: 'mkdocs',   href: 'docs/' },
   { key: 'tutorial', href: 'tutorial-strategy.html' },
-  { key: 'roadmap',  href: _anchorBase + '#roadmap' },
   { key: 'faq',      href: _anchorBase + '#faq' },
+  { key: 'mkdocs',   href: 'docs/' },
 ];
 
 function XIcon({ size = 16 }) {


### PR DESCRIPTION
## 変更内容

### ヘッダー（全ページ共通 SiteHeader）

- 「ロードマップ」項目を削除
- 項目順を「プロダクト / 料金 / インストール / チュートリアル / FAQ / ドキュメント」に並び替え
- ファイル: `site-header.jsx` の `HEADER_LINKS` 配列

### フッター（ランディング専用）

- 「インストール」「ドキュメント」のリンクを削除（同じ動線がヘッダーにあり、フッターは法務系のみに絞る）
- ファイル: `homepage-copy.jsx` の `ja.footer.links` と `en.footer.links`

### 整合性のための補助変更

- `homepage-copy.jsx` の `ja.nav` / `en.nav` 辞書からも `roadmap` キーを削除し、`tutorial` キーを追加（site-header.jsx は独自の HEADER_COPY 辞書を使うため直接の機能影響はないが、未使用キーが残らないよう同期）

## 影響範囲

- ランディング (`ja/index.html`, `en/index.html`)
- ヘッダーを共有する `install.html` / `tutorial-strategy.html` / `privacy.html` / `terms.html` / `docs.html` のヘッダーにも反映
- JSX はクライアント側で動的描画されるため `build.py` での HTML 再生成は不要（実行しても HTML に差分は出ない）

## テスト

- 編集後、`uv run python build.py` で生成 HTML に差分が出ないことを確認（JSX は `<script>` でクライアントに読み込まれる）