### PR TITLE
docs(install): alpha-strike (PyPI) のインストールセクションを install ページに追加

### DIFF
--- a/en/install.html
+++ b/en/install.html
@@ -143,7 +143,7 @@ forge backtest run SPY --strategy sma_crossover_v1</code></pre>
 
       <h2 class="section-heading">Visualize Results — alpha-visualizer (optional)</h2>
       <p>
-        <strong>alpha-visualizer</strong> is an OSS Python package (PyPI, MIT-licensed) that renders the backtest results
+        <strong>alpha-visualizer</strong> is an OSS Python package (PyPI, Apache-2.0-licensed) that renders the backtest results
         produced by <code>forge</code> in your browser. It runs standalone — no dependency on <code>forge</code> itself — so you can add it any time.
       </p>
       <pre><code># uv (recommended)
@@ -155,6 +155,29 @@ pip install alpha-visualizer</code></pre>
         See the <a href="/en/docs/alpha-visualizer/installation/">alpha-visualizer installation guide</a> for full usage and configuration.
         PyPI: <a href="https://pypi.org/project/alpha-visualizer/" target="_blank" rel="noopener">pypi.org/project/alpha-visualizer</a> /
         GitHub: <a href="https://github.com/alforge-labs/alpha-visualizer" target="_blank" rel="noopener">alforge-labs/alpha-visualizer</a>
+      </p>
+
+      <h2 class="section-heading">Automated Order Bridge — alpha-strike (optional)</h2>
+      <p>
+        <strong>alpha-strike</strong> is a self-hosted webhook bridge that receives TradingView alerts and routes orders to
+        <strong>moomoo</strong> (US / HK stocks, crypto) and <strong>OANDA</strong> (FX / CFD), available as an OSS Python package
+        (PyPI, Apache-2.0-licensed). The repo ships a reference architecture for running on Oracle Cloud Always Free + Cloudflare Tunnel + WAF at zero monthly cost.
+      </p>
+      <pre><code># uv (recommended)
+uv tool install alpha-strike
+
+# pipx for a global CLI
+pipx install alpha-strike
+
+# pip
+pip install alpha-strike
+
+# Run
+WEBHOOK_PASSPHRASE=your-secret alpha-strike</code></pre>
+      <p style="font-size: 0.9rem; color: var(--text2);">
+        See the <a href="/en/docs/guides/alpha-strike-setup/">alpha-strike setup guide</a> for the full VM provisioning, Cloudflare Tunnel, WAF and systemd procedure.
+        PyPI: <a href="https://pypi.org/project/alpha-strike/" target="_blank" rel="noopener">pypi.org/project/alpha-strike</a> /
+        GitHub: <a href="https://github.com/alforge-labs/alpha-strike" target="_blank" rel="noopener">alforge-labs/alpha-strike</a>
       </p>
 
       <h2 class="section-heading">Troubleshooting</h2>

--- a/ja/install.html
+++ b/ja/install.html
@@ -145,7 +145,7 @@ forge backtest run SPY --strategy sma_crossover_v1</code></pre>
       <h2 class="section-heading">結果を可視化する — alpha-visualizer（任意）</h2>
       <p>
         <strong>alpha-visualizer</strong> は forge が出力するバックテスト結果を Web ブラウザで可視化する
-        OSS パッケージです（PyPI 配布・MIT ライセンス）。forge 本体に依存せず単体動作するため、必要に応じて後から追加できます。
+        OSS パッケージです（PyPI 配布・Apache-2.0 ライセンス）。forge 本体に依存せず単体動作するため、必要に応じて後から追加できます。
       </p>
       <pre><code># uv（推奨）
 uv tool install alpha-visualizer
@@ -157,6 +157,30 @@ pip install alpha-visualizer</code></pre>
         <a href="/ja/docs/alpha-visualizer/installation/">alpha-visualizer インストールガイド</a>
         を参照してください。PyPI: <a href="https://pypi.org/project/alpha-visualizer/" target="_blank" rel="noopener">pypi.org/project/alpha-visualizer</a> /
         GitHub: <a href="https://github.com/alforge-labs/alpha-visualizer" target="_blank" rel="noopener">alforge-labs/alpha-visualizer</a>
+      </p>
+
+      <h2 class="section-heading">自動発注ブリッジ — alpha-strike（任意）</h2>
+      <p>
+        <strong>alpha-strike</strong> は TradingView アラートを Webhook で受け取り、<strong>moomoo 証券</strong>（米国株 / 香港株 / 暗号資産）と
+        <strong>OANDA 証券</strong>（FX / CFD）へ自動発注するセルフホスト型ブリッジです（PyPI 配布・Apache-2.0 ライセンス）。
+        Oracle Cloud Always Free + Cloudflare Tunnel + WAF のリファレンス構成で月額 0 円で本格運用できます。
+      </p>
+      <pre><code># uv（推奨）
+uv tool install alpha-strike
+
+# pipx でグローバル CLI として
+pipx install alpha-strike
+
+# pip
+pip install alpha-strike
+
+# 起動
+WEBHOOK_PASSPHRASE=your-secret alpha-strike</code></pre>
+      <p style="font-size: 0.9rem; color: var(--text2);">
+        VM プロビジョニング・Cloudflare Tunnel・WAF・systemd の完全手順は
+        <a href="/ja/docs/guides/alpha-strike-setup/">alpha-strike セットアップガイド</a>
+        を参照してください。PyPI: <a href="https://pypi.org/project/alpha-strike/" target="_blank" rel="noopener">pypi.org/project/alpha-strike</a> /
+        GitHub: <a href="https://github.com/alforge-labs/alpha-strike" target="_blank" rel="noopener">alforge-labs/alpha-strike</a>
       </p>
 
       <h2 class="section-heading">トラブルシューティング</h2>

--- a/templates/install.html.j2
+++ b/templates/install.html.j2
@@ -93,7 +93,7 @@ forge backtest run SPY --strategy sma_crossover_v1</code></pre>
       <h2 class="section-heading">結果を可視化する — alpha-visualizer（任意）</h2>
       <p>
         <strong>alpha-visualizer</strong> は forge が出力するバックテスト結果を Web ブラウザで可視化する
-        OSS パッケージです（PyPI 配布・MIT ライセンス）。forge 本体に依存せず単体動作するため、必要に応じて後から追加できます。
+        OSS パッケージです（PyPI 配布・Apache-2.0 ライセンス）。forge 本体に依存せず単体動作するため、必要に応じて後から追加できます。
       </p>
       <pre><code># uv（推奨）
 uv tool install alpha-visualizer
@@ -105,6 +105,30 @@ pip install alpha-visualizer</code></pre>
         <a href="/ja/docs/alpha-visualizer/installation/">alpha-visualizer インストールガイド</a>
         を参照してください。PyPI: <a href="https://pypi.org/project/alpha-visualizer/" target="_blank" rel="noopener">pypi.org/project/alpha-visualizer</a> /
         GitHub: <a href="https://github.com/alforge-labs/alpha-visualizer" target="_blank" rel="noopener">alforge-labs/alpha-visualizer</a>
+      </p>
+
+      <h2 class="section-heading">自動発注ブリッジ — alpha-strike（任意）</h2>
+      <p>
+        <strong>alpha-strike</strong> は TradingView アラートを Webhook で受け取り、<strong>moomoo 証券</strong>（米国株 / 香港株 / 暗号資産）と
+        <strong>OANDA 証券</strong>（FX / CFD）へ自動発注するセルフホスト型ブリッジです（PyPI 配布・Apache-2.0 ライセンス）。
+        Oracle Cloud Always Free + Cloudflare Tunnel + WAF のリファレンス構成で月額 0 円で本格運用できます。
+      </p>
+      <pre><code># uv（推奨）
+uv tool install alpha-strike
+
+# pipx でグローバル CLI として
+pipx install alpha-strike
+
+# pip
+pip install alpha-strike
+
+# 起動
+WEBHOOK_PASSPHRASE=your-secret alpha-strike</code></pre>
+      <p style="font-size: 0.9rem; color: var(--text2);">
+        VM プロビジョニング・Cloudflare Tunnel・WAF・systemd の完全手順は
+        <a href="/ja/docs/guides/alpha-strike-setup/">alpha-strike セットアップガイド</a>
+        を参照してください。PyPI: <a href="https://pypi.org/project/alpha-strike/" target="_blank" rel="noopener">pypi.org/project/alpha-strike</a> /
+        GitHub: <a href="https://github.com/alforge-labs/alpha-strike" target="_blank" rel="noopener">alforge-labs/alpha-strike</a>
       </p>
 
       <h2 class="section-heading">トラブルシューティング</h2>
@@ -260,7 +284,7 @@ forge backtest run SPY --strategy sma_crossover_v1</code></pre>
 
       <h2 class="section-heading">Visualize Results — alpha-visualizer (optional)</h2>
       <p>
-        <strong>alpha-visualizer</strong> is an OSS Python package (PyPI, MIT-licensed) that renders the backtest results
+        <strong>alpha-visualizer</strong> is an OSS Python package (PyPI, Apache-2.0-licensed) that renders the backtest results
         produced by <code>forge</code> in your browser. It runs standalone — no dependency on <code>forge</code> itself — so you can add it any time.
       </p>
       <pre><code># uv (recommended)
@@ -272,6 +296,29 @@ pip install alpha-visualizer</code></pre>
         See the <a href="/en/docs/alpha-visualizer/installation/">alpha-visualizer installation guide</a> for full usage and configuration.
         PyPI: <a href="https://pypi.org/project/alpha-visualizer/" target="_blank" rel="noopener">pypi.org/project/alpha-visualizer</a> /
         GitHub: <a href="https://github.com/alforge-labs/alpha-visualizer" target="_blank" rel="noopener">alforge-labs/alpha-visualizer</a>
+      </p>
+
+      <h2 class="section-heading">Automated Order Bridge — alpha-strike (optional)</h2>
+      <p>
+        <strong>alpha-strike</strong> is a self-hosted webhook bridge that receives TradingView alerts and routes orders to
+        <strong>moomoo</strong> (US / HK stocks, crypto) and <strong>OANDA</strong> (FX / CFD), available as an OSS Python package
+        (PyPI, Apache-2.0-licensed). The repo ships a reference architecture for running on Oracle Cloud Always Free + Cloudflare Tunnel + WAF at zero monthly cost.
+      </p>
+      <pre><code># uv (recommended)
+uv tool install alpha-strike
+
+# pipx for a global CLI
+pipx install alpha-strike
+
+# pip
+pip install alpha-strike
+
+# Run
+WEBHOOK_PASSPHRASE=your-secret alpha-strike</code></pre>
+      <p style="font-size: 0.9rem; color: var(--text2);">
+        See the <a href="/en/docs/guides/alpha-strike-setup/">alpha-strike setup guide</a> for the full VM provisioning, Cloudflare Tunnel, WAF and systemd procedure.
+        PyPI: <a href="https://pypi.org/project/alpha-strike/" target="_blank" rel="noopener">pypi.org/project/alpha-strike</a> /
+        GitHub: <a href="https://github.com/alforge-labs/alpha-strike" target="_blank" rel="noopener">alforge-labs/alpha-strike</a>
       </p>
 
       <h2 class="section-heading">Troubleshooting</h2>


### PR DESCRIPTION
## 概要

alpha-strike が **v0.3.0 で PyPI 公開** ([pypi.org/project/alpha-strike/](https://pypi.org/project/alpha-strike/)) されたため、Getting Started の install ページ ([alforgelabs.com/ja/install.html](https://alforgelabs.com/ja/install.html) / [en/install.html](https://alforgelabs.com/en/install.html)) に **alpha-visualizer 同等の任意インストール案内セクション** を追加します。

## 変更

### `templates/install.html.j2`

- ja パートに **「自動発注ブリッジ — alpha-strike（任意）」** セクションを追加
- en パートに **"Automated Order Bridge — alpha-strike (optional)"** セクションを追加（同等内容）

| 項目 | 内容 |
|---|---|
| インストール | `uv tool install alpha-strike` / `pipx install alpha-strike` / `pip install alpha-strike` |
| 起動例 | `WEBHOOK_PASSPHRASE=your-secret alpha-strike` |
| リンク | セットアップガイド / PyPI / GitHub |

### alpha-visualizer のライセンス表記訂正

- 旧: 「PyPI 配布・MIT ライセンス」
- 新: 「PyPI 配布・Apache-2.0 ライセンス」

alpha-visualizer は v0.6.0 で MIT → Apache-2.0 に変更済み（[alforge-labs/alpha-visualizer#201](https://github.com/alforge-labs/alpha-visualizer/pull/201)）でしたが install ページの表記が古かったので訂正。

## ビルド

- `uv run python build.py` で `ja/install.html` / `en/install.html` を再生成
- `alpha-strike` 言及が **9 箇所ずつ** 追加されたことを確認
- mkdocs_src 内の他 docs にインストール手順を含むものはなかったため、mkdocs build は確認のみ

## 関連

- PyPI 公開: [pypi.org/project/alpha-strike/0.3.0/](https://pypi.org/project/alpha-strike/0.3.0/)
- alpha-strike #48: PyPI 化リファクタ
- alforge-labs #306: alpha-strike-setup.md の PyPI 対応