### PR TITLE
feat(lp): install ページに AI エージェント貼るだけプロンプトと DEMO 即実行を追加（A6）

### DIFF
--- a/en/install.html
+++ b/en/install.html
@@ -125,10 +125,20 @@
       <p>
         Once installed, the Trial plan lets you immediately run <code>alpha-forge backtest run</code>, <code>alpha-forge optimize run</code>, <code>alpha-forge optimize walk-forward</code>, and more. The only Trial limits are: data capped at 2023-12-31, optimization capped at 50 trials, and no Pine Script export — everything else mirrors the paid plans.
       </p>
-      <pre><code># Example: run a backtest right away (Trial plan, no Whop registration)
-alpha-forge system init                 # initialize a working directory
+      <pre><code># Example: one-shot backtest on bundled DEMO data (Trial plan, no Whop registration, no data fetch)
+alpha-forge demo                        # init + DEMO backtest + result + visualization hint, all at once
+# To try real data:
 alpha-forge data fetch SPY --period 5y  # auto-fetch data up to 2023-12-31
 alpha-forge backtest run SPY --strategy sma_crossover_v1</code></pre>
+
+      <h3 class="sub-heading">Hand it to an AI agent (paste-ready prompt)</h3>
+      <p>Paste the following prompt into an AI agent (Claude Code / Cursor / Codex, ...) and it will install and run your first backtest automatically (free Trial, no login).</p>
+      <pre><code>Install AlphaForge (a backtesting CLI) and run my first backtest:
+1. Run the installer (mac/Linux): curl -sSL https://alforge-labs.github.io/install.sh | bash
+   (Windows PowerShell: irm https://alforge-labs.github.io/install.ps1 | iex)
+2. Run `alpha-forge demo` (initializes and runs a backtest on bundled DEMO data in one shot)
+3. Summarize the printed result (Sharpe, total return, number of trades)
+AlphaForge runs on the free Trial (no login). If anything fails, run `alpha-forge system doctor`.</code></pre>
 
       <h2 class="section-heading">Paid plans (optional) — Sign in with Whop</h2>
       <p>

--- a/ja/install.html
+++ b/ja/install.html
@@ -126,10 +126,20 @@
       <p>
         インストール直後から Trial プランで <code>alpha-forge backtest run</code> / <code>alpha-forge optimize run</code> / <code>alpha-forge optimize walk-forward</code> 等が動きます。Trial の制限はデータ上限 2023-12-31・最適化 50 trials・Pine Script 生成不可の 3 点のみで、それ以外は有料プランと同じ機能を試せます。
       </p>
-      <pre><code># 例: いきなりバックテストを動かす（Trial プラン・Whop 登録不要）
-alpha-forge system init                 # 作業ディレクトリ初期化
+      <pre><code># 例: 同梱 DEMO データで一発バックテスト（Trial プラン・Whop 登録不要・データ取得不要）
+alpha-forge demo                        # init＋DEMO バックテスト＋結果＋可視化案内を一括
+# 実データで試す場合:
 alpha-forge data fetch SPY --period 5y  # 2023-12-31 までのデータを自動取得
 alpha-forge backtest run SPY --strategy sma_crossover_v1</code></pre>
+
+      <h3 class="sub-heading">AI エージェントに丸投げ（貼るだけプロンプト）</h3>
+      <p>Claude Code / Cursor / Codex などの AI エージェントに次のプロンプトをそのまま貼り付けると、インストールから初回バックテストまでを自動で実行します（無料 Trial・ログイン不要）。</p>
+      <pre><code>AlphaForge（バックテスト用 CLI）をインストールして、最初のバックテストまで実行して：
+1. インストーラを実行（mac/Linux）: curl -sSL https://alforge-labs.github.io/install.sh | bash
+   （Windows PowerShell の場合: irm https://alforge-labs.github.io/install.ps1 | iex）
+2. alpha-forge demo を実行（同梱 DEMO データで初期化＋バックテストを一発実行）
+3. 出力された結果サマリ（Sharpe・総リターン・取引数）を要約して報告して
+AlphaForge は無料 Trial（ログイン不要）で動く。詰まったら alpha-forge system doctor を実行して。</code></pre>
 
       <h2 class="section-heading">有料プラン（任意） — Whop でログイン認証</h2>
       <p>

--- a/templates/install.html.j2
+++ b/templates/install.html.j2
@@ -74,10 +74,20 @@
       <p>
         インストール直後から Trial プランで <code>alpha-forge backtest run</code> / <code>alpha-forge optimize run</code> / <code>alpha-forge optimize walk-forward</code> 等が動きます。Trial の制限はデータ上限 2023-12-31・最適化 50 trials・Pine Script 生成不可の 3 点のみで、それ以外は有料プランと同じ機能を試せます。
       </p>
-      <pre><code># 例: いきなりバックテストを動かす（Trial プラン・Whop 登録不要）
-alpha-forge system init                 # 作業ディレクトリ初期化
+      <pre><code># 例: 同梱 DEMO データで一発バックテスト（Trial プラン・Whop 登録不要・データ取得不要）
+alpha-forge demo                        # init＋DEMO バックテスト＋結果＋可視化案内を一括
+# 実データで試す場合:
 alpha-forge data fetch SPY --period 5y  # 2023-12-31 までのデータを自動取得
 alpha-forge backtest run SPY --strategy sma_crossover_v1</code></pre>
+
+      <h3 class="sub-heading">AI エージェントに丸投げ（貼るだけプロンプト）</h3>
+      <p>Claude Code / Cursor / Codex などの AI エージェントに次のプロンプトをそのまま貼り付けると、インストールから初回バックテストまでを自動で実行します（無料 Trial・ログイン不要）。</p>
+      <pre><code>AlphaForge（バックテスト用 CLI）をインストールして、最初のバックテストまで実行して：
+1. インストーラを実行（mac/Linux）: curl -sSL https://alforge-labs.github.io/install.sh | bash
+   （Windows PowerShell の場合: irm https://alforge-labs.github.io/install.ps1 | iex）
+2. alpha-forge demo を実行（同梱 DEMO データで初期化＋バックテストを一発実行）
+3. 出力された結果サマリ（Sharpe・総リターン・取引数）を要約して報告して
+AlphaForge は無料 Trial（ログイン不要）で動く。詰まったら alpha-forge system doctor を実行して。</code></pre>
 
       <h2 class="section-heading">有料プラン（任意） — Whop でログイン認証</h2>
       <p>
@@ -266,10 +276,20 @@ WEBHOOK_PASSPHRASE=your-secret alpha-strike</code></pre>
       <p>
         Once installed, the Trial plan lets you immediately run <code>alpha-forge backtest run</code>, <code>alpha-forge optimize run</code>, <code>alpha-forge optimize walk-forward</code>, and more. The only Trial limits are: data capped at 2023-12-31, optimization capped at 50 trials, and no Pine Script export — everything else mirrors the paid plans.
       </p>
-      <pre><code># Example: run a backtest right away (Trial plan, no Whop registration)
-alpha-forge system init                 # initialize a working directory
+      <pre><code># Example: one-shot backtest on bundled DEMO data (Trial plan, no Whop registration, no data fetch)
+alpha-forge demo                        # init + DEMO backtest + result + visualization hint, all at once
+# To try real data:
 alpha-forge data fetch SPY --period 5y  # auto-fetch data up to 2023-12-31
 alpha-forge backtest run SPY --strategy sma_crossover_v1</code></pre>
+
+      <h3 class="sub-heading">Hand it to an AI agent (paste-ready prompt)</h3>
+      <p>Paste the following prompt into an AI agent (Claude Code / Cursor / Codex, ...) and it will install and run your first backtest automatically (free Trial, no login).</p>
+      <pre><code>Install AlphaForge (a backtesting CLI) and run my first backtest:
+1. Run the installer (mac/Linux): curl -sSL https://alforge-labs.github.io/install.sh | bash
+   (Windows PowerShell: irm https://alforge-labs.github.io/install.ps1 | iex)
+2. Run `alpha-forge demo` (initializes and runs a backtest on bundled DEMO data in one shot)
+3. Summarize the printed result (Sharpe, total return, number of trades)
+AlphaForge runs on the free Trial (no login). If anything fails, run `alpha-forge system doctor`.</code></pre>
 
       <h2 class="section-heading">Paid plans (optional) — Sign in with Whop</h2>
       <p>


### PR DESCRIPTION
## 概要

free-tier onboarding **A6** の LP 側。install ページに、AI エージェントへ丸投げできる**貼るだけプロンプト**（install → `alpha-forge demo` → 結果報告）を追加し、ステップ2 を **DEMO 即実行（A1/A2）先頭**へ更新する。

対応 issue: ysakae/alpha-forge#1275
SSoT: ysakae/alpha-trade:docs/superpowers/specs/2026-06-28-a6-agent-paste-prompt-design.md

## 変更点

- `templates/install.html.j2`（ja/en 両セクション）:
  - 「ステップ2 / Step 2」のコード例を `alpha-forge demo` 先頭へ（実データ `data fetch SPY` 例は後段に併記）。
  - 「AI エージェントに丸投げ（貼るだけプロンプト）/ Hand it to an AI agent」ブロックを追加。インストーラ実行（mac/Linux `curl … | bash` / Windows `irm … | iex`）→ `alpha-forge demo` → 結果サマリ報告。無料 Trial・ログイン不要・詰まったら `alpha-forge system doctor`。
- `uv run python build.py` で `ja/install.html`・`en/install.html` を再生成（同梱）。

## 検証

- build.py 成功・生成 HTML に `alpha-forge demo`（各2）・貼るだけ/paste-ready（各1）を確認。差分は install ページのみ。
- レビュー: spec ✅・Approved・Critical/Important 0。

## スコープ外

- React ホームページ hero への貼るだけ追加は follow-up（既存 aiAgents コンポーネント改修＋白画面リスク回避のため本 PR では行わない）。
