### PR TITLE
fix(tutorial): step-list 内側の grid も minmax(0, 1fr) で overflow を抑制

### DIFF
--- a/en/tutorial-strategy.html
+++ b/en/tutorial-strategy.html
@@ -102,9 +102,10 @@
     .step-list { list-style: none; padding: 0; counter-reset: steps; }
     .step-list li {
       counter-increment: steps;
-      display: grid; grid-template-columns: 2rem 1fr; gap: 1rem;
+      display: grid; grid-template-columns: 2rem minmax(0, 1fr); gap: 1rem;
       margin-bottom: 1.5rem; align-items: start;
     }
+    .step-list li > div { min-width: 0; }
     .step-list li::before {
       content: counter(steps);
       display: flex; align-items: center; justify-content: center;

--- a/ja/tutorial-strategy.html
+++ b/ja/tutorial-strategy.html
@@ -102,9 +102,10 @@
     .step-list { list-style: none; padding: 0; counter-reset: steps; }
     .step-list li {
       counter-increment: steps;
-      display: grid; grid-template-columns: 2rem 1fr; gap: 1rem;
+      display: grid; grid-template-columns: 2rem minmax(0, 1fr); gap: 1rem;
       margin-bottom: 1.5rem; align-items: start;
     }
+    .step-list li > div { min-width: 0; }
     .step-list li::before {
       content: counter(steps);
       display: flex; align-items: center; justify-content: center;

--- a/templates/tutorial-strategy.html.j2
+++ b/templates/tutorial-strategy.html.j2
@@ -50,9 +50,10 @@
     .step-list { list-style: none; padding: 0; counter-reset: steps; }
     .step-list li {
       counter-increment: steps;
-      display: grid; grid-template-columns: 2rem 1fr; gap: 1rem;
+      display: grid; grid-template-columns: 2rem minmax(0, 1fr); gap: 1rem;
       margin-bottom: 1.5rem; align-items: start;
     }
+    .step-list li > div { min-width: 0; }
     .step-list li::before {
       content: counter(steps);
       display: flex; align-items: center; justify-content: center;


### PR DESCRIPTION
## 原因

PR #277 で `.doc-layout` の grid を `minmax(0, 1fr)` に修正したが、**ステップ説明の `<ol class="step-list">` の `<li>` も独自の grid**（`grid-template-columns: 2rem 1fr`）を持っており、入れ子の grid item でも同じ `min-width: auto` 問題が再発していた。

ステップごとに含まれる `<pre>` / `<code>` 内のコマンド長さが異なるため、コードブロックの右端位置がバラバラ（ステップ 2・3 のように長い行を含む pre は親 grid item を引っ張って広がる）に見えていました（添付スクショ）。

## 修正

- `.step-list li` の grid を `2rem minmax(0, 1fr)` に変更
- `.step-list li > div { min-width: 0; }` で内側 div にも保険

これで step-list 内の `<pre>` も親 div の幅内に収まり、長いコード行は pre 内で横スクロール（PR #277 で追加した `.doc-layout pre { overflow-x: auto }` が機能する）。

## 影響範囲

- tutorial-strategy.html のみ（インライン `<style>` 内の修正）
- ja/en HTML を build.py で再生成

## 残課題メモ

CSS Grid の `1fr` で nested grid を作っている箇所は他にもある可能性があるため、念のため確認しておいた方が良い（今回は step-list で発覚）。