### PR TITLE
docs(marketing): Zenn 日本語プロフィール案を追加

### DIFF
--- a/marketing/article-drafts/zenn_profile_ja.md
+++ b/marketing/article-drafts/zenn_profile_ja.md
@@ -1,0 +1,24 @@
+# Zenn プロフィール案（AlphaForge・日本語）
+
+Zenn アカウント用のプロフィール。Zenn は日本語圏なので日本語。声は `alpha-bot/docs/ALFORGE_BOT_VOICE.md`（冷静・実装ベース・反クリックベイト・絵文字最小）準拠。表示名・アバター・リンクは dev.to / @Alforge_bot と統一。
+
+| フィールド | 値 |
+|-----------|-----|
+| **表示名** | `AlphaForge` |
+| **ユーザー名（zenn.dev/@…）** | `alphaforge`（取得済みなら `alforgelabs` → `alforge_dev`） |
+| **アバター** | @Alforge_bot / dev.to と同じブランドロゴ |
+| **Website** | `https://alforgelabs.com` |
+| **GitHub 連携** | `alforge-labs` |
+| **X 連携** | `Alforge_bot` |
+
+**自己紹介（bio）**:
+> 個人クオンツ向けのローカル CLI「AlphaForge」を build-in-public で開発中。JSON で書いた戦略を Optuna TPE で最適化し、ウォークフォワード検証で過学習を炙り出し、TradingView Pine v6 に出力します。Claude Code / MCP から AI エージェントで操作できる設計。クリックベイトな過学習バックテストとは無縁です。
+
+**短縮版（自己紹介が短い場合）**:
+> AI エージェント（Claude Code / MCP）で操作できるローカル Quant CLI「AlphaForge」を build-in-public 開発中。JSON 戦略 → Optuna TPE → ウォークフォワード → TradingView Pine v6。過学習バックテストとは無縁。
+
+## メモ
+- 言語の使い分け: dev.to=英語 / Zenn=日本語 / X=英日ハイブリッド。
+- 表示名・アバター・リンクは全チャネル統一でブランド認知を集約。
+- 差別化軸③（ウォークフォワードで過学習を炙り出す／クリックベイトと無縁）をプロフィールでも明示。
+- 絵文字なし・誇張なし・受託臭なし（VOICE 準拠）。


### PR DESCRIPTION
Zenn アカウント用の日本語プロフィール案（builder voice・dev.to/@Alforge_bot と統一）。marketing/article-drafts/zenn_profile_ja.md。ビルド対象外。