### PR TITLE
feat(stats): Releases DL 数の時系列収集 + shields バッジ + Actions 定期実行

### DIFF
--- a/.github/scripts/collect_download_stats.sh
+++ b/.github/scripts/collect_download_stats.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# GitHub Releases のアセット DL 数を収集し、時系列 JSONL に追記しつつ
+# shields.io endpoint バッジ用 JSON を再生成する。
+#
+# 使い方:
+#   STATS_REPO=owner/repo GH_TOKEN=<token> bash collect_download_stats.sh <DATA_DIR>
+#
+#   - <DATA_DIR>/download-stats.jsonl : 1 行 1 スナップショットの時系列（追記）
+#   - <DATA_DIR>/download-badge.json  : shields.io endpoint 形式（毎回上書き）
+#
+# 依存: gh, jq, python3（いずれも GitHub Actions ubuntu ランナーに同梱）
+#
+# 注意: GitHub の download_count は「リリースに添付したアセット」のみ計上され、
+#       自動生成の Source code (zip/tar.gz) は対象外。累計値のためここでは
+#       スナップショットを並べて自前で日次差分を出せるようにする。
+set -euo pipefail
+
+REPO="${STATS_REPO:-alforge-labs/alforge-labs.github.io}"
+DATA_DIR="${1:-.}"
+JSONL="${DATA_DIR}/download-stats.jsonl"
+BADGE="${DATA_DIR}/download-badge.json"
+
+mkdir -p "${DATA_DIR}"
+
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+day="$(date -u +%Y-%m-%d)"
+
+# 全リリース（draft 含む。draft アセットの download_count は 0）を取得。
+releases_json="$(gh api "repos/${REPO}/releases" --paginate)"
+
+# スナップショット 1 行を生成。
+snapshot="$(printf '%s' "${releases_json}" | jq -c --arg ts "${ts}" --arg day "${day}" '
+  {
+    ts: $ts,
+    date: $day,
+    total: ([.[].assets[].download_count] | add // 0),
+    by_tag: (map({ (.tag_name): ([.assets[].download_count] | add // 0) }) | add // {}),
+    by_asset: [ .[] | .tag_name as $t | .assets[] | {tag: $t, name: .name, count: .download_count} ]
+  }')"
+
+echo "${snapshot}" >> "${JSONL}"
+
+current_total="$(printf '%s' "${snapshot}" | jq '.total')"
+
+# 7 日前以前で最も新しいスナップショットの total を取り、日次差分（7d）を出す。
+# ISO 日付 (YYYY-MM-DD) は辞書順比較で日付順と一致する。
+cutoff="$(python3 -c "import datetime; print((datetime.datetime.now(datetime.UTC).date() - datetime.timedelta(days=7)).isoformat())")"
+prev_total="$(jq -rs --arg cutoff "${cutoff}" '
+  [ .[] | select(.date <= $cutoff) ] | (last.total // empty)
+' "${JSONL}" 2>/dev/null || true)"
+
+if [ -n "${prev_total}" ]; then
+  delta=$(( current_total - prev_total ))
+  if [ "${delta}" -ge 0 ]; then sign="+"; else sign=""; fi
+  message="${current_total} (${sign}${delta} / 7d)"
+else
+  # 7 日分の履歴がまだ無い（運用開始直後）。
+  message="${current_total}"
+fi
+
+jq -n --arg msg "${message}" '{
+  schemaVersion: 1,
+  label: "downloads",
+  message: $msg,
+  color: "blue",
+  namedLogo: "github"
+}' > "${BADGE}"
+
+echo "collected: total=${current_total} 7d_prev=${prev_total:-n/a} -> ${message}"

--- a/.github/workflows/release-download-stats.yml
+++ b/.github/workflows/release-download-stats.yml
@@ -1,0 +1,61 @@
+name: Release Download Stats
+
+# GitHub Releases のアセット DL 数を毎日スナップショットして時系列を蓄積する。
+# Pages は main ブランチ直配信のため、データは専用ブランチ `download-stats` に
+# push してサイトの再デプロイを発生させない（main を汚さない）。
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # 毎日 03:00 UTC（12:00 JST）
+  workflow_dispatch:        # 手動実行も可能
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-download-stats
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main (収集スクリプト取得用)
+        uses: actions/checkout@v4
+
+      - name: Prepare download-stats branch working copy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if git ls-remote --exit-code --heads "$remote" download-stats >/dev/null 2>&1; then
+            git clone --depth 50 --branch download-stats "$remote" stats-data
+          else
+            # 初回: orphan ブランチを作成（履歴・サイトファイルを持たない）
+            git clone --depth 1 "$remote" stats-data
+            cd stats-data
+            git checkout --orphan download-stats
+            git rm -rf . >/dev/null 2>&1 || true
+            cd ..
+          fi
+
+      - name: Collect snapshot
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STATS_REPO: ${{ github.repository }}
+        run: bash .github/scripts/collect_download_stats.sh stats-data
+
+      - name: Commit & push to download-stats
+        run: |
+          set -euo pipefail
+          cd stats-data
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add download-stats.jsonl download-badge.json
+          if git diff --cached --quiet; then
+            echo "変更なし（スキップ）"
+            exit 0
+          fi
+          git commit -m "chore(stats): download snapshot $(date -u +%FT%TZ)"
+          git push origin HEAD:download-stats

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # alforge-labs.github.io
 
+[![Downloads (total)](https://img.shields.io/github/downloads/alforge-labs/alforge-labs.github.io/total?logo=github&label=downloads)](https://github.com/alforge-labs/alforge-labs.github.io/releases)
+[![Downloads (trend)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Falforge-labs%2Falforge-labs.github.io%2Fdownload-stats%2Fdownload-badge.json)](https://github.com/alforge-labs/alforge-labs.github.io/blob/download-stats/download-stats.jsonl)
+
 Alforge Labs のランディングページ（静的サイト）。
+
+> 左バッジは GitHub Releases アセットの累計 DL 数（shields.io 組み込み・リアルタイム）。
+> 右バッジは `Release Download Stats` ワークフロー（毎日 03:00 UTC）が
+> `download-stats` ブランチに蓄積する時系列から算出した「累計（直近7日差分）」。
+> 右バッジは初回ワークフロー実行後に表示されます。時系列の生データは
+> [`download-stats` ブランチの `download-stats.jsonl`](https://github.com/alforge-labs/alforge-labs.github.io/blob/download-stats/download-stats.jsonl) を参照。
 
 ## 概要
 


### PR DESCRIPTION
## 目的
GitHub Releases のアセット DL 数を**時系列で追跡**し、**shields.io バッジ**で可視化する。収集は **GitHub Actions で毎日自動実行**。

> 配布バイナリは本リポジトリ（`alforge-labs.github.io`）の Releases にあるため、ここに収集基盤を置く。

## 追加ファイル
| ファイル | 役割 |
|---|---|
| `.github/scripts/collect_download_stats.sh` | `gh api` で全リリースのアセット `download_count` を収集 → `download-stats.jsonl` に 1 行 1 スナップショットで追記し、`download-badge.json`（shields endpoint 形式・累計＋直近7日差分）を再生成 |
| `.github/workflows/release-download-stats.yml` | 毎日 03:00 UTC（+ `workflow_dispatch`）に実行 |
| `README.md` | バッジ 2 種を追加 |

## 設計判断
- **データは専用ブランチ `download-stats` に保存**。Pages が **main 直配信（legacy）** のため、main に日次コミットするとサイトが毎日再デプロイされ履歴も汚れる。専用ブランチなら再デプロイ・main 汚染を回避でき、`raw.githubusercontent.com` 経由で shields endpoint から読める。
- **PUBLIC リポジトリ**なので Actions は無料枠（課金懸念なし）。
- 権限は `contents: write` のみ。トリガーは `schedule`/`workflow_dispatch` で untrusted な event payload を扱わない（インジェクション面なし）。`github.token`/`github.repository` のみ使用。
- GitHub の `download_count` は**アセットのみ**計上（Source code zip/tar.gz は対象外）・**累計値**のため、スナップショットを並べて自前で日次差分を算出。

## バッジ
1. **累計 DL**（shields 組み込み・リアルタイム）:
   `https://img.shields.io/github/downloads/alforge-labs/alforge-labs.github.io/total`
2. **累計＋直近7日差分**（自前 endpoint・**初回ワークフロー実行後**に表示）:
   `https://img.shields.io/endpoint?url=<raw>/download-stats/download-badge.json`

## 検証
- 実 repo に対しスクリプトをローカル実行 → `total=12` を収集、JSONL/バッジ JSON が妥当（shields endpoint schema 準拠）。
- 7日差分ロジック: 10日前 `total=5` を仕込み → `12 (+7 / 7d)` を確認。
- `bash -n` / YAML パース OK。`datetime.utcnow()` 非推奨警告も解消済み。

## マージ後の手順
初回は `download-stats` ブランチが無いため、`Actions → Release Download Stats → Run workflow` を 1 回手動実行すると、ブランチ作成＋初回スナップショット＋バッジ JSON が生成され、右バッジが表示されるようになります（以降は毎日自動）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)