### PR TITLE
fix(install, tutorial): Trial プランは Whop 登録不要であることを正しく反映

### DIFF
--- a/en/install.html
+++ b/en/install.html
@@ -87,8 +87,8 @@
     <div class="lang-en">
       
       <div class="page-label">Getting Started</div>
-      <h1 class="page-title">Get AlphaForge Running in 3 Steps</h1>
-      <p class="page-subtitle">Register on Whop → Install → Sign in. The Free plan is free of charge (about 10 minutes total). Full instructions live in the official docs.</p>
+      <h1 class="page-title">Get AlphaForge Running in a Single Step</h1>
+      <p class="page-subtitle"><strong>The Trial plan needs no Whop registration and has no time limit</strong> — install once and you're ready to run (about 5 minutes total). A Whop OAuth login is only required to unlock the paid plans (Lifetime / Annual / Monthly). Full instructions live in the official docs.</p>
 
       <div class="callout" style="margin-bottom: 2rem;">
         <p style="margin-bottom: 0.75rem;">
@@ -100,20 +100,7 @@
         </a>
       </div>
 
-      <h2 class="section-heading">Step 1 — Create a Whop Account</h2>
-      <p>
-        AlphaForge requires a Whop account for <strong>every plan, including Free</strong>. Start with the Free plan and upgrade to a paid plan later if you need more.
-      </p>
-      <p style="margin-top: 1rem;">
-        <a href="https://whop.com/alforge-labs/alphaforge-free/" target="_blank" rel="noopener" class="btn-primary">
-          Register Free on Whop →
-        </a>
-      </p>
-      <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
-        Want to start on a paid plan? Pick one from the <a href="https://whop.com/alforge-labs/alphaforge/" target="_blank" rel="noopener">paid plans page</a>. See <a href="/en/docs/guides/freemium-limits/">Freemium Limits</a> for the differences.
-      </p>
-
-      <h2 class="section-heading">Step 2 — Install the CLI</h2>
+      <h2 class="section-heading">Step 1 — Install the CLI</h2>
       <div class="platform-tabs" role="tablist">
         <button type="button" class="platform-tab active" role="tab" aria-selected="true" aria-controls="tab-en-mac" onclick="switchTab('en', 'mac', event)">macOS / Linux</button>
         <button type="button" class="platform-tab" role="tab" aria-selected="false" aria-controls="tab-en-win" onclick="switchTab('en', 'win', event)">Windows</button>
@@ -134,11 +121,25 @@
         <a href="https://github.com/alforge-labs/alforge-labs.github.io/releases/latest" target="_blank" rel="noopener">GitHub Releases (latest)</a>.
       </p>
 
-      <h2 class="section-heading">Step 3 — Sign in with Whop</h2>
-      <p>Sign in with the Whop account you registered in Step 1 via OAuth 2.0 PKCE — your browser opens automatically. Authentication data is cached at <code>~/.forge/credentials.json</code>.</p>
+      <h2 class="section-heading">Step 2 — Run on the Trial plan right away (no Whop registration)</h2>
+      <p>
+        Once installed, the Trial plan lets you immediately run <code>forge backtest run</code>, <code>forge optimize run</code>, <code>forge optimize walk-forward</code>, and more. The only Trial limits are: data capped at 2023-12-31, optimization capped at 50 trials, and no Pine Script export — everything else mirrors the paid plans.
+      </p>
+      <pre><code># Example: run a backtest right away (Trial plan, no Whop registration)
+forge system init                 # initialize a working directory
+forge data fetch SPY --period 5y  # auto-fetch data up to 2023-12-31
+forge backtest run SPY --strategy sma_crossover_v1</code></pre>
+
+      <h2 class="section-heading">Paid plans (optional) — Sign in with Whop</h2>
+      <p>
+        To lift the Trial limits, purchase a <a href="https://whop.com/alforge-labs/alphaforge/" target="_blank" rel="noopener">paid plan on Whop</a> (Lifetime / Annual / Monthly) and then run the command below. The OAuth 2.0 PKCE flow opens your browser automatically; credentials are cached at <code>~/.forge/credentials.json</code>.
+      </p>
       <pre><code>forge system auth login</code></pre>
       <p>Verify the activated membership with:</p>
       <pre><code>forge system auth status</code></pre>
+      <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
+        See <a href="/en/docs/guides/freemium-limits/">Freemium Limits</a> for the full feature comparison between Trial and paid plans.
+      </p>
 
       <h2 class="section-heading">Visualize Results — alpha-visualizer (optional)</h2>
       <p>

--- a/en/tutorial-strategy.html
+++ b/en/tutorial-strategy.html
@@ -219,13 +219,13 @@
                 <div>
                   <strong>Install alpha-forge</strong>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                    The installer downloads the latest binary (macOS / Linux shown). See the <a href="install.html">installation guide</a> for Windows or manual placement. Then sign in with your Whop account (OAuth 2.0 PKCE) — the browser opens automatically.
+                    The installer downloads the latest binary (macOS / Linux shown). See the <a href="install.html">installation guide</a> for Windows or manual placement. <strong>The Trial plan needs no Whop registration and has no time limit</strong> — you can use the CLI right after installing. Whop OAuth login is only required after purchasing a paid plan (Lifetime / Annual / Monthly) to unlock the additional features.
                   </p>
                   <pre><code># Install the latest binary (macOS / Linux)
 curl -sSL https://alforge-labs.github.io/install.sh | bash
 
-# Sign in via Whop OAuth
-forge system auth login</code></pre>
+# (optional) After purchasing a paid plan, sign in via Whop OAuth to unlock it
+# forge system auth login</code></pre>
                 </div>
               </li>
               <li>

--- a/ja/install.html
+++ b/ja/install.html
@@ -87,8 +87,8 @@
     <div class="lang-ja">
       
       <div class="page-label">Getting Started</div>
-      <h1 class="page-title">3 ステップで AlphaForge を動かす</h1>
-      <p class="page-subtitle">Whop 登録 → インストール → ログイン認証。Free プランなら無料で始められます（所要時間 約 10 分）。詳細手順は公式ドキュメントへ。</p>
+      <h1 class="page-title">最短 1 ステップで AlphaForge を動かす</h1>
+      <p class="page-subtitle"><strong>Trial プランは Whop 登録不要・期限なし</strong>で、インストール直後からそのまま使えます（所要時間 約 5 分）。有料プラン（Lifetime / Annual / Monthly）の機能解放のみ Whop OAuth 認証が必要です。詳細手順は公式ドキュメントへ。</p>
 
       <div class="callout" style="margin-bottom: 2rem;">
         <p style="margin-bottom: 0.75rem;">
@@ -100,20 +100,7 @@
         </a>
       </div>
 
-      <h2 class="section-heading">ステップ 1 — Whop でアカウント登録</h2>
-      <p>
-        AlphaForge は Whop でのアカウント登録が必要です（<strong>Free プランも含めて全プラン共通</strong>）。まずは無料プランで登録し、CLI を動かしてから必要に応じて有料プランへアップグレードできます。
-      </p>
-      <p style="margin-top: 1rem;">
-        <a href="https://whop.com/alforge-labs/alphaforge-free/" target="_blank" rel="noopener" class="btn-primary">
-          無料で Whop に登録 →
-        </a>
-      </p>
-      <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
-        最初から有料プランで始めたい場合は <a href="https://whop.com/alforge-labs/alphaforge/" target="_blank" rel="noopener">有料プラン一覧</a> から購入してください。Free / 有料の機能差は <a href="/ja/docs/guides/freemium-limits/">フリーミアム制限</a> を参照。
-      </p>
-
-      <h2 class="section-heading">ステップ 2 — CLI をインストール</h2>
+      <h2 class="section-heading">ステップ 1 — CLI をインストール</h2>
       <div class="platform-tabs" role="tablist">
         <button type="button" class="platform-tab active" role="tab" aria-selected="true" aria-controls="tab-ja-mac" onclick="switchTab('ja', 'mac', event)">macOS / Linux</button>
         <button type="button" class="platform-tab" role="tab" aria-selected="false" aria-controls="tab-ja-win" onclick="switchTab('ja', 'win', event)">Windows</button>
@@ -135,11 +122,25 @@
         から各プラットフォーム向けバイナリを直接ダウンロードできます。
       </p>
 
-      <h2 class="section-heading">ステップ 3 — Whop でログイン認証</h2>
-      <p>ステップ 1 で登録した Whop アカウントで OAuth 2.0 PKCE 認証を行います。ブラウザが自動で開きます。認証情報は <code>~/.forge/credentials.json</code> に保存されます。</p>
+      <h2 class="section-heading">ステップ 2 — そのまま Trial プランで使う（Whop 登録不要）</h2>
+      <p>
+        インストール直後から Trial プランで <code>forge backtest run</code> / <code>forge optimize run</code> / <code>forge optimize walk-forward</code> 等が動きます。Trial の制限はデータ上限 2023-12-31・最適化 50 trials・Pine Script 生成不可の 3 点のみで、それ以外は有料プランと同じ機能を試せます。
+      </p>
+      <pre><code># 例: いきなりバックテストを動かす（Trial プラン・Whop 登録不要）
+forge system init                 # 作業ディレクトリ初期化
+forge data fetch SPY --period 5y  # 2023-12-31 までのデータを自動取得
+forge backtest run SPY --strategy sma_crossover_v1</code></pre>
+
+      <h2 class="section-heading">有料プラン（任意） — Whop でログイン認証</h2>
+      <p>
+        Trial の制限を解除したい場合のみ、<a href="https://whop.com/alforge-labs/alphaforge/" target="_blank" rel="noopener">Whop の有料プラン</a>（Lifetime / Annual / Monthly）を購入してから以下を実行します。OAuth 2.0 PKCE 認証でブラウザが自動で開き、認証情報は <code>~/.forge/credentials.json</code> に保存されます。
+      </p>
       <pre><code>forge system auth login</code></pre>
       <p>認証済みメンバーシップは以下で確認できます：</p>
       <pre><code>forge system auth status</code></pre>
+      <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
+        Trial / 各有料プランの機能差は <a href="/ja/docs/guides/freemium-limits/">フリーミアム制限</a> を参照。
+      </p>
 
       <h2 class="section-heading">結果を可視化する — alpha-visualizer（任意）</h2>
       <p>

--- a/ja/tutorial-strategy.html
+++ b/ja/tutorial-strategy.html
@@ -218,13 +218,13 @@
                 <div>
                   <strong>alpha-forge を取得してインストール</strong>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                    インストーラーが最新バイナリをダウンロードします（macOS / Linux 例）。Windows / 手動配置は <a href="install.html">インストールガイド</a> を参照してください。続けて Whop アカウントで OAuth 2.0 PKCE 認証を行います（ブラウザが自動で開きます）。
+                    インストーラーが最新バイナリをダウンロードします（macOS / Linux 例）。Windows / 手動配置は <a href="install.html">インストールガイド</a> を参照してください。<strong>Trial プランは Whop 登録不要・期限なし</strong>でインストール直後からそのまま使えます。Whop OAuth 認証は有料プラン（Lifetime / Annual / Monthly）を購入後に機能解放したい場合のみ実行してください。
                   </p>
                   <pre><code># 最新バイナリをインストール（macOS / Linux）
 curl -sSL https://alforge-labs.github.io/install.sh | bash
 
-# Whop アカウントで認証
-forge system auth login</code></pre>
+# （任意）有料プラン購入後に Whop OAuth 認証で機能解放する
+# forge system auth login</code></pre>
                 </div>
               </li>
               <li>

--- a/templates/install.html.j2
+++ b/templates/install.html.j2
@@ -35,8 +35,8 @@
     <div class="lang-{{ lang }}">
       {% if lang == 'ja' %}
       <div class="page-label">Getting Started</div>
-      <h1 class="page-title">3 ステップで AlphaForge を動かす</h1>
-      <p class="page-subtitle">Whop 登録 → インストール → ログイン認証。Free プランなら無料で始められます（所要時間 約 10 分）。詳細手順は公式ドキュメントへ。</p>
+      <h1 class="page-title">最短 1 ステップで AlphaForge を動かす</h1>
+      <p class="page-subtitle"><strong>Trial プランは Whop 登録不要・期限なし</strong>で、インストール直後からそのまま使えます（所要時間 約 5 分）。有料プラン（Lifetime / Annual / Monthly）の機能解放のみ Whop OAuth 認証が必要です。詳細手順は公式ドキュメントへ。</p>
 
       <div class="callout" style="margin-bottom: 2rem;">
         <p style="margin-bottom: 0.75rem;">
@@ -48,20 +48,7 @@
         </a>
       </div>
 
-      <h2 class="section-heading">ステップ 1 — Whop でアカウント登録</h2>
-      <p>
-        AlphaForge は Whop でのアカウント登録が必要です（<strong>Free プランも含めて全プラン共通</strong>）。まずは無料プランで登録し、CLI を動かしてから必要に応じて有料プランへアップグレードできます。
-      </p>
-      <p style="margin-top: 1rem;">
-        <a href="https://whop.com/alforge-labs/alphaforge-free/" target="_blank" rel="noopener" class="btn-primary">
-          無料で Whop に登録 →
-        </a>
-      </p>
-      <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
-        最初から有料プランで始めたい場合は <a href="https://whop.com/alforge-labs/alphaforge/" target="_blank" rel="noopener">有料プラン一覧</a> から購入してください。Free / 有料の機能差は <a href="/ja/docs/guides/freemium-limits/">フリーミアム制限</a> を参照。
-      </p>
-
-      <h2 class="section-heading">ステップ 2 — CLI をインストール</h2>
+      <h2 class="section-heading">ステップ 1 — CLI をインストール</h2>
       <div class="platform-tabs" role="tablist">
         <button type="button" class="platform-tab active" role="tab" aria-selected="true" aria-controls="tab-ja-mac" onclick="switchTab('ja', 'mac', event)">macOS / Linux</button>
         <button type="button" class="platform-tab" role="tab" aria-selected="false" aria-controls="tab-ja-win" onclick="switchTab('ja', 'win', event)">Windows</button>
@@ -83,11 +70,25 @@
         から各プラットフォーム向けバイナリを直接ダウンロードできます。
       </p>
 
-      <h2 class="section-heading">ステップ 3 — Whop でログイン認証</h2>
-      <p>ステップ 1 で登録した Whop アカウントで OAuth 2.0 PKCE 認証を行います。ブラウザが自動で開きます。認証情報は <code>~/.forge/credentials.json</code> に保存されます。</p>
+      <h2 class="section-heading">ステップ 2 — そのまま Trial プランで使う（Whop 登録不要）</h2>
+      <p>
+        インストール直後から Trial プランで <code>forge backtest run</code> / <code>forge optimize run</code> / <code>forge optimize walk-forward</code> 等が動きます。Trial の制限はデータ上限 2023-12-31・最適化 50 trials・Pine Script 生成不可の 3 点のみで、それ以外は有料プランと同じ機能を試せます。
+      </p>
+      <pre><code># 例: いきなりバックテストを動かす（Trial プラン・Whop 登録不要）
+forge system init                 # 作業ディレクトリ初期化
+forge data fetch SPY --period 5y  # 2023-12-31 までのデータを自動取得
+forge backtest run SPY --strategy sma_crossover_v1</code></pre>
+
+      <h2 class="section-heading">有料プラン（任意） — Whop でログイン認証</h2>
+      <p>
+        Trial の制限を解除したい場合のみ、<a href="https://whop.com/alforge-labs/alphaforge/" target="_blank" rel="noopener">Whop の有料プラン</a>（Lifetime / Annual / Monthly）を購入してから以下を実行します。OAuth 2.0 PKCE 認証でブラウザが自動で開き、認証情報は <code>~/.forge/credentials.json</code> に保存されます。
+      </p>
       <pre><code>forge system auth login</code></pre>
       <p>認証済みメンバーシップは以下で確認できます：</p>
       <pre><code>forge system auth status</code></pre>
+      <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
+        Trial / 各有料プランの機能差は <a href="/ja/docs/guides/freemium-limits/">フリーミアム制限</a> を参照。
+      </p>
 
       <h2 class="section-heading">結果を可視化する — alpha-visualizer（任意）</h2>
       <p>
@@ -203,8 +204,8 @@ pip install alpha-visualizer</code></pre>
       </div>
       {% else %}
       <div class="page-label">Getting Started</div>
-      <h1 class="page-title">Get AlphaForge Running in 3 Steps</h1>
-      <p class="page-subtitle">Register on Whop → Install → Sign in. The Free plan is free of charge (about 10 minutes total). Full instructions live in the official docs.</p>
+      <h1 class="page-title">Get AlphaForge Running in a Single Step</h1>
+      <p class="page-subtitle"><strong>The Trial plan needs no Whop registration and has no time limit</strong> — install once and you're ready to run (about 5 minutes total). A Whop OAuth login is only required to unlock the paid plans (Lifetime / Annual / Monthly). Full instructions live in the official docs.</p>
 
       <div class="callout" style="margin-bottom: 2rem;">
         <p style="margin-bottom: 0.75rem;">
@@ -216,20 +217,7 @@ pip install alpha-visualizer</code></pre>
         </a>
       </div>
 
-      <h2 class="section-heading">Step 1 — Create a Whop Account</h2>
-      <p>
-        AlphaForge requires a Whop account for <strong>every plan, including Free</strong>. Start with the Free plan and upgrade to a paid plan later if you need more.
-      </p>
-      <p style="margin-top: 1rem;">
-        <a href="https://whop.com/alforge-labs/alphaforge-free/" target="_blank" rel="noopener" class="btn-primary">
-          Register Free on Whop →
-        </a>
-      </p>
-      <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
-        Want to start on a paid plan? Pick one from the <a href="https://whop.com/alforge-labs/alphaforge/" target="_blank" rel="noopener">paid plans page</a>. See <a href="/en/docs/guides/freemium-limits/">Freemium Limits</a> for the differences.
-      </p>
-
-      <h2 class="section-heading">Step 2 — Install the CLI</h2>
+      <h2 class="section-heading">Step 1 — Install the CLI</h2>
       <div class="platform-tabs" role="tablist">
         <button type="button" class="platform-tab active" role="tab" aria-selected="true" aria-controls="tab-en-mac" onclick="switchTab('en', 'mac', event)">macOS / Linux</button>
         <button type="button" class="platform-tab" role="tab" aria-selected="false" aria-controls="tab-en-win" onclick="switchTab('en', 'win', event)">Windows</button>
@@ -250,11 +238,25 @@ pip install alpha-visualizer</code></pre>
         <a href="https://github.com/alforge-labs/alforge-labs.github.io/releases/latest" target="_blank" rel="noopener">GitHub Releases (latest)</a>.
       </p>
 
-      <h2 class="section-heading">Step 3 — Sign in with Whop</h2>
-      <p>Sign in with the Whop account you registered in Step 1 via OAuth 2.0 PKCE — your browser opens automatically. Authentication data is cached at <code>~/.forge/credentials.json</code>.</p>
+      <h2 class="section-heading">Step 2 — Run on the Trial plan right away (no Whop registration)</h2>
+      <p>
+        Once installed, the Trial plan lets you immediately run <code>forge backtest run</code>, <code>forge optimize run</code>, <code>forge optimize walk-forward</code>, and more. The only Trial limits are: data capped at 2023-12-31, optimization capped at 50 trials, and no Pine Script export — everything else mirrors the paid plans.
+      </p>
+      <pre><code># Example: run a backtest right away (Trial plan, no Whop registration)
+forge system init                 # initialize a working directory
+forge data fetch SPY --period 5y  # auto-fetch data up to 2023-12-31
+forge backtest run SPY --strategy sma_crossover_v1</code></pre>
+
+      <h2 class="section-heading">Paid plans (optional) — Sign in with Whop</h2>
+      <p>
+        To lift the Trial limits, purchase a <a href="https://whop.com/alforge-labs/alphaforge/" target="_blank" rel="noopener">paid plan on Whop</a> (Lifetime / Annual / Monthly) and then run the command below. The OAuth 2.0 PKCE flow opens your browser automatically; credentials are cached at <code>~/.forge/credentials.json</code>.
+      </p>
       <pre><code>forge system auth login</code></pre>
       <p>Verify the activated membership with:</p>
       <pre><code>forge system auth status</code></pre>
+      <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
+        See <a href="/en/docs/guides/freemium-limits/">Freemium Limits</a> for the full feature comparison between Trial and paid plans.
+      </p>
 
       <h2 class="section-heading">Visualize Results — alpha-visualizer (optional)</h2>
       <p>

--- a/templates/tutorial-strategy.html.j2
+++ b/templates/tutorial-strategy.html.j2
@@ -166,13 +166,13 @@
                 <div>
                   <strong>alpha-forge を取得してインストール</strong>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                    インストーラーが最新バイナリをダウンロードします（macOS / Linux 例）。Windows / 手動配置は <a href="install.html">インストールガイド</a> を参照してください。続けて Whop アカウントで OAuth 2.0 PKCE 認証を行います（ブラウザが自動で開きます）。
+                    インストーラーが最新バイナリをダウンロードします（macOS / Linux 例）。Windows / 手動配置は <a href="install.html">インストールガイド</a> を参照してください。<strong>Trial プランは Whop 登録不要・期限なし</strong>でインストール直後からそのまま使えます。Whop OAuth 認証は有料プラン（Lifetime / Annual / Monthly）を購入後に機能解放したい場合のみ実行してください。
                   </p>
                   <pre><code># 最新バイナリをインストール（macOS / Linux）
 curl -sSL https://alforge-labs.github.io/install.sh | bash
 
-# Whop アカウントで認証
-forge system auth login</code></pre>
+# （任意）有料プラン購入後に Whop OAuth 認証で機能解放する
+# forge system auth login</code></pre>
                 </div>
               </li>
               <li>
@@ -574,13 +574,13 @@ Avg Sharpe: 1.10  |  Avg CAGR: 13.9%  |  WF Efficiency: 89%</code></pre>
                 <div>
                   <strong>Install alpha-forge</strong>
                   <p style="font-size:0.88rem;color:var(--text2);margin-top:0.3rem;">
-                    The installer downloads the latest binary (macOS / Linux shown). See the <a href="install.html">installation guide</a> for Windows or manual placement. Then sign in with your Whop account (OAuth 2.0 PKCE) — the browser opens automatically.
+                    The installer downloads the latest binary (macOS / Linux shown). See the <a href="install.html">installation guide</a> for Windows or manual placement. <strong>The Trial plan needs no Whop registration and has no time limit</strong> — you can use the CLI right after installing. Whop OAuth login is only required after purchasing a paid plan (Lifetime / Annual / Monthly) to unlock the additional features.
                   </p>
                   <pre><code># Install the latest binary (macOS / Linux)
 curl -sSL https://alforge-labs.github.io/install.sh | bash
 
-# Sign in via Whop OAuth
-forge system auth login</code></pre>
+# (optional) After purchasing a paid plan, sign in via Whop OAuth to unlock it
+# forge system auth login</code></pre>
                 </div>
               </li>
               <li>


### PR DESCRIPTION
## 症状

ユーザーから指摘:

- [/ja/install.html](https://alforgelabs.com/ja/install.html): 「Whop 登録 → インストール → ログイン認証。Free プランなら無料」「AlphaForge は Whop でのアカウント登録が必要です（**Free プランも含めて全プラン共通**）」という旧 Free プラン時代の誤情報が残っていた
- [/ja/tutorial-strategy.html](https://alforgelabs.com/ja/tutorial-strategy.html): 「続けて Whop アカウントで OAuth 2.0 PKCE 認証を行います」「`# Whop アカウントで認証 / forge system auth login`」が実質必須のように読める形で残置
- 英語版（`/en/install.html`, `/en/tutorial-strategy.html`）も同様

## 実際の仕様（PR #254 以降）

- **Trial プラン**: Whop 登録不要・期限なし、インストール直後から backtest / optimize / WFT が動く（データ上限 2023-12-31 / 最適化 50 trials / Pine 生成不可の 3 制限のみ）
- **有料プラン（Lifetime / Annual / Monthly）の機能解放のみ** Whop OAuth 認証が必要

## 修正

### `templates/install.html.j2`
- サブタイトル: 「Trial プランは Whop 登録不要・期限なし」「有料プランのみ Whop OAuth 認証が必要」に書き換え
- **「ステップ 1 — Whop でアカウント登録」セクションを削除**
- ステップ構成を「1. CLI インストール → 2. Trial プランでそのまま使う（Whop 登録不要） → 任意: 有料プラン購入後に Whop ログイン」に再編
- 廃止された `alphaforge-free` Whop URL とその CTA ボタンを除去

### `templates/tutorial-strategy.html.j2`
- 「続けて Whop アカウントで OAuth 2.0 PKCE 認証を行います（ブラウザが自動で開きます）」→「Trial プランは Whop 登録不要・期限なし」+「有料プラン購入後のみ Whop OAuth 認証」
- コマンドブロックの `forge system auth login` を**コメントアウト**して説明追記

日英両方を同じ内容で更新、`uv run python build.py` で `ja/install.html` / `en/install.html` / `ja/tutorial-strategy.html` / `en/tutorial-strategy.html` の生成物も再生成。

## Test plan

- [x] grep で `Free プラン` / `Free plan` / `全プラン共通` / `every plan, including Free` / `無料で Whop` / `Register Free on Whop` / `alphaforge-free` の残存 0 件
- [x] grep で tutorial-strategy 側の `Whop アカウントで認証` / `Sign in via Whop OAuth` / `Whop アカウントで OAuth 2.0 PKCE 認証を行います` / `Then sign in with your Whop account` の残存 0 件
- [x] `uv run python build.py` 成功
- [ ] マージ後 https://alforgelabs.com/ja/install.html と https://alforgelabs.com/ja/tutorial-strategy.html を目視確認