### PR TITLE
docs(install): コマンドカタログのサブコマンド数と内部リンクを実装に同期

### DIFF
--- a/en/install.html
+++ b/en/install.html
@@ -138,7 +138,7 @@ forge backtest run SPY --strategy sma_crossover_v1</code></pre>
       <p>Verify the activated membership with:</p>
       <pre><code>forge system auth status</code></pre>
       <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
-        See <a href="/en/docs/guides/freemium-limits/">Freemium Limits</a> for the full feature comparison between Trial and paid plans.
+        See <a href="/en/docs/guides/trial-limits/">Trial Limits</a> for the full feature comparison between Trial and paid plans.
       </p>
 
       <h2 class="section-heading">Visualize Results — alpha-visualizer (optional)</h2>
@@ -257,13 +257,13 @@ WEBHOOK_PASSPHRASE=your-secret alpha-strike</code></pre>
       <table class="cmd-table">
         <thead><tr><th>Group</th><th>Description</th><th>Subcommands</th></tr></thead>
         <tbody>
-          <tr><td><a href="/en/docs/cli-reference/backtest/"><code>forge backtest</code></a></td><td>Backtest execution, scanning, custom experiments</td><td>11</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/backtest/"><code>forge backtest</code></a></td><td>Backtest execution, scanning, custom experiments</td><td>12</td></tr>
           <tr><td><a href="/en/docs/cli-reference/optimize/"><code>forge optimize</code></a></td><td>Parameter optimization (grid / bayes / wfa)</td><td>9</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>Strategy JSON save / validate / apply</td><td>9</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/data/"><code>forge data</code></a></td><td>Historical data fetch / update</td><td>4</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>Strategy JSON save / validate / apply</td><td>11</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/data/"><code>forge data</code></a></td><td>Historical / alternative / TradingView MCP data fetch</td><td>6</td></tr>
           <tr><td><a href="/en/docs/cli-reference/journal/"><code>forge journal</code></a></td><td>Trading journal and trade analysis</td><td>8</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/live/"><code>forge live</code></a></td><td>Live trading and broker integration</td><td>9</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/other/">Other commands</a></td><td><code>system</code> / <code>pine</code> / <code>idea</code> / <code>analyze</code> / <code>explore</code> and more</td><td>10 groups</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/live/"><code>forge live</code></a></td><td>Live trade analysis, replay, operations log</td><td>10</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/">Other commands</a></td><td><code>system</code> / <code>pine</code> / <code>idea</code> / <code>analyze</code> / <code>explore</code> / <code>self</code></td><td>6 groups</td></tr>
         </tbody>
       </table>
 

--- a/ja/install.html
+++ b/ja/install.html
@@ -139,7 +139,7 @@ forge backtest run SPY --strategy sma_crossover_v1</code></pre>
       <p>認証済みメンバーシップは以下で確認できます：</p>
       <pre><code>forge system auth status</code></pre>
       <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
-        Trial / 各有料プランの機能差は <a href="/ja/docs/guides/freemium-limits/">フリーミアム制限</a> を参照。
+        Trial / 各有料プランの機能差は <a href="/ja/docs/guides/trial-limits/">Trial 制限</a> を参照。
       </p>
 
       <h2 class="section-heading">結果を可視化する — alpha-visualizer（任意）</h2>
@@ -260,13 +260,13 @@ WEBHOOK_PASSPHRASE=your-secret alpha-strike</code></pre>
       <table class="cmd-table">
         <thead><tr><th>グループ</th><th>説明</th><th>サブコマンド数</th></tr></thead>
         <tbody>
-          <tr><td><a href="/ja/docs/cli-reference/backtest/"><code>forge backtest</code></a></td><td>バックテスト実行・スキャン・カスタム実験</td><td>11</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/backtest/"><code>forge backtest</code></a></td><td>バックテスト実行・スキャン・カスタム実験</td><td>12</td></tr>
           <tr><td><a href="/ja/docs/cli-reference/optimize/"><code>forge optimize</code></a></td><td>パラメータ最適化（grid / bayes / wfa）</td><td>9</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>戦略 JSON の保存・検証・適用</td><td>9</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/data/"><code>forge data</code></a></td><td>ヒストリカルデータ取得・更新</td><td>4</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>戦略 JSON の保存・検証・適用</td><td>11</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/data/"><code>forge data</code></a></td><td>ヒストリカル / 代替 / TradingView MCP データ取得</td><td>6</td></tr>
           <tr><td><a href="/ja/docs/cli-reference/journal/"><code>forge journal</code></a></td><td>取引ジャーナル・トレード分析</td><td>8</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/live/"><code>forge live</code></a></td><td>ライブトレーディング・ブローカー連携</td><td>9</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/other/">その他コマンド</a></td><td><code>system</code> / <code>pine</code> / <code>idea</code> / <code>analyze</code> / <code>explore</code> 他</td><td>10 グループ</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/live/"><code>forge live</code></a></td><td>ライブトレード分析・リプレイ・運用記録</td><td>10</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/">その他コマンド</a></td><td><code>system</code> / <code>pine</code> / <code>idea</code> / <code>analyze</code> / <code>explore</code> / <code>self</code></td><td>6 グループ</td></tr>
         </tbody>
       </table>
 

--- a/templates/install.html.j2
+++ b/templates/install.html.j2
@@ -87,7 +87,7 @@ forge backtest run SPY --strategy sma_crossover_v1</code></pre>
       <p>認証済みメンバーシップは以下で確認できます：</p>
       <pre><code>forge system auth status</code></pre>
       <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
-        Trial / 各有料プランの機能差は <a href="/ja/docs/guides/freemium-limits/">フリーミアム制限</a> を参照。
+        Trial / 各有料プランの機能差は <a href="/ja/docs/guides/trial-limits/">Trial 制限</a> を参照。
       </p>
 
       <h2 class="section-heading">結果を可視化する — alpha-visualizer（任意）</h2>
@@ -208,13 +208,13 @@ WEBHOOK_PASSPHRASE=your-secret alpha-strike</code></pre>
       <table class="cmd-table">
         <thead><tr><th>グループ</th><th>説明</th><th>サブコマンド数</th></tr></thead>
         <tbody>
-          <tr><td><a href="/ja/docs/cli-reference/backtest/"><code>forge backtest</code></a></td><td>バックテスト実行・スキャン・カスタム実験</td><td>11</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/backtest/"><code>forge backtest</code></a></td><td>バックテスト実行・スキャン・カスタム実験</td><td>12</td></tr>
           <tr><td><a href="/ja/docs/cli-reference/optimize/"><code>forge optimize</code></a></td><td>パラメータ最適化（grid / bayes / wfa）</td><td>9</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>戦略 JSON の保存・検証・適用</td><td>9</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/data/"><code>forge data</code></a></td><td>ヒストリカルデータ取得・更新</td><td>4</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>戦略 JSON の保存・検証・適用</td><td>11</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/data/"><code>forge data</code></a></td><td>ヒストリカル / 代替 / TradingView MCP データ取得</td><td>6</td></tr>
           <tr><td><a href="/ja/docs/cli-reference/journal/"><code>forge journal</code></a></td><td>取引ジャーナル・トレード分析</td><td>8</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/live/"><code>forge live</code></a></td><td>ライブトレーディング・ブローカー連携</td><td>9</td></tr>
-          <tr><td><a href="/ja/docs/cli-reference/other/">その他コマンド</a></td><td><code>system</code> / <code>pine</code> / <code>idea</code> / <code>analyze</code> / <code>explore</code> 他</td><td>10 グループ</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/live/"><code>forge live</code></a></td><td>ライブトレード分析・リプレイ・運用記録</td><td>10</td></tr>
+          <tr><td><a href="/ja/docs/cli-reference/">その他コマンド</a></td><td><code>system</code> / <code>pine</code> / <code>idea</code> / <code>analyze</code> / <code>explore</code> / <code>self</code></td><td>6 グループ</td></tr>
         </tbody>
       </table>
 
@@ -279,7 +279,7 @@ forge backtest run SPY --strategy sma_crossover_v1</code></pre>
       <p>Verify the activated membership with:</p>
       <pre><code>forge system auth status</code></pre>
       <p style="margin-top: 0.75rem; font-size: 0.9rem; color: var(--text2);">
-        See <a href="/en/docs/guides/freemium-limits/">Freemium Limits</a> for the full feature comparison between Trial and paid plans.
+        See <a href="/en/docs/guides/trial-limits/">Trial Limits</a> for the full feature comparison between Trial and paid plans.
       </p>
 
       <h2 class="section-heading">Visualize Results — alpha-visualizer (optional)</h2>
@@ -398,13 +398,13 @@ WEBHOOK_PASSPHRASE=your-secret alpha-strike</code></pre>
       <table class="cmd-table">
         <thead><tr><th>Group</th><th>Description</th><th>Subcommands</th></tr></thead>
         <tbody>
-          <tr><td><a href="/en/docs/cli-reference/backtest/"><code>forge backtest</code></a></td><td>Backtest execution, scanning, custom experiments</td><td>11</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/backtest/"><code>forge backtest</code></a></td><td>Backtest execution, scanning, custom experiments</td><td>12</td></tr>
           <tr><td><a href="/en/docs/cli-reference/optimize/"><code>forge optimize</code></a></td><td>Parameter optimization (grid / bayes / wfa)</td><td>9</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>Strategy JSON save / validate / apply</td><td>9</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/data/"><code>forge data</code></a></td><td>Historical data fetch / update</td><td>4</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/strategy/"><code>forge strategy</code></a></td><td>Strategy JSON save / validate / apply</td><td>11</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/data/"><code>forge data</code></a></td><td>Historical / alternative / TradingView MCP data fetch</td><td>6</td></tr>
           <tr><td><a href="/en/docs/cli-reference/journal/"><code>forge journal</code></a></td><td>Trading journal and trade analysis</td><td>8</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/live/"><code>forge live</code></a></td><td>Live trading and broker integration</td><td>9</td></tr>
-          <tr><td><a href="/en/docs/cli-reference/other/">Other commands</a></td><td><code>system</code> / <code>pine</code> / <code>idea</code> / <code>analyze</code> / <code>explore</code> and more</td><td>10 groups</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/live/"><code>forge live</code></a></td><td>Live trade analysis, replay, operations log</td><td>10</td></tr>
+          <tr><td><a href="/en/docs/cli-reference/">Other commands</a></td><td><code>system</code> / <code>pine</code> / <code>idea</code> / <code>analyze</code> / <code>explore</code> / <code>self</code></td><td>6 groups</td></tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
## 概要

install ページ（`templates/install.html.j2` → `ja/install.html` / `en/install.html`）の「全コマンドカタログ」表が現行 forge CLI（85 サブコマンド）と乖離していたため是正。alpha-forge#1028 / labs#349 と同系統のドリフトです。

## 変更（ja / en 両方）
### 全コマンドカタログ表のサブコマンド数
| グループ | 旧 | 新 | 理由 |
|---|---|---|---|
| `forge backtest` | 11 | **12** | `combine` 追加（#941） |
| `forge strategy` | 9 | **11** | `cost-presets`（#785）/ `signals` 等 |
| `forge data` | 4 | **6** | `alt` / `tv-mcp` を含む |
| `forge live` | 9 | **10** | `replay` 追加 |
| その他 | 「10 グループ」 | **6 グループ** | 残り 6 グループ（system/pine/idea/analyze/explore/**self**）に訂正 |

### broken link 修正
- `/{lang}/docs/cli-reference/other/`（存在しないページ）→ `/{lang}/docs/cli-reference/`（index）
- `/{lang}/docs/guides/freemium-limits/`（存在しない）→ `/{lang}/docs/guides/trial-limits/`（実在ページ）

## 検証（変更不要だった箇所）
- 主要 6 コマンドカードのフラグ（`backtest run --strategy/--start/--json`、`optimize run --metric/--trials/--apply`、`optimize walk-forward --windows/--metric`、`data fetch --period/--interval/--watchlist`、`strategy save --force`、`journal show STRATEGY_ID`）は現行 forge CLI に全て実在
- `install.sh` / `install.ps1` の curl/irm 手順、`forge system init/auth login/auth status`、alpha-visualizer / alpha-strike の install 手順は実装と一致
- `build.py` で `ja/install.html` / `en/install.html` を再生成（差分は install ページのみ・他生成物に影響なし）

注: ルートの旧 `install.html`（2026-04-26、ビルド対象外の legacy）は当該カタログ表を持たないため変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)