### PR TITLE
fix(tutorial): H1 のハードコード <br> を削除し .page-title に text-wrap: balance を追加

### DIFF
--- a/en/tutorial-strategy.html
+++ b/en/tutorial-strategy.html
@@ -150,7 +150,7 @@
       
 
       <div class="page-label">Tutorial</div>
-      <h1 class="page-title">Strategy Development,<br>Backtesting &amp; Optimization</h1>
+      <h1 class="page-title">Strategy Development, Backtesting &amp; Optimization</h1>
       <p class="page-subtitle">
         A step-by-step guide to building quantitative investment strategies with AlphaForge —
         from writing strategy JSON to running backtests, Bayesian optimization, and walk-forward validation.

--- a/ja/tutorial-strategy.html
+++ b/ja/tutorial-strategy.html
@@ -150,7 +150,7 @@
       
 
       <div class="page-label">チュートリアル</div>
-      <h1 class="page-title">投資戦略の開発・<br>バックテスト・最適化</h1>
+      <h1 class="page-title">投資戦略の開発・バックテスト・最適化</h1>
       <p class="page-subtitle">
         戦略 JSON の作成から、バックテスト実行・ベイズ最適化・ウォークフォワード検証まで一気通貫で学べる AlphaForge 入門ガイドです。
         CL=F（WTI原油先物）を例題に、HMM + ボリンジャーバンド + RSI の複合戦略を実装します。

--- a/page.css
+++ b/page.css
@@ -158,6 +158,7 @@ body[data-lang="en"] .lang-en { display: block; }
   font-size: clamp(2rem, 5vw, 3rem); font-weight: 700;
   letter-spacing: -0.04em; line-height: 1.1; color: var(--text);
   margin-bottom: 0.75rem;
+  text-wrap: balance;
 }
 .page-subtitle {
   font-size: 1rem; color: var(--text2); line-height: 1.7;

--- a/templates/tutorial-strategy.html.j2
+++ b/templates/tutorial-strategy.html.j2
@@ -98,7 +98,7 @@
       {% if lang == 'ja' %}
 
       <div class="page-label">チュートリアル</div>
-      <h1 class="page-title">投資戦略の開発・<br>バックテスト・最適化</h1>
+      <h1 class="page-title">投資戦略の開発・バックテスト・最適化</h1>
       <p class="page-subtitle">
         戦略 JSON の作成から、バックテスト実行・ベイズ最適化・ウォークフォワード検証まで一気通貫で学べる AlphaForge 入門ガイドです。
         CL=F（WTI原油先物）を例題に、HMM + ボリンジャーバンド + RSI の複合戦略を実装します。
@@ -505,7 +505,7 @@ Avg Sharpe: 1.10  |  Avg CAGR: 13.9%  |  WF Efficiency: 89%</code></pre>
       {% else %}
 
       <div class="page-label">Tutorial</div>
-      <h1 class="page-title">Strategy Development,<br>Backtesting &amp; Optimization</h1>
+      <h1 class="page-title">Strategy Development, Backtesting &amp; Optimization</h1>
       <p class="page-subtitle">
         A step-by-step guide to building quantitative investment strategies with AlphaForge —
         from writing strategy JSON to running backtests, Bayesian optimization, and walk-forward validation.


### PR DESCRIPTION
## 背景

PR #274 で tutorial の `page-wrap` を 860px に統一した後も「install と幅が違って見える」というフィードバックを受け、再調査した結果、根本原因は H1 内の **`<br>` ハードコード** による強制改行でした（前回の私の「H1 が doc-layout 内にある」という判定は誤読でした。H1 は元から doc-layout の外で page-wrap 直下にあります）。

## 修正前後

| 項目 | install.html | tutorial.html（旧） | tutorial.html（本 PR 後） |
|---|---|---|---|
| H1 | 「3 ステップで AlphaForge を動かす」1 行 | 「投資戦略の開発・**`<br>`**バックテスト・最適化」常に 2 行 | 同左テキストを `<br>` なしで自動改行 |
| 見た目 | page-wrap 全幅で広く流れる | 強制 2 行で詰まって見える | install と同じ感覚で流れる |

## 変更

- `templates/tutorial-strategy.html.j2`: ja / en の H1 から `<br>` を削除
- `page.css`: `.page-title` に `text-wrap: balance` を追加 — ビューポート幅や言語で 1 行に収まる場合は 1 行、収まらない場合はブラウザがバランスよく自動改行
- `ja/tutorial-strategy.html` / `en/tutorial-strategy.html`: `uv run python build.py` で再生成

## ブラウザ互換

`text-wrap: balance` は Chrome 114+ / Firefox 121+ / Safari 17.5+ で動作。非対応ブラウザでは単純な auto wrap にフォールバックし、最低限「`<br>` で常時 2 行」よりは自然な改行になります。