### PR TITLE
fix(installer): INSTALL_DIR 明示時の rc 追記スキップと完了メッセージへの Trial 案内追加

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@
 #   bash <(curl -sSL https://alforge-labs.github.io/install.sh) --dry-run
 #
 #   # 非対話で symlink 配置先を環境変数で指定（CI / Dockerfile 等向け）
+#   # INSTALL_DIR 指定時は ~/.zshrc 等への PATH 追記をスキップし手動追加を案内する。
 #   INSTALL_DIR=~/.local/bin bash <(curl -sSL https://alforge-labs.github.io/install.sh)
 #   INSTALL_DIR=/opt/forge/bin bash <(curl -sSL https://alforge-labs.github.io/install.sh)
 #
@@ -406,7 +407,13 @@ esac
 if [[ ":${PATH}:" != *":${BIN_DIR}:"* ]]; then
   PATH_LINE="export PATH=\"${BIN_DIR}:\${PATH}\""
 
-  if [ "${DRY_RUN}" = "false" ]; then
+  if [ -n "${INSTALL_DIR_FROM_ENV}" ]; then
+    # INSTALL_DIR を明示した非対話インストール（CI / Dockerfile 等）では
+    # ユーザーの rc を勝手に書き換えない。代わりに手動で PATH へ追加する案内のみ出す。
+    info "$(lang "INSTALL_DIR 指定のため rc への PATH 追記をスキップしました。次の行を PATH に追加してください：" \
+                  "Skipped writing to your shell rc because INSTALL_DIR was specified. Add the following to your PATH:")"
+    echo "    ${PATH_LINE}"
+  elif [ "${DRY_RUN}" = "false" ]; then
     if ! grep -qF "${BIN_DIR}" "${RC}" 2>/dev/null; then
       printf '\n# AlphaForge alpha-forge\n%s\n' "${PATH_LINE}" >> "${RC}"
       ok "$(lang "PATH を ${RC} に追記しました" "Added PATH entry to ${RC}")"
@@ -440,9 +447,19 @@ else
               "Dry run complete. Re-run without --dry-run to actually install.")"
 fi
 
-# ── 9. ライセンス認証の案内（alpha-forge system auth login）────────────
+# ── 9a. すぐ使い始める案内（Trial プラン / getting-started）────────────
+# Whop 認証なしでも Trial プランで即利用できる旨を最初に案内する（getting-started の主訴求）。
 echo ""
-echo "$(lang "次のステップ: ライセンス認証" "Next step: license activation")"
+echo "$(lang "次のステップ: すぐに使い始める" "Next step: start using right away")"
+echo "  $(lang "認証なしの Trial プランでそのまま使い始められます。" \
+                "You can start using it immediately on the no-auth Trial plan.")"
+echo "  $(lang "はじめ方ガイド" "Getting started guide"):"
+echo "      $(lang "https://alforge-labs.github.io/ja/docs/getting-started/" \
+                    "https://alforge-labs.github.io/en/docs/getting-started/")"
+
+# ── 9b. ライセンス認証の案内（alpha-forge system auth login）────────────
+echo ""
+echo "$(lang "有料プランを使う場合: ライセンス認証" "To use a paid plan: license activation")"
 echo "  $(lang "AlphaForge は Whop OAuth でライセンス認証を行います。" \
                 "AlphaForge uses Whop OAuth for license activation.")"
 echo "  $(lang "以下のコマンドを実行するとブラウザが開き、Whop で購入したアカウントで認証できます：" \
@@ -456,8 +473,10 @@ echo "      alpha-forge system auth status"
 # ── 10. シェルへの反映案内 ──────────────────────────────────────
 echo ""
 if [ "${DRY_RUN}" = "false" ]; then
-  # 現在のシェルから PATH を反映するための手順
-  if [[ ":${PATH}:" != *":${BIN_DIR}:"* ]]; then
+  # 現在のシェルから PATH を反映するための手順。
+  # INSTALL_DIR 明示時は rc を書き換えていないので source ${RC} は案内しない
+  # （PATH への追加手順はセクション 7 で既に案内済み）。
+  if [[ ":${PATH}:" != *":${BIN_DIR}:"* ]] && [ -z "${INSTALL_DIR_FROM_ENV}" ]; then
     echo "$(lang "PATH を現在のシェルに反映するには、次のいずれかを実行してください：" \
                   "To apply the new PATH to the current shell, run one of the following:")"
     echo "    source ${RC}"

--- a/tests/test_install_sh_ux.py
+++ b/tests/test_install_sh_ux.py
@@ -16,7 +16,9 @@
 
 import os
 import shutil
+import stat
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -26,6 +28,32 @@ INSTALL_SH = ROOT / "install.sh"
 BASH = shutil.which("bash") or "/bin/bash"
 
 
+def _make_fake_uname_dir() -> str:
+    """`uname -s`→Darwin / `uname -m`→arm64 を返す偽 uname を含む dir を作る。
+
+    install.sh は冒頭で `uname -s`（OS）と `uname -m`（アーキテクチャ）を呼び、
+    Darwin 以外を「未対応プラットフォーム」として早期 fail する。CI（Linux）でも
+    --dry-run の検証を走らせるため、PATH 先頭に偽 uname を差し込んで
+    macOS arm64 を装う。install.sh 本体は macOS 専用で正しいので変更しない。
+
+    呼び出しパターンは install.sh 上 `uname -s` / `uname -m` の 2 つのみ
+    （`grep -n uname install.sh` で確認済み）。引数なし呼び出しは無いが、
+    将来の追加に備えて引数なしは Darwin を返しておく。
+    """
+    fake_dir = tempfile.mkdtemp(prefix="forge-fake-uname-")
+    fake_uname = Path(fake_dir) / "uname"
+    fake_uname.write_text(
+        "#!/bin/sh\n"
+        'case "$1" in\n'
+        "  -s) echo Darwin ;;\n"
+        "  -m) echo arm64 ;;\n"
+        "  *)  echo Darwin ;;\n"
+        "esac\n"
+    )
+    fake_uname.chmod(fake_uname.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return fake_dir
+
+
 def run_install_dry_run(install_dir: str | None, locale: str = "ja") -> str:
     """install.sh を --dry-run で実行し stdout+stderr を結合して返す。
 
@@ -33,24 +61,49 @@ def run_install_dry_run(install_dir: str | None, locale: str = "ja") -> str:
     触らない（--dry-run なので追記自体行われないが二重の安全策）。
     --dry-run のため version 取得に失敗してもインストーラは続行する
     （ネットワーク不通環境でも完走する）。
+
+    PATH 先頭に偽 uname を差し込み、Linux CI でも macOS arm64 として
+    プラットフォーム検出を通過させる（issue #377）。
     """
     env = dict(os.environ)
     env["FORGE_INSTALL_LOCALE"] = locale
     env["HOME"] = "/tmp/forge-test-home-377"
     Path(env["HOME"]).mkdir(parents=True, exist_ok=True)
+    fake_uname_dir = _make_fake_uname_dir()
+    env["PATH"] = fake_uname_dir + os.pathsep + env.get("PATH", "")
     if install_dir is None:
         env.pop("INSTALL_DIR", None)
     else:
         env["INSTALL_DIR"] = install_dir
 
-    proc = subprocess.run(
-        [BASH, str(INSTALL_SH), "--dry-run"],
-        capture_output=True,
-        text=True,
-        env=env,
-        timeout=120,
-    )
+    try:
+        proc = subprocess.run(
+            [BASH, str(INSTALL_SH), "--dry-run"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+        )
+    finally:
+        shutil.rmtree(fake_uname_dir, ignore_errors=True)
     return proc.stdout + proc.stderr
+
+
+class InstallShFakeUnameTest(unittest.TestCase):
+    """偽 uname による PATH 偽装が効き、プラットフォーム検出を通過すること。
+
+    install.sh は Darwin 以外で「未対応プラットフォーム」と早期 fail するため、
+    この検証が通る＝偽 uname が PATH 先頭から呼ばれている証左になる
+    （Linux CI 上でも他の dry-run テストが成立する前提を担保する）。
+    """
+
+    def test_fake_uname_passes_platform_detection(self):
+        out = run_install_dry_run(install_dir=None, locale="ja")
+        # 早期 fail のメッセージが出ていないこと（=検出を通過した）。
+        self.assertNotIn("未対応プラットフォーム", out)
+        # 偽 uname が返した macOS arm64 のアーティファクト名が出ること。
+        self.assertIn("Darwin-arm64", out)
+        self.assertIn("alpha-forge-macos-arm64", out)
 
 
 class InstallShInstallDirPathBehaviorTest(unittest.TestCase):

--- a/tests/test_install_sh_ux.py
+++ b/tests/test_install_sh_ux.py
@@ -1,0 +1,106 @@
+"""install.sh の UX 改善 2 点（issue alforge-labs#377）の回帰テスト。
+
+実物の install.sh を `--dry-run` で実行し、出力メッセージを検証する。
+--dry-run はダウンロード・symlink 作成・rc 追記等の副作用を一切行わず、
+何を行う予定かを `[dry-run]` 行や案内メッセージとして出力するだけなので、
+インストーラ本体の破壊的副作用を走らせずにロジックを検証できる。
+
+検証する 2 点:
+1. INSTALL_DIR を明示指定した非対話インストールでは ~/.zshrc 等への
+   PATH 追記をスキップし、代わりに「PATH に追加してください」案内を出す
+   （CI / Dockerfile 用途で rc を書き換える副作用を防ぐ）。
+   INSTALL_DIR 未指定（通常インストール）では従来どおり rc 追記を行う。
+2. 完了メッセージに「認証なしの Trial プランで即利用できる」旨と
+   getting-started ドキュメントへの導線を追加する。
+"""
+
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = ROOT / "install.sh"
+
+BASH = shutil.which("bash") or "/bin/bash"
+
+
+def run_install_dry_run(install_dir: str | None, locale: str = "ja") -> str:
+    """install.sh を --dry-run で実行し stdout+stderr を結合して返す。
+
+    HOME を一時ディレクトリに隔離するので、テスト実行者の実 rc を
+    触らない（--dry-run なので追記自体行われないが二重の安全策）。
+    --dry-run のため version 取得に失敗してもインストーラは続行する
+    （ネットワーク不通環境でも完走する）。
+    """
+    env = dict(os.environ)
+    env["FORGE_INSTALL_LOCALE"] = locale
+    env["HOME"] = "/tmp/forge-test-home-377"
+    Path(env["HOME"]).mkdir(parents=True, exist_ok=True)
+    if install_dir is None:
+        env.pop("INSTALL_DIR", None)
+    else:
+        env["INSTALL_DIR"] = install_dir
+
+    proc = subprocess.run(
+        [BASH, str(INSTALL_SH), "--dry-run"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+    return proc.stdout + proc.stderr
+
+
+class InstallShInstallDirPathBehaviorTest(unittest.TestCase):
+    """課題1: INSTALL_DIR 明示時の rc 無条件追記をやめる。"""
+
+    def test_install_dir_explicit_does_not_append_to_rc(self):
+        """INSTALL_DIR 明示時は rc への PATH 追記（>> rc）を予定しない。"""
+        out = run_install_dry_run(install_dir="/tmp/forge-377-bin", locale="ja")
+        # 旧挙動の dry-run 行 `echo 'export PATH=...' >> .../.zshrc` が出ないこと。
+        self.assertNotIn(">> ", out)
+        self.assertNotIn(".zshrc", out)
+
+    def test_install_dir_explicit_shows_manual_path_guidance(self):
+        """INSTALL_DIR 明示時は「PATH に追加してください」案内を出す。"""
+        out = run_install_dry_run(install_dir="/tmp/forge-377-bin", locale="en")
+        self.assertIn("PATH", out)
+        self.assertIn("/tmp/forge-377-bin", out)
+        # 手動追加を促す文言（英語）
+        self.assertIn("add", out.lower())
+
+    def test_default_install_still_appends_to_rc(self):
+        """INSTALL_DIR 未指定（通常インストール）では従来どおり rc 追記を行う。"""
+        out = run_install_dry_run(install_dir=None, locale="ja")
+        # 通常インストールでは rc への追記 dry-run 行が残ること（既定挙動を変えない）。
+        self.assertIn(">> ", out)
+
+
+class InstallShTrialGuidanceTest(unittest.TestCase):
+    """課題2: 完了メッセージに Trial 即利用の案内を追加する。"""
+
+    def test_completion_message_mentions_trial_ja(self):
+        """日本語完了メッセージに Trial 即利用の案内が含まれる。"""
+        out = run_install_dry_run(install_dir=None, locale="ja")
+        self.assertIn("Trial", out)
+
+    def test_completion_message_mentions_trial_en(self):
+        """英語完了メッセージに Trial 即利用の案内が含まれる。"""
+        out = run_install_dry_run(install_dir=None, locale="en")
+        self.assertIn("Trial", out)
+
+    def test_completion_message_links_getting_started_ja(self):
+        """日本語完了メッセージに ja の getting-started 導線が含まれる。"""
+        out = run_install_dry_run(install_dir=None, locale="ja")
+        self.assertIn("https://alforge-labs.github.io/ja/docs/getting-started/", out)
+
+    def test_completion_message_links_getting_started_en(self):
+        """英語完了メッセージに en の getting-started 導線が含まれる。"""
+        out = run_install_dry_run(install_dir=None, locale="en")
+        self.assertIn("https://alforge-labs.github.io/en/docs/getting-started/", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

install.sh の UX 改善 2 点（Closes #377）。

### 1. INSTALL_DIR 明示時は rc への PATH 追記をスキップ
- INSTALL_DIR を明示した非対話インストール（CI / Dockerfile 等）でユーザーの `~/.zshrc` 等を書き換えないようにし、代わりに手動で PATH へ追加する案内（日英）を表示。
- rc を書いていない場合は `source ${RC}` の案内も出さないようガード（誤案内の防止）。
- 既定の対話/通常インストールの挙動は不変。

### 2. 完了メッセージに Trial 即利用の案内を追加
- 「次のステップ: すぐに使い始める」セクションを新設し、認証なしの Trial プランで即利用できる旨と getting-started ガイドへの導線（ja/en 出し分け）を表示。
- 既存のライセンス認証案内は「有料プランを使う場合」として従の位置づけに調整。

## テスト

- [x] 新規 `tests/test_install_sh_ux.py`（7 件）: 実物 install.sh を `--dry-run` 実行して検証（ダウンロード・rc 追記の副作用なし）。テストファースト（RED→GREEN）で作成
- [x] `uv run --with pytest pytest tests/ -x -q` → 31 passed
- [x] shellcheck: 新種 warning なし（既存スタイル踏襲の SC2005 既知分のみ）
- [x] bash 3.2 互換維持（bash4 専用機能不使用）