### PR TITLE
fix(lp): 現在のステータスの MCP 項目を「正式版は予定・alpha 公開中」に調整

### DIFF
--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -82,7 +82,7 @@ window.COPY = {
           title: '2026 年夏予定',
           items: [
             'v1.0 正式リリース（全プロダクト）',
-            'MCP サーバ PyPI 公開（Claude Code / Codex / Cursor 連携）',
+            'MCP サーバ正式版（alpha 版は uvx alpha-forge-mcp で公開中）',
             'FRED / ALFRED マクロデータ provider',
             'サポート・コミュニティ体制の整備',
           ],
@@ -548,7 +548,7 @@ window.COPY = {
           title: 'Targeting summer 2026',
           items: [
             'v1.0 official release (all products)',
-            'MCP server on PyPI (Claude Code / Codex / Cursor)',
+            'MCP server GA (alpha already live: uvx alpha-forge-mcp)',
             'FRED / ALFRED macro data provider',
             'Support & community infrastructure',
           ],


### PR DESCRIPTION
## 概要

ロードマップで MCP を ✅ 公開済みに更新（#344）した一方、トップの「現在のステータス」サマリー（`AvailabilitySummary`）の **「2026 年夏予定（○）」列**には MCP が「予定」として残り矛盾していたため、文言を調整します（ja/en）。

- 列の `mark: '○'` は**正式版(GA)が v1.0 で予定**であることを表すので、行を **「MCP サーバ正式版（alpha 版は uvx alpha-forge-mcp で公開中）」** に変更。alpha が既に公開済みである事実と整合し、かつ GA が v1.0 予定であることも保持。
- `homepage-copy.jsx` のみ（実行時 babel ロードのため build 不要）。`node --check` 済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)