### PR TITLE
fix(lp): ロードマップから未実装機能（WFO 二段ランキング・Experiment 宣言型 API）を削除

### DIFF
--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -295,7 +295,7 @@ window.COPY = {
           status: 'active',
           badgeLabel: '進行中',
           title: '正式リリース・商用化',
-          items: ['全プロダクト正式リリース（v1.0）', 'MCP サーバ PyPI 公開（Claude Code / Codex / Cursor 連携）', 'WFO 二段ランキング・Experiment 宣言型 API', 'FRED/ALFRED マクロデータ provider', 'サポート・コミュニティ体制整備'],
+          items: ['全プロダクト正式リリース（v1.0）', 'MCP サーバ PyPI 公開（Claude Code / Codex / Cursor 連携）', 'FRED/ALFRED マクロデータ provider', 'サポート・コミュニティ体制整備'],
         },
       ],
     },
@@ -726,7 +726,7 @@ window.COPY = {
         { period: 'Late March 2026', status: 'done', badgeLabel: 'Done', title: 'Live Execution Integration', items: ['alpha-strike Webhook server', 'OANDA & moomoo API execution', 'Execution & response event analysis pipeline'] },
         { period: 'April 2026', status: 'done', badgeLabel: 'Done', title: 'Productization', items: ['License management, binary distribution & CI/CD pipeline', 'Official site launch', 'Claude-driven autonomous parameter search'] },
         { period: 'May 2026', status: 'done', badgeLabel: 'Done', title: 'Beta Release', items: ['alpha-forge v0.4.0 release (macOS / Windows / Linux binaries)', 'alpha-visualizer v0.2.0 published (OSS, TradingView Lightweight Charts)', 'Trial plan launched', 'Documentation polish'] },
-        { period: 'Summer 2026', status: 'active', badgeLabel: 'Active', title: 'Public Launch & Commercialization', items: ['Full v1.0 product release', 'MCP server published on PyPI (Claude Code / Codex / Cursor integration)', 'Two-stage WFO ranking & declarative Experiment API', 'FRED/ALFRED macro data provider', 'Support & community setup'] },
+        { period: 'Summer 2026', status: 'active', badgeLabel: 'Active', title: 'Public Launch & Commercialization', items: ['Full v1.0 product release', 'MCP server published on PyPI (Claude Code / Codex / Cursor integration)', 'FRED/ALFRED macro data provider', 'Support & community setup'] },
       ],
     },
     faq: {


### PR DESCRIPTION
## 概要

2026年夏ロードマップ（「正式リリース・商用化 / Public Launch & Commercialization」）が言及していた **「WFO 二段ランキング」** と **「Experiment 宣言型 API」** が、調査の結果いずれも未実装方針となったため、過剰な約束を避けて該当バレットを ja/en 両方から削除します。

## 背景（なぜ削除するか）

- **WFO 二段ランキング (alpha-forge #627)**: 現行 WFO（窓ごとに独立した Optuna 再最適化を行う rolling 方式）と、提案の「固定候補を全 train 窓で評価→top-k のみ holdout 再評価」という固定候補×二段 CV が**構造的に不整合**。Optuna TPE の適応サンプリングとも衝突し、新最適化モードの新設（XL）が必要。問題提起の前提（IS/OOS 混在）も事実と異なるため **not planned でクローズ**。
- **Experiment 宣言型 API (alpha-forge #625)**: 価値の大半は依存 issue #596/#599 の `Request` DTO + Orchestrator + Protocol で**既に実現済み**。残差は実質リネーム化粧＋大規模テスト書き換えで費用対効果が低く**見送り**（optimize 側の dead-layer 配線のみ #1021 で実施済み）。

## 変更点

- `homepage-copy.jsx` の ja（2026年夏）・en（Summer 2026）ロードマップ配列から該当バレットを削除。
- 残り4項目（v1.0 正式リリース / MCP サーバ PyPI 公開 / FRED/ALFRED マクロデータ provider / サポート・コミュニティ）は実態と一致。

## 検証

- `node --check`（`.js` コピー）で `homepage-copy.jsx` の構文が有効であることを確認（JSX タグ 0 の純データ定義）。
- 既存 homepage テストは本変更前後で結果不変（失敗 9 件はロードマップと無関係な環境/cwd 起因の pre-existing で、stash した clean 状態でも同一）。
- ロードマップのコピーは `ja/index.html`・`en/index.html` に埋め込まれず `<script src="../homepage-copy.jsx">` で**実行時 babel ロード**されるため、`build.py` 再実行・HTML 再生成は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)