### PR TITLE
docs: CLAUDE.md に React コンポーネントの window 登録ルールを追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,13 @@ uv run mkdocs build -f mkdocs.en.yml
 
 を実行して `ja/docs/` / `en/docs/` を再生成すること。
 
+### 5. 新規 React コンポーネントは window に登録する
+
+`homepage-components.jsx` / `site-header.jsx` で定義したコンポーネントは、ファイル末尾の
+`Object.assign(window, { ... })` に必ず追加すること。各 JSX は独立した script として
+ロードされるため、登録を忘れると `app.jsx` から undefined 参照になり**ページ全体が白画面**になる
+（過去に2回発生）。検証は本番と同一の babel transpile + headless ブラウザでの実描画で行うこと。
+
 ---
 
 ## ファイル構成


### PR DESCRIPTION
## 概要

CLAUDE.md 監査（claude-md-improver）での追記。新規 React コンポーネントを `Object.assign(window, {...})` に登録し忘れると、別 script の app.jsx から undefined 参照になりページ全体が白画面になる（過去 2 回発生した実害のある非自明パターン）。重要ルール 5 として明文化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)