### PR TITLE
fix(landing): pricing セクションの CSS 命名 .free-* → .trial-* に追従

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -666,8 +666,8 @@
       color: var(--text3); max-width: 1040px;
     }
 
-    /* ── FREE BANNER ── */
-    .free-banner {
+    /* ── TRIAL BANNER ── */
+    .trial-banner {
       margin-top: 2rem;
       border: 1px dashed rgba(0,228,154,0.35);
       border-radius: var(--r);
@@ -675,37 +675,37 @@
       padding: 1.1rem 1.4rem;
       display: flex; align-items: center; gap: 1.2rem; flex-wrap: wrap;
     }
-    .free-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
-    .free-banner-body { flex: 1; min-width: 200px; }
-    .free-banner-title {
+    .trial-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
+    .trial-banner-body { flex: 1; min-width: 200px; }
+    .trial-banner-title {
       font-size: 0.95rem; font-weight: 600;
       display: flex; align-items: center; gap: 0.5rem;
     }
-    .free-badge {
+    .trial-badge {
       font-family: var(--mono); font-size: 0.6rem; letter-spacing: 0.08em;
       text-transform: uppercase;
       background: rgba(0,228,154,0.12); color: var(--accent);
       border: 1px solid rgba(0,228,154,0.25); border-radius: 4px; padding: 1px 6px;
     }
-    .free-banner-desc {
+    .trial-banner-desc {
       margin-top: 0.3rem; color: var(--text2);
       font-size: 0.82rem; line-height: 1.5;
     }
-    .free-banner-pills {
+    .trial-banner-pills {
       margin-top: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.4rem;
     }
-    .free-pill {
+    .trial-pill {
       font-size: 0.68rem; padding: 2px 8px; border-radius: 20px;
       border: 1px solid var(--border); color: var(--text2);
     }
-    .free-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
-    .free-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
-    .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
-    .free-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
-    .free-banner-cta .btn-secondary {
+    .trial-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
+    .trial-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
+    .trial-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
+    .trial-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
+    .trial-banner-cta .btn-secondary {
       width: 100%; justify-content: center;
     }
-    .free-banner-status {
+    .trial-banner-status {
       margin-top: 0.35rem;
       color: var(--text3);
       font-family: var(--mono);
@@ -729,11 +729,11 @@
     }
     .comparison-table thead tr { border-bottom: 1px solid var(--border); }
     .comparison-th-feature { padding: 0.5rem 0.75rem; text-align: left; font-weight: 600; font-size: 0.78rem; width: 48%; }
-    .comparison-th-free    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
-    .comparison-th-paid    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
+    .comparison-th-trial    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
+    .comparison-th-lifetime    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
     .comparison-td-feature { padding: 0.5rem 0.75rem; color: var(--text2); border-bottom: 1px solid rgba(255,255,255,0.04); }
-    .comparison-td-free    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
-    .comparison-td-paid    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-trial    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-lifetime    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
     .comparison-table tbody tr:last-child td { border-bottom: none; }
     .comparison-table tbody tr:nth-child(even) td { background: rgba(255,255,255,0.015); }
     .cmp-ok    { color: var(--accent); }
@@ -1052,9 +1052,9 @@
         text-align: center;
       }
       .trial-start-link { width: fit-content; }
-      .free-banner { flex-direction: column; align-items: flex-start; }
-      .free-banner-cta { width: 100%; }
-      .free-banner-cta .btn-secondary { width: 100%; }
+      .trial-banner { flex-direction: column; align-items: flex-start; }
+      .trial-banner-cta { width: 100%; }
+      .trial-banner-cta .btn-secondary { width: 100%; }
       .nav-page-link { padding: 0 0.55rem; }
       .lang-btn { padding: 0 0.55rem; }
       .follow-btn-nav {

--- a/ja/index.html
+++ b/ja/index.html
@@ -666,8 +666,8 @@
       color: var(--text3); max-width: 1040px;
     }
 
-    /* ── FREE BANNER ── */
-    .free-banner {
+    /* ── TRIAL BANNER ── */
+    .trial-banner {
       margin-top: 2rem;
       border: 1px dashed rgba(0,228,154,0.35);
       border-radius: var(--r);
@@ -675,37 +675,37 @@
       padding: 1.1rem 1.4rem;
       display: flex; align-items: center; gap: 1.2rem; flex-wrap: wrap;
     }
-    .free-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
-    .free-banner-body { flex: 1; min-width: 200px; }
-    .free-banner-title {
+    .trial-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
+    .trial-banner-body { flex: 1; min-width: 200px; }
+    .trial-banner-title {
       font-size: 0.95rem; font-weight: 600;
       display: flex; align-items: center; gap: 0.5rem;
     }
-    .free-badge {
+    .trial-badge {
       font-family: var(--mono); font-size: 0.6rem; letter-spacing: 0.08em;
       text-transform: uppercase;
       background: rgba(0,228,154,0.12); color: var(--accent);
       border: 1px solid rgba(0,228,154,0.25); border-radius: 4px; padding: 1px 6px;
     }
-    .free-banner-desc {
+    .trial-banner-desc {
       margin-top: 0.3rem; color: var(--text2);
       font-size: 0.82rem; line-height: 1.5;
     }
-    .free-banner-pills {
+    .trial-banner-pills {
       margin-top: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.4rem;
     }
-    .free-pill {
+    .trial-pill {
       font-size: 0.68rem; padding: 2px 8px; border-radius: 20px;
       border: 1px solid var(--border); color: var(--text2);
     }
-    .free-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
-    .free-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
-    .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
-    .free-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
-    .free-banner-cta .btn-secondary {
+    .trial-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
+    .trial-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
+    .trial-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
+    .trial-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
+    .trial-banner-cta .btn-secondary {
       width: 100%; justify-content: center;
     }
-    .free-banner-status {
+    .trial-banner-status {
       margin-top: 0.35rem;
       color: var(--text3);
       font-family: var(--mono);
@@ -729,11 +729,11 @@
     }
     .comparison-table thead tr { border-bottom: 1px solid var(--border); }
     .comparison-th-feature { padding: 0.5rem 0.75rem; text-align: left; font-weight: 600; font-size: 0.78rem; width: 48%; }
-    .comparison-th-free    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
-    .comparison-th-paid    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
+    .comparison-th-trial    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
+    .comparison-th-lifetime    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
     .comparison-td-feature { padding: 0.5rem 0.75rem; color: var(--text2); border-bottom: 1px solid rgba(255,255,255,0.04); }
-    .comparison-td-free    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
-    .comparison-td-paid    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-trial    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-lifetime    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
     .comparison-table tbody tr:last-child td { border-bottom: none; }
     .comparison-table tbody tr:nth-child(even) td { background: rgba(255,255,255,0.015); }
     .cmp-ok    { color: var(--accent); }
@@ -1052,9 +1052,9 @@
         text-align: center;
       }
       .trial-start-link { width: fit-content; }
-      .free-banner { flex-direction: column; align-items: flex-start; }
-      .free-banner-cta { width: 100%; }
-      .free-banner-cta .btn-secondary { width: 100%; }
+      .trial-banner { flex-direction: column; align-items: flex-start; }
+      .trial-banner-cta { width: 100%; }
+      .trial-banner-cta .btn-secondary { width: 100%; }
       .nav-page-link { padding: 0 0.55rem; }
       .lang-btn { padding: 0 0.55rem; }
       .follow-btn-nav {

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -586,8 +586,8 @@
       color: var(--text3); max-width: 1040px;
     }
 
-    /* ── FREE BANNER ── */
-    .free-banner {
+    /* ── TRIAL BANNER ── */
+    .trial-banner {
       margin-top: 2rem;
       border: 1px dashed rgba(0,228,154,0.35);
       border-radius: var(--r);
@@ -595,37 +595,37 @@
       padding: 1.1rem 1.4rem;
       display: flex; align-items: center; gap: 1.2rem; flex-wrap: wrap;
     }
-    .free-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
-    .free-banner-body { flex: 1; min-width: 200px; }
-    .free-banner-title {
+    .trial-banner-icon { font-size: 1.5rem; flex-shrink: 0; }
+    .trial-banner-body { flex: 1; min-width: 200px; }
+    .trial-banner-title {
       font-size: 0.95rem; font-weight: 600;
       display: flex; align-items: center; gap: 0.5rem;
     }
-    .free-badge {
+    .trial-badge {
       font-family: var(--mono); font-size: 0.6rem; letter-spacing: 0.08em;
       text-transform: uppercase;
       background: rgba(0,228,154,0.12); color: var(--accent);
       border: 1px solid rgba(0,228,154,0.25); border-radius: 4px; padding: 1px 6px;
     }
-    .free-banner-desc {
+    .trial-banner-desc {
       margin-top: 0.3rem; color: var(--text2);
       font-size: 0.82rem; line-height: 1.5;
     }
-    .free-banner-pills {
+    .trial-banner-pills {
       margin-top: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.4rem;
     }
-    .free-pill {
+    .trial-pill {
       font-size: 0.68rem; padding: 2px 8px; border-radius: 20px;
       border: 1px solid var(--border); color: var(--text2);
     }
-    .free-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
-    .free-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
-    .free-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
-    .free-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
-    .free-banner-cta .btn-secondary {
+    .trial-pill-ok    { border-color: rgba(0,228,154,0.3); color: var(--accent); }
+    .trial-pill-limit { border-color: rgba(245,166,35,0.3); color: var(--amber); }
+    .trial-pill-no    { border-color: rgba(255,255,255,0.1); color: var(--text3); text-decoration: line-through; }
+    .trial-banner-cta { flex-shrink: 0; min-width: 140px; text-align: center; }
+    .trial-banner-cta .btn-secondary {
       width: 100%; justify-content: center;
     }
-    .free-banner-status {
+    .trial-banner-status {
       margin-top: 0.35rem;
       color: var(--text3);
       font-family: var(--mono);
@@ -649,11 +649,11 @@
     }
     .comparison-table thead tr { border-bottom: 1px solid var(--border); }
     .comparison-th-feature { padding: 0.5rem 0.75rem; text-align: left; font-weight: 600; font-size: 0.78rem; width: 48%; }
-    .comparison-th-free    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
-    .comparison-th-paid    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
+    .comparison-th-trial    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 22%; color: var(--text2); }
+    .comparison-th-lifetime    { padding: 0.5rem 0.75rem; text-align: center; font-weight: 600; font-size: 0.78rem; width: 30%; color: var(--accent); }
     .comparison-td-feature { padding: 0.5rem 0.75rem; color: var(--text2); border-bottom: 1px solid rgba(255,255,255,0.04); }
-    .comparison-td-free    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
-    .comparison-td-paid    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-trial    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
+    .comparison-td-lifetime    { padding: 0.5rem 0.75rem; text-align: center; border-bottom: 1px solid rgba(255,255,255,0.04); }
     .comparison-table tbody tr:last-child td { border-bottom: none; }
     .comparison-table tbody tr:nth-child(even) td { background: rgba(255,255,255,0.015); }
     .cmp-ok    { color: var(--accent); }
@@ -972,9 +972,9 @@
         text-align: center;
       }
       .trial-start-link { width: fit-content; }
-      .free-banner { flex-direction: column; align-items: flex-start; }
-      .free-banner-cta { width: 100%; }
-      .free-banner-cta .btn-secondary { width: 100%; }
+      .trial-banner { flex-direction: column; align-items: flex-start; }
+      .trial-banner-cta { width: 100%; }
+      .trial-banner-cta .btn-secondary { width: 100%; }
       .nav-page-link { padding: 0 0.55rem; }
       .lang-btn { padding: 0 0.55rem; }
       .follow-btn-nav {


### PR DESCRIPTION
## 症状

ランディングページ #pricing セクションの Trial プランバナー（TrialBanner）と
比較表が CSS 完全未適用となり、グリッド・カード・ピル・バッジが全部フラットな
テキスト並びで表示されていた。

> 「使い方に合わせて選べるプラン」の下に ⚙ アイコンと
> 「Trial プランで始めるTrial」というラベルがフラットに並ぶ崩壊状態

## 原因

PR #254（Free → Trial 全面リネーム、5bc4102）で
`homepage-components.jsx` の className を `.free-*` → `.trial-*` にリネームしたが、
CSS 本体である `templates/index.html.j2` のセレクタは `.free-*` のまま残っていた。

PR bfa0603 で過去 1 度修正したものの、修正先が `ja/index.html` / `en/index.html` の
**生成済みファイルだけ**で、テンプレート側に未反映 → `build.py` 実行で巻き戻り。

（ランディング JSX className と CSS の同期問題、**3 度目の発生**）

## 修正

`templates/index.html.j2` のセレクタをまとめてリネーム:

| 旧（CSS のみ存在） | 新（JSX と一致） |
|-------------------|----------------|
| `.free-banner` / `.free-banner-icon` / `.free-banner-body` / `.free-banner-title` / `.free-banner-desc` / `.free-banner-pills` / `.free-banner-cta` / `.free-banner-status` | `.trial-banner` ... 同名 |
| `.free-badge` | `.trial-badge` |
| `.free-pill` / `.free-pill-ok` / `.free-pill-limit` / `.free-pill-no` | `.trial-pill` ... 同名 |
| `.comparison-th-free` / `.comparison-th-paid` | `.comparison-th-trial` / `.comparison-th-lifetime` |
| `.comparison-td-free` / `.comparison-td-paid` | `.comparison-td-trial` / `.comparison-td-lifetime` |

その後 `uv run python build.py` で `ja/index.html` / `en/index.html` を再生成。

## Test plan

- [x] JSX className と CSS セレクタの diff: MISSING は `trial-banner-install-link` と `trial-start-examples-link` のみで、両方 JSX 側でインライン style 指定済みのため意図的にスキップ
- [x] `uv run python build.py` で ja/en 両方に `.trial-banner` CSS の展開を確認（12 件マッチ）
- [ ] マージ後 https://alforgelabs.com/ja/#pricing を目視確認