### PR TITLE
feat(lp): hero stats を「無人 24/7」「Trial 無料」に差し替え

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -355,7 +355,8 @@
 
     .hero-stats {
       margin-top: 5rem;
-      display: flex; gap: 3rem; flex-wrap: wrap;
+      /* gap 3rem だと 3 stat + 長め lbl で折り返し余裕が 10px 未満になる（en で実害）ため縮小 */
+      display: flex; gap: 2.25rem; flex-wrap: wrap;
       padding-top: 2rem; border-top: 1px solid var(--border);
       animation: fadeUp 0.7s var(--ease) 0.4s both;
     }

--- a/homepage-copy.jsx
+++ b/homepage-copy.jsx
@@ -46,8 +46,8 @@ window.COPY = {
     },
     heroStats: [
       { val: 'MCP + スキル 8 種', accent: false, lbl: 'コマンド 5 + スキル 3・Claude Code / Codex 対応' },
-      { val: 'Max DD ‑23%', accent: true, lbl: 'QQQ(‑35%)比で大幅縮小・リターンは同等（5年検証）' },
-      { val: '2026夏', accent: false, lbl: '正式リリース目標' },
+      { val: '無人 24/7', accent: true, lbl: '指標 × 銘柄を夜間に自律探索（探索→最適化→検証）' },
+      { val: 'Trial 無料', accent: false, lbl: 'Whop 登録不要・期限なしで今すぐ試せる' },
     ],
     aiAgents: {
       label: 'AI エージェント連携',
@@ -552,9 +552,9 @@ window.COPY = {
       ],
     },
     heroStats: [
-      { val: 'MCP + 8 skills', accent: false, lbl: '5 commands + 3 skills · Claude Code / Codex' },
-      { val: '‑23% Max DD', accent: true, lbl: 'vs QQQ ‑35%, comparable return (5yr backtest)' },
-      { val: 'Summer 2026', accent: false, lbl: 'Target Release' },
+      { val: 'MCP + 8 skills', accent: false, lbl: '5 commands + 3 skills · Claude / Codex' },
+      { val: 'Unmanned 24/7', accent: true, lbl: 'Explore → optimize → validate overnight' },
+      { val: 'Free Trial', accent: false, lbl: 'No Whop signup, no expiry — start now' },
     ],
     aiAgents: {
       label: 'AI Agent Integration',

--- a/ja/index.html
+++ b/ja/index.html
@@ -355,7 +355,8 @@
 
     .hero-stats {
       margin-top: 5rem;
-      display: flex; gap: 3rem; flex-wrap: wrap;
+      /* gap 3rem だと 3 stat + 長め lbl で折り返し余裕が 10px 未満になる（en で実害）ため縮小 */
+      display: flex; gap: 2.25rem; flex-wrap: wrap;
       padding-top: 2rem; border-top: 1px solid var(--border);
       animation: fadeUp 0.7s var(--ease) 0.4s both;
     }

--- a/seo.yaml
+++ b/seo.yaml
@@ -42,14 +42,14 @@ pages:
   docs:
     ja:
       title: "ドキュメント — Alforge Labs"
-      description: "AlphaForge CLI 公式ドキュメント。主要 6 コマンドの早見表と全 7 グループ × 76 サブコマンドのカタログ。エンドツーエンド戦略開発ワークフロー、TradingView 連携ガイド、バックテスト・最適化・ウォークフォワード検証も網羅。"
+      description: "AlphaForge CLI 公式ドキュメント。主要 6 コマンドの早見表と全 12 グループ × 100 超のサブコマンドのカタログ。AI エージェント連携、エンドツーエンド戦略開発ワークフロー、TradingView 連携ガイド、バックテスト・最適化・ウォークフォワード検証も網羅。"
       keywords: "AlphaForge, ドキュメント, コマンドリファレンス, バックテスト, 最適化, 戦略開発ワークフロー, TradingView, CLI"
       og_title: "AlphaForge CLI ドキュメント"
       og_description: "主要 6 コマンドの早見表と全コマンドカタログ。エンドツーエンド戦略開発ワークフローと TradingView 連携ガイドは MkDocs ベースの公式 CLI リファレンスへ。"
       json_ld_type: breadcrumb
     en:
       title: "Documentation — Alforge Labs"
-      description: "AlphaForge CLI official docs. Quick reference for the six core commands and a full catalog of 7 groups × 76 subcommands. Also covers the end-to-end strategy development workflow, TradingView integration, and backtesting / optimization / walk-forward validation."
+      description: "AlphaForge CLI official docs. Quick reference for the six core commands and a full catalog of 12 groups × 100+ subcommands. Also covers AI agent integration, the end-to-end strategy development workflow, TradingView integration, and backtesting / optimization / walk-forward validation."
       keywords: "AlphaForge, documentation, command reference, backtesting, optimization, strategy workflow, TradingView, CLI"
       og_title: "AlphaForge CLI Documentation"
       og_description: "A quick reference for the six core commands and a full command catalog. The end-to-end strategy workflow and TradingView integration guides live in the MkDocs-based official CLI reference."

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -275,7 +275,8 @@
 
     .hero-stats {
       margin-top: 5rem;
-      display: flex; gap: 3rem; flex-wrap: wrap;
+      /* gap 3rem だと 3 stat + 長め lbl で折り返し余裕が 10px 未満になる（en で実害）ため縮小 */
+      display: flex; gap: 2.25rem; flex-wrap: wrap;
       padding-top: 2rem; border-top: 1px solid var(--border);
       animation: fadeUp 0.7s var(--ease) 0.4s both;
     }


### PR DESCRIPTION
## 概要

#384 のフィードバック対応。エージェント主導の hero に対して浮いていた「Max DD ‑23%」と、賞味期限が近い「2026夏」を差し替える。

## 変更

| 枠 | 旧 | 新 |
|---|---|---|
| 枠1 | MCP + スキル 8 種（維持） | — |
| 枠2（緑） | Max DD ‑23% | **無人 24/7** — 指標 × 銘柄を夜間に自律探索（探索→最適化→検証）/ Unmanned 24/7 |
| 枠3 | 2026夏 / 正式リリース目標 | **Trial 無料** — Whop 登録不要・期限なしで今すぐ試せる / Free Trial |

選定プロセス: 3 レンズ（agent-proof / rigor-trust / conversion-evergreen）× 13 候補 → 3 審査員採点 → ユーザー最終選定。両枠とも evergreen で時限差し替え不要。

## 付随修正

- **stats 折り返しバグ**: en で stats 合計幅が container を 10px 超過し 3 枠目が折り返し（ja も余裕 1px の脆さ）→ gap 3rem→2.25rem + en lbl 短縮。1440/1280px で 1 行を計測確認
- seo.yaml の stale「7 グループ × 76 サブコマンド」→ 実数ベース「12 グループ × 100 超」（現ドキュメント実数 108）

## テスト計画

- [x] build.py 成功・生成 HTML 同梱
- [x] pytest 32 passed
- [x] headless 検証: console エラー 0・stats 1 行（ja/en・1440/1280px）・モバイル 375px はみ出しなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)