### PR TITLE
fix(lp): ロードマップの MCP 項目を「公開済み ✅」に更新

### DIFF
--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -295,7 +295,7 @@ window.COPY = {
           status: 'active',
           badgeLabel: '進行中',
           title: '正式リリース・商用化',
-          items: ['全プロダクト正式リリース（v1.0）', 'MCP サーバ PyPI 公開（Claude Code / Codex / Cursor 連携）', 'FRED/ALFRED マクロデータ provider', 'サポート・コミュニティ体制整備'],
+          items: ['全プロダクト正式リリース（v1.0）', '✅ MCP サーバ PyPI 公開済み（uvx alpha-forge-mcp・Claude Code / Codex / Cursor）', 'FRED/ALFRED マクロデータ provider', 'サポート・コミュニティ体制整備'],
         },
       ],
     },
@@ -726,7 +726,7 @@ window.COPY = {
         { period: 'Late March 2026', status: 'done', badgeLabel: 'Done', title: 'Live Execution Integration', items: ['alpha-strike Webhook server', 'OANDA & moomoo API execution', 'Execution & response event analysis pipeline'] },
         { period: 'April 2026', status: 'done', badgeLabel: 'Done', title: 'Productization', items: ['License management, binary distribution & CI/CD pipeline', 'Official site launch', 'Claude-driven autonomous parameter search'] },
         { period: 'May 2026', status: 'done', badgeLabel: 'Done', title: 'Beta Release', items: ['alpha-forge v0.4.0 release (macOS / Windows / Linux binaries)', 'alpha-visualizer v0.2.0 published (OSS, TradingView Lightweight Charts)', 'Trial plan launched', 'Documentation polish'] },
-        { period: 'Summer 2026', status: 'active', badgeLabel: 'Active', title: 'Public Launch & Commercialization', items: ['Full v1.0 product release', 'MCP server published on PyPI (Claude Code / Codex / Cursor integration)', 'FRED/ALFRED macro data provider', 'Support & community setup'] },
+        { period: 'Summer 2026', status: 'active', badgeLabel: 'Active', title: 'Public Launch & Commercialization', items: ['Full v1.0 product release', '✅ MCP server published on PyPI — uvx alpha-forge-mcp (Claude Code / Codex / Cursor)', 'FRED/ALFRED macro data provider', 'Support & community setup'] },
       ],
     },
     faq: {


### PR DESCRIPTION
## 概要

`alpha-forge-mcp`（alpha-forge #716）を **PyPI 公開済み**（`0.1.0a2` / `uvx alpha-forge-mcp` / 7 tools）にしたため、2026年夏ロードマップの「MCP サーバ PyPI 公開」項目を **✅ 公開済み**に更新します（ja / en）。

- ロードマップ section の `status` は他項目（v1.0 正式リリース / FRED macro / サポート）が進行中のため **active のまま**、当該バレットのみ done を明示。
- `homepage-copy.jsx` の roadmap copy は実行時 `@babel/standalone` ロードのため build 不要。`node --check` で構文確認済み。

## 補足（スコープ外）

トップの「現在のステータス」サマリー（`AvailabilitySummary`）にも MCP が「2026年夏予定（○）」として載っていますが、これは列単位の `mark: '○'` を各項目に前置する構造のため ✅ と矛盾します。本 PR はユーザー依頼どおり**ロードマップ項目のみ**を対象としています（サマリー側の扱いは別途相談）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)