### PR TITLE
fix(tutorial): page-wrap の max-width インライン上書きを削除し他ページと 860px に統一

### DIFF
--- a/en/tutorial-strategy.html
+++ b/en/tutorial-strategy.html
@@ -144,7 +144,7 @@
 <body data-theme="dark" data-lang="en">
   <div id="site-header"></div>
 
-  <div class="page-wrap" style="max-width: 1060px;">
+  <div class="page-wrap">
 
     <div class="lang-en">
       

--- a/ja/tutorial-strategy.html
+++ b/ja/tutorial-strategy.html
@@ -144,7 +144,7 @@
 <body data-theme="dark" data-lang="ja">
   <div id="site-header"></div>
 
-  <div class="page-wrap" style="max-width: 1060px;">
+  <div class="page-wrap">
 
     <div class="lang-ja">
       

--- a/templates/tutorial-strategy.html.j2
+++ b/templates/tutorial-strategy.html.j2
@@ -92,7 +92,7 @@
 <body data-theme="dark" data-lang="{{ lang }}">
   <div id="site-header"></div>
 
-  <div class="page-wrap" style="max-width: 1060px;">
+  <div class="page-wrap">
 
     <div class="lang-{{ lang }}">
       {% if lang == 'ja' %}


### PR DESCRIPTION
## 背景

`tutorial-strategy.html` だけ `<div class="page-wrap" style="max-width: 1060px;">` でインラインに 1060px を指定しており、他ページ（`install` / `privacy` / `terms`）の 860px（`page.css` の `--max-w` グローバル変数）と不整合。

左右パディング `--pad: clamp(1.25rem, 4vw, 2rem)`（最大 32px）はそのままで本文だけ約 1.23 倍広いため、コンテンツに対する右余白の相対比が縮み、ユーザーから「右余白が少ない」とフィードバックがあった。

## 変更

- `templates/tutorial-strategy.html.j2`: `style="max-width: 1060px;"` を削除し、`.page-wrap` クラスのみに（page.css の `--max-w: 860px` を継承）
- `ja/tutorial-strategy.html` / `en/tutorial-strategy.html`: `uv run python build.py` で再生成

## トレードオフ

860px に戻すことで、コードブロックや表で横スクロールが必要になる箇所が増える可能性があります（特にチュートリアル内のコマンド例）。実利用で問題が顕在化した場合は中間値（960px 等）に再調整する余地あり。