### PR TITLE
docs(marketing): dev.to プロフィール案を追加

### DIFF
--- a/marketing/article-drafts/devto_profile.md
+++ b/marketing/article-drafts/devto_profile.md
@@ -1,0 +1,38 @@
+# dev.to プロフィール案（AlphaForge）
+
+dev.to アカウント作成時に使うプロフィール。英語圏プラットフォームなので英語。声は `alpha-bot/docs/ALFORGE_BOT_VOICE.md`（冷静・実装ベース・反クリックベイト・build-in-public）準拠。@Alforge_bot と一貫させる。
+
+| フィールド | 値 |
+|-----------|-----|
+| **Name（表示名）** | `AlphaForge`（より人間味を出すなら `Building AlphaForge` も可。@Alforge_bot との一貫性なら `AlphaForge` 推奨） |
+| **Username（@ハンドル）** | `alphaforge`（取得済みなら `alforgelabs` → `alforge_dev` → `alphaforge_cli`） |
+| **Profile image** | @Alforge_bot と同じブランドロゴ（X とフィードで同一視されるように） |
+| **Website** | `https://alforgelabs.com` |
+| **Location** | `Japan` |
+| **Brand / Work** | `Alforge Labs` |
+| **Twitter/X** | `Alforge_bot` |
+| **GitHub** | `alforge-labs` |
+| **Available for hire** | OFF（受託でなくプロダクト議論） |
+
+**Bio（~200字以内）**:
+> Building AlphaForge — a local, agent-native quant CLI. JSON strategies → Optuna TPE → walk-forward → TradingView Pine v6. Anti-overfitting, build-in-public.
+
+**Currently hacking on**:
+> AlphaForge — agent-native quant CLI (MCP server + walk-forward validation), in public beta.
+
+**Available for**:
+> Feedback & discussion on agent-native quant tooling and AI-agent dev workflows.
+
+**Skills / Interests（タグ）**: `ai agents`, `mcp`, `claude`, `python`, `quant`, `algorithmic trading`, `backtesting`, `tradingview`
+
+**About（プロフィール本文・Markdown 可）**:
+> I build tools for individual quants. **AlphaForge** is a local CLI designed to be driven by AI agents (Claude Code, Codex, MCP): write strategies as JSON, optimize with Optuna TPE, validate with **walk-forward** to fight overfitting, and export to **TradingView Pine v6**.
+>
+> No clickbait backtests — I'd rather show you the out-of-sample gap than a pretty in-sample curve. I write here about agent-native tooling, quant research, and building in public.
+>
+> Free trial & docs → [alforgelabs.com](https://alforgelabs.com) · MCP server: `uvx alpha-forge-mcp` (Apache-2.0)
+
+## メモ
+- 言語: dev.to=英語 / Zenn=日本語（X の英日ハイブリッドとは使い分け）。
+- 避ける: 誇張・絵文字過多・受託臭・クリックベイト。
+- Zenn 用の日本語プロフィール案は別途作成可（未作成）。


### PR DESCRIPTION
dev.to アカウント作成用のプロフィール案（英語・builder voice・@Alforge_bot と一貫）。marketing/article-drafts/devto_profile.md。ビルド対象外。