### PR TITLE
fix(tutorial): doc-layout grid の overflow を minmax(0, 1fr) で抑制

### DIFF
--- a/en/tutorial-strategy.html
+++ b/en/tutorial-strategy.html
@@ -74,8 +74,11 @@
       border-left: 2px solid transparent;
     }
     .doc-layout {
-      display: grid; grid-template-columns: 210px 1fr; gap: 3rem;
+      display: grid; grid-template-columns: 210px minmax(0, 1fr); gap: 3rem;
     }
+    .doc-layout > * { min-width: 0; }
+    .doc-layout pre { overflow-x: auto; }
+    .doc-layout .option-table { display: block; overflow-x: auto; }
     .option-table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
     .option-table th {
       font-family: var(--mono); font-size: 0.65rem; color: var(--text3);

--- a/ja/tutorial-strategy.html
+++ b/ja/tutorial-strategy.html
@@ -74,8 +74,11 @@
       border-left: 2px solid transparent;
     }
     .doc-layout {
-      display: grid; grid-template-columns: 210px 1fr; gap: 3rem;
+      display: grid; grid-template-columns: 210px minmax(0, 1fr); gap: 3rem;
     }
+    .doc-layout > * { min-width: 0; }
+    .doc-layout pre { overflow-x: auto; }
+    .doc-layout .option-table { display: block; overflow-x: auto; }
     .option-table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
     .option-table th {
       font-family: var(--mono); font-size: 0.65rem; color: var(--text3);

--- a/templates/tutorial-strategy.html.j2
+++ b/templates/tutorial-strategy.html.j2
@@ -22,8 +22,11 @@
       border-left: 2px solid transparent;
     }
     .doc-layout {
-      display: grid; grid-template-columns: 210px 1fr; gap: 3rem;
+      display: grid; grid-template-columns: 210px minmax(0, 1fr); gap: 3rem;
     }
+    .doc-layout > * { min-width: 0; }
+    .doc-layout pre { overflow-x: auto; }
+    .doc-layout .option-table { display: block; overflow-x: auto; }
     .option-table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
     .option-table th {
       font-family: var(--mono); font-size: 0.65rem; color: var(--text3);


### PR DESCRIPTION
## 原因

`.doc-layout` の `grid-template-columns: 210px 1fr` は CSS Grid の典型的 gotcha で、右カラムの暗黙の `min-width: auto` がコンテンツ依存になります。内側の `<pre><code>` の長い curl / JSON ブロックや `<table>` が grid item をコンテンツ幅まで拡大し、結果として **page-wrap (860px) の右端から本文ブロックがはみ出す** 状態になっていました（添付スクショの「コンポーネント / 役割」テーブルや段落が画面右端まで届く現象）。

## 修正

- `.doc-layout` の grid を **`210px minmax(0, 1fr)`** に変更（min を 0 に固定してコンテンツによる拡大を止める）
- `.doc-layout > * { min-width: 0; }` で grid item 全体に保険
- `.doc-layout pre { overflow-x: auto; }` で長いコードブロックは横スクロール
- `.doc-layout .option-table` を `display: block; overflow-x: auto` で広い表も横スクロール

## 影響範囲

- `tutorial-strategy.html` のみ（インライン `<style>` 内の修正なので他ページに影響なし）
- ja/en HTML を `build.py` で再生成