### PR TITLE
fix(tutorial): H1 に意味境界の <br> を復活させ tutorial 専用にフォントを縮小

### DIFF
--- a/en/tutorial-strategy.html
+++ b/en/tutorial-strategy.html
@@ -123,6 +123,10 @@
       background: var(--accent-bg); color: var(--accent); border-radius: 4px;
       padding: 0.15rem 0.5rem; margin-left: 0.4rem; vertical-align: middle;
     }
+    /* tutorial 専用: H1 文字列が長いため、page-title フォントを 1 段下げて右余白を確保 */
+    .page-title {
+      font-size: clamp(1.75rem, 4vw, 2.5rem);
+    }
     @media (max-width: 768px) {
       .doc-layout { grid-template-columns: 1fr; }
       .cmd-nav { display: none; }
@@ -150,7 +154,7 @@
       
 
       <div class="page-label">Tutorial</div>
-      <h1 class="page-title">Strategy Development, Backtesting &amp; Optimization</h1>
+      <h1 class="page-title">Strategy Development,<br>Backtesting &amp; Optimization</h1>
       <p class="page-subtitle">
         A step-by-step guide to building quantitative investment strategies with AlphaForge —
         from writing strategy JSON to running backtests, Bayesian optimization, and walk-forward validation.

--- a/ja/tutorial-strategy.html
+++ b/ja/tutorial-strategy.html
@@ -123,6 +123,10 @@
       background: var(--accent-bg); color: var(--accent); border-radius: 4px;
       padding: 0.15rem 0.5rem; margin-left: 0.4rem; vertical-align: middle;
     }
+    /* tutorial 専用: H1 文字列が長いため、page-title フォントを 1 段下げて右余白を確保 */
+    .page-title {
+      font-size: clamp(1.75rem, 4vw, 2.5rem);
+    }
     @media (max-width: 768px) {
       .doc-layout { grid-template-columns: 1fr; }
       .cmd-nav { display: none; }
@@ -150,7 +154,7 @@
       
 
       <div class="page-label">チュートリアル</div>
-      <h1 class="page-title">投資戦略の開発・バックテスト・最適化</h1>
+      <h1 class="page-title">投資戦略の開発・<br>バックテスト・最適化</h1>
       <p class="page-subtitle">
         戦略 JSON の作成から、バックテスト実行・ベイズ最適化・ウォークフォワード検証まで一気通貫で学べる AlphaForge 入門ガイドです。
         CL=F（WTI原油先物）を例題に、HMM + ボリンジャーバンド + RSI の複合戦略を実装します。

--- a/page.css
+++ b/page.css
@@ -158,7 +158,6 @@ body[data-lang="en"] .lang-en { display: block; }
   font-size: clamp(2rem, 5vw, 3rem); font-weight: 700;
   letter-spacing: -0.04em; line-height: 1.1; color: var(--text);
   margin-bottom: 0.75rem;
-  text-wrap: balance;
 }
 .page-subtitle {
   font-size: 1rem; color: var(--text2); line-height: 1.7;

--- a/templates/tutorial-strategy.html.j2
+++ b/templates/tutorial-strategy.html.j2
@@ -71,6 +71,10 @@
       background: var(--accent-bg); color: var(--accent); border-radius: 4px;
       padding: 0.15rem 0.5rem; margin-left: 0.4rem; vertical-align: middle;
     }
+    /* tutorial 専用: H1 文字列が長いため、page-title フォントを 1 段下げて右余白を確保 */
+    .page-title {
+      font-size: clamp(1.75rem, 4vw, 2.5rem);
+    }
     @media (max-width: 768px) {
       .doc-layout { grid-template-columns: 1fr; }
       .cmd-nav { display: none; }
@@ -98,7 +102,7 @@
       {% if lang == 'ja' %}
 
       <div class="page-label">チュートリアル</div>
-      <h1 class="page-title">投資戦略の開発・バックテスト・最適化</h1>
+      <h1 class="page-title">投資戦略の開発・<br>バックテスト・最適化</h1>
       <p class="page-subtitle">
         戦略 JSON の作成から、バックテスト実行・ベイズ最適化・ウォークフォワード検証まで一気通貫で学べる AlphaForge 入門ガイドです。
         CL=F（WTI原油先物）を例題に、HMM + ボリンジャーバンド + RSI の複合戦略を実装します。
@@ -505,7 +509,7 @@ Avg Sharpe: 1.10  |  Avg CAGR: 13.9%  |  WF Efficiency: 89%</code></pre>
       {% else %}
 
       <div class="page-label">Tutorial</div>
-      <h1 class="page-title">Strategy Development, Backtesting &amp; Optimization</h1>
+      <h1 class="page-title">Strategy Development,<br>Backtesting &amp; Optimization</h1>
       <p class="page-subtitle">
         A step-by-step guide to building quantitative investment strategies with AlphaForge —
         from writing strategy JSON to running backtests, Bayesian optimization, and walk-forward validation.


### PR DESCRIPTION
## 背景

PR #275 後の状態で：

- `text-wrap: balance` が日本語 18 文字を文字数で均等分割し「投資戦略の開発・**バ**／**ック**テスト・最適化」と単語の途中で切れる読みづらい改行になっていた
- さらに H1 フォントが 3rem (48px) のままで、文字長 × フォントの組み合わせで page-wrap (860px) のほぼ全幅を占め、install と比べて右余白が極端に少なく見える問題も残っていた

C 案として install には影響を与えず tutorial だけ修正します。

## 変更内容

### `templates/tutorial-strategy.html.j2`
- ja / en の H1 に **意味境界の `<br>` を復活**
  - ja: `投資戦略の開発・<br>バックテスト・最適化`
  - en: `Strategy Development,<br>Backtesting & Optimization`
- インライン `<style>` 内で **`.page-title` の font-size を tutorial 専用に縮小**：`clamp(2rem, 5vw, 3rem)` → `clamp(1.75rem, 4vw, 2.5rem)`（48px → 40px が最大）

### `page.css`
- PR #275 で追加した `.page-title` の `text-wrap: balance` を **削除**（balance を残すと install など他ページの短い H1 で意図しないバランス分割が起きるリスクがあるため、責任範囲を tutorial に限定）

### `ja/tutorial-strategy.html` / `en/tutorial-strategy.html`
- `uv run python build.py` で再生成

## 効果

- H1 は意味境界で 2 行表示 → 読みやすい
- フォントが 1 段下がり、各行が page-wrap の右端まで届かなくなり右余白が確保される
- install / privacy / terms / docs / index の H1 は影響を受けない（CSS scope は tutorial のインライン style 内に閉じている）